### PR TITLE
Fix LiveLink curve API for UE 5.6 using property-based system

### DIFF
--- a/plugins/unreal/Open3DStream/Source/Open3DStream/Private/Open3DStreamSource.cpp
+++ b/plugins/unreal/Open3DStream/Source/Open3DStream/Private/Open3DStreamSource.cpp
@@ -263,19 +263,14 @@ void FOpen3DStreamSource::OnPackage(const TArray<uint8>& data)
 		}
 
 		// Curves (morph targets)
-		// TODO: UE 5.6 changed the LiveLink curve API - needs investigation
-		// The old CurveNames/CurveValues API no longer exists
-		// Need to determine the correct API for setting curves in UE 5.6+
-		/*
-		FrameData.CurveNames.Empty();
-		FrameData.CurveValues.Empty();
+		// UE 5.6+ uses a property-based system in FLiveLinkBaseFrameData
+		// Curves are stored in PropertyValues array (values) which pairs with
+		// PropertyNames from the static data
 		for (size_t ci = 0; ci < subject->mCurveNames.size(); ++ci)
 		{
-			FName cname(subject->mCurveNames[ci].c_str());
-			FrameData.CurveNames.Add(cname);
-			FrameData.CurveValues.Add(subject->mCurveValues.size() > ci ? subject->mCurveValues[ci] : 0.0f);
+			float value = subject->mCurveValues.size() > ci ? subject->mCurveValues[ci] : 0.0f;
+			FrameData.PropertyValues.Add(value);
 		}
-		*/
 
 		// Check if skeleton has not been initialized yet
 		if (InitializedSubjects.Find(SubjectName) == INDEX_NONE)
@@ -291,6 +286,14 @@ void FOpen3DStreamSource::OnPackage(const TArray<uint8>& data)
 
 			SkeletonDataPtr->SetBoneNames(BoneNames);
 			SkeletonDataPtr->SetBoneParents(BoneParents);
+
+			// Set up curve property names in static data (UE 5.6+ API)
+			TArray<FName> PropertyNames;
+			for (const auto& curveName : subject->mCurveNames)
+			{
+				PropertyNames.Add(FName(curveName.c_str()));
+			}
+			SkeletonDataPtr->PropertyNames = PropertyNames;
 
 			Client->RemoveSubject_AnyThread(SubjectKey);
 			Client->PushSubjectStaticData_AnyThread(SubjectKey, ULiveLinkAnimationRole::StaticClass(), MoveTemp(LiveLinkSkeletonStaticData));

--- a/plugins/unreal/Open3DStream/Source/Open3DStream/Private/Open3DStreamSource.cpp
+++ b/plugins/unreal/Open3DStream/Source/Open3DStream/Private/Open3DStreamSource.cpp
@@ -175,6 +175,7 @@ void FOpen3DStreamSource::OnPackage(const TArray<uint8>& data)
 	{
 		FLiveLinkFrameDataStruct FrameDataStruct(FLiveLinkAnimationFrameData::StaticStruct());
 		FLiveLinkAnimationFrameData& FrameData = *FrameDataStruct.Cast<FLiveLinkAnimationFrameData>();
+		FLiveLinkBaseFrameData& BaseFrameData = static_cast<FLiveLinkBaseFrameData&>(FrameData);
 
 		//ArrivalTimeOffset = FPlatformTime::Seconds() - mSubjects.mTime;
 		FrameData.WorldTime = FPlatformTime::Seconds();
@@ -269,7 +270,7 @@ void FOpen3DStreamSource::OnPackage(const TArray<uint8>& data)
 		for (size_t ci = 0; ci < subject->mCurveNames.size(); ++ci)
 		{
 			float value = subject->mCurveValues.size() > ci ? subject->mCurveValues[ci] : 0.0f;
-			FrameData.PropertyValues.Add(value);
+			BaseFrameData.PropertyValues.Add(value);
 		}
 
 		// Check if skeleton has not been initialized yet

--- a/plugins/unreal/Open3DStream/Source/Open3DStream/Private/Open3DStreamSource.cpp
+++ b/plugins/unreal/Open3DStream/Source/Open3DStream/Private/Open3DStreamSource.cpp
@@ -4,7 +4,6 @@
 #include "ILiveLinkClient.h"
 #include "Roles/LiveLinkAnimationTypes.h"
 #include "Roles/LiveLinkAnimationRole.h"
-#include "LiveLinkTypes.h"
 #include "Common/UdpSocketBuilder.h"
 #include "Internationalization/Regex.h"
 
@@ -264,23 +263,7 @@ void FOpen3DStreamSource::OnPackage(const TArray<uint8>& data)
 		}
 
 		// Curves (morph targets)
-		// NOTE: Unreal Engine changed the LiveLink curve API around UE 5.4.
-		// Older engines exposed FrameData.CurveNames and FrameData.CurveValues
-		// as separate arrays. Newer engines use FrameData.Curves which is an
-		// array of FLiveLinkCurveElement (Name/Value). We version-guard here
-		// so the plugin can compile against multiple engine versions.
-#if defined(ENGINE_MAJOR_VERSION) && ( (ENGINE_MAJOR_VERSION > 5) || (ENGINE_MAJOR_VERSION == 5 && defined(ENGINE_MINOR_VERSION) && ENGINE_MINOR_VERSION >= 4) )
-		FrameData.Curves.Empty();
-		for (size_t ci = 0; ci < subject->mCurveNames.size(); ++ci)
-		{
-			FName cname(subject->mCurveNames[ci].c_str());
-			float value = subject->mCurveValues.size() > ci ? subject->mCurveValues[ci] : 0.0f;
-			FLiveLinkCurveElement elem;
-			elem.Name = cname;
-			elem.Value = value;
-			FrameData.Curves.Add(elem);
-		}
-#else
+		// Populate LiveLink animation curve data from subject curve arrays
 		FrameData.CurveNames.Empty();
 		FrameData.CurveValues.Empty();
 		for (size_t ci = 0; ci < subject->mCurveNames.size(); ++ci)
@@ -289,7 +272,6 @@ void FOpen3DStreamSource::OnPackage(const TArray<uint8>& data)
 			FrameData.CurveNames.Add(cname);
 			FrameData.CurveValues.Add(subject->mCurveValues.size() > ci ? subject->mCurveValues[ci] : 0.0f);
 		}
-#endif
 
 		// Check if skeleton has not been initialized yet
 		if (InitializedSubjects.Find(SubjectName) == INDEX_NONE)

--- a/plugins/unreal/Open3DStream/Source/Open3DStream/Private/Open3DStreamSource.cpp
+++ b/plugins/unreal/Open3DStream/Source/Open3DStream/Private/Open3DStreamSource.cpp
@@ -4,6 +4,7 @@
 #include "ILiveLinkClient.h"
 #include "Roles/LiveLinkAnimationTypes.h"
 #include "Roles/LiveLinkAnimationRole.h"
+#include "LiveLinkTypes.h"
 #include "Common/UdpSocketBuilder.h"
 #include "Internationalization/Regex.h"
 
@@ -263,6 +264,23 @@ void FOpen3DStreamSource::OnPackage(const TArray<uint8>& data)
 		}
 
 		// Curves (morph targets)
+		// NOTE: Unreal Engine changed the LiveLink curve API around UE 5.4.
+		// Older engines exposed FrameData.CurveNames and FrameData.CurveValues
+		// as separate arrays. Newer engines use FrameData.Curves which is an
+		// array of FLiveLinkCurveElement (Name/Value). We version-guard here
+		// so the plugin can compile against multiple engine versions.
+#if defined(ENGINE_MAJOR_VERSION) && ( (ENGINE_MAJOR_VERSION > 5) || (ENGINE_MAJOR_VERSION == 5 && defined(ENGINE_MINOR_VERSION) && ENGINE_MINOR_VERSION >= 4) )
+		FrameData.Curves.Empty();
+		for (size_t ci = 0; ci < subject->mCurveNames.size(); ++ci)
+		{
+			FName cname(subject->mCurveNames[ci].c_str());
+			float value = subject->mCurveValues.size() > ci ? subject->mCurveValues[ci] : 0.0f;
+			FLiveLinkCurveElement elem;
+			elem.Name = cname;
+			elem.Value = value;
+			FrameData.Curves.Add(elem);
+		}
+#else
 		FrameData.CurveNames.Empty();
 		FrameData.CurveValues.Empty();
 		for (size_t ci = 0; ci < subject->mCurveNames.size(); ++ci)
@@ -271,6 +289,7 @@ void FOpen3DStreamSource::OnPackage(const TArray<uint8>& data)
 			FrameData.CurveNames.Add(cname);
 			FrameData.CurveValues.Add(subject->mCurveValues.size() > ci ? subject->mCurveValues[ci] : 0.0f);
 		}
+#endif
 
 		// Check if skeleton has not been initialized yet
 		if (InitializedSubjects.Find(SubjectName) == INDEX_NONE)

--- a/plugins/unreal/Open3DStream/Source/Open3DStream/Private/Open3DStreamSource.cpp
+++ b/plugins/unreal/Open3DStream/Source/Open3DStream/Private/Open3DStreamSource.cpp
@@ -263,7 +263,10 @@ void FOpen3DStreamSource::OnPackage(const TArray<uint8>& data)
 		}
 
 		// Curves (morph targets)
-		// Populate LiveLink animation curve data from subject curve arrays
+		// TODO: UE 5.6 changed the LiveLink curve API - needs investigation
+		// The old CurveNames/CurveValues API no longer exists
+		// Need to determine the correct API for setting curves in UE 5.6+
+		/*
 		FrameData.CurveNames.Empty();
 		FrameData.CurveValues.Empty();
 		for (size_t ci = 0; ci < subject->mCurveNames.size(); ++ci)
@@ -272,6 +275,7 @@ void FOpen3DStreamSource::OnPackage(const TArray<uint8>& data)
 			FrameData.CurveNames.Add(cname);
 			FrameData.CurveValues.Add(subject->mCurveValues.size() > ci ? subject->mCurveValues[ci] : 0.0f);
 		}
+		*/
 
 		// Check if skeleton has not been initialized yet
 		if (InitializedSubjects.Find(SubjectName) == INDEX_NONE)

--- a/plugins/unreal/Open3DStream/Source/Open3DStream/Private/UOpen3DServer.cpp
+++ b/plugins/unreal/Open3DStream/Source/Open3DStream/Private/UOpen3DServer.cpp
@@ -39,7 +39,7 @@ bool O3DSServer::start(FText Url, FText Protocol )
 	const char* surl = TCHAR_TO_ANSI(*Url.ToString());
 	const char* sprotocol = TCHAR_TO_ANSI(*Protocol.ToString());
 
-	FText::Format(LOCTEXT("ConnectingString", "Connecting {0}"), Protocol);
+	// Note: Connection status message formatting removed - was unused
 
 	// NNG
 	if (strncmp(sprotocol, "NNG Subscribe", 13) == 0)


### PR DESCRIPTION
## Problem
The CI build was failing with compilation errors related to LiveLink curve handling:
- **Error C2039**: 'CurveNames' and 'CurveValues' are not members of 'FLiveLinkAnimationFrameData'
- **Error C4834**: discarding return value of function with [[nodiscard]] attribute in UOpen3DServer.cpp

## Root Cause
Unreal Engine 5.6 changed the LiveLink API significantly:
1. Removed the old `CurveNames`/`CurveValues` arrays from `FLiveLinkAnimationFrameData`
2. Introduced a **property-based system** where:
   - Curve **names** are stored in `PropertyNames` (TArray<FName>) in `FLiveLinkBaseStaticData`
   - Curve **values** are stored in `PropertyValues` (TArray<float>) in `FLiveLinkBaseFrameData`
3. The intermediate UE 5.4 API with `FLiveLinkCurveElement` was also deprecated

## Solution
Implemented the UE 5.6 property-based curve API following the pattern used in the [VMCLiveLink plugin](https://github.com/atgoldberg/VMCLiveLink):

### Static Data (Skeleton Setup)
```cpp
// Set up curve property names in static data (UE 5.6+ API)
TArray<FName> PropertyNames;
for (const auto& curveName : subject->mCurveNames)
{
    PropertyNames.Add(FName(curveName.c_str()));
}
SkeletonDataPtr->PropertyNames = PropertyNames;
```

### Frame Data (Per-Frame Values)
```cpp
// Access PropertyValues through the base class cast
FLiveLinkBaseFrameData& BaseFrameData = static_cast<FLiveLinkBaseFrameData&>(FrameData);

for (size_t ci = 0; ci < subject->mCurveNames.size(); ++ci)
{
    float value = subject->mCurveValues.size() > ci ? subject->mCurveValues[ci] : 0.0f;
    BaseFrameData.PropertyValues.Add(value);
}
```

## Key Changes

### 1. Open3DStreamSource.cpp
- Added `FLiveLinkBaseFrameData` cast to access `PropertyValues` correctly
- Set `PropertyNames` in skeleton static data initialization
- Removed old curve API code (CurveNames/CurveValues arrays)

### 2. UOpen3DServer.cpp
- Fixed nodiscard warning by removing unused `FText::Format` return value

## Technical Details
The property-based system works as follows:
1. **Static Data** (published once per subject): Contains `PropertyNames` array defining all curve names
2. **Frame Data** (published every frame): Contains `PropertyValues` array with curve values
3. The arrays are **index-aligned**: `PropertyValues[i]` corresponds to the curve named `PropertyNames[i]`
4. `PropertyValues` is accessed through `FLiveLinkBaseFrameData` (base class) not `FLiveLinkAnimationFrameData` directly

## References
- [VMCLiveLink Plugin Source](https://github.com/atgoldberg/VMCLiveLink/tree/main/Plugins/VMCLiveLink)
- [UE LiveLink API Documentation](https://dev.epicgames.com/documentation/en-us/unreal-engine/API/Runtime/LiveLinkInterface)
- Specifically: [FLiveLinkBaseFrameData](https://dev.epicgames.com/documentation/en-us/unreal-engine/API/Runtime/LiveLinkInterface/FLiveLinkBaseFrameData) and [FLiveLinkBaseStaticData](https://dev.epicgames.com/documentation/en-us/unreal-engine/API/Runtime/LiveLinkInterface/FLiveLinkBaseStaticData)

## Testing
✅ Build passed successfully in CI (UE 5.6 environment)
- All compilation errors resolved
- Curve support now properly implemented using UE 5.6 API

## Migration Notes
This change removes version guards and fully commits to the UE 5.6+ property-based API. If backward compatibility with older UE versions is needed, version guards would need to be re-added.