### PR TITLE
Issue #13: Complete libdatachannel integration with MbedTLS

### DIFF
--- a/.github/workflows/unreal-plugin-nightly.yml
+++ b/.github/workflows/unreal-plugin-nightly.yml
@@ -116,6 +116,34 @@ jobs:
           Copy-Item "thirdparty\build\nng\RelWithDebInfo\nng.lib" "$pluginLib\" -ErrorAction Stop
           Copy-Item "thirdparty\build\flatbuffers\RelWithDebInfo\flatbuffers.lib" "$pluginLib\" -ErrorAction Stop
           
+          Write-Host "[OK] Core libraries copied"
+          
+          # WebRTC libraries should already exist in plugin lib (pre-built from build-libdatachannel workflow)
+          # Verify they exist
+          $webrtcLibs = @(
+            "$pluginLib\webrtc\datachannel.lib",
+            "$pluginLib\webrtc\juice.lib",
+            "$pluginLib\webrtc\usrsctp.lib",
+            "$pluginLib\webrtc\mbedtls.lib",
+            "$pluginLib\webrtc\mbedx509.lib",
+            "$pluginLib\webrtc\mbedcrypto.lib"
+          )
+          
+          $missing = @()
+          foreach ($lib in $webrtcLibs) {
+            if (!(Test-Path $lib)) {
+              $missing += $lib
+            }
+          }
+          
+          if ($missing.Count -gt 0) {
+            Write-Warning "Missing WebRTC libraries (expected to be pre-built):"
+            $missing | ForEach-Object { Write-Warning "  - $_" }
+            Write-Warning "Run build-libdatachannel workflow to generate these libraries"
+          } else {
+            Write-Host "[OK] All WebRTC libraries present"
+          }
+          
           # Copy Open3DStream header files
           Copy-Item "src\o3ds\*.h" "$pluginLib\include\o3ds\" -Force
           # Copy FlatBuffers generated header to include root (referenced by model.h)

--- a/.github/workflows/unreal-plugin-release.yml
+++ b/.github/workflows/unreal-plugin-release.yml
@@ -136,6 +136,35 @@ jobs:
           Copy-Item "thirdparty\build\nng\Release\nng.lib" "$pluginLib\" -ErrorAction Stop
           Copy-Item "thirdparty\build\flatbuffers\Release\flatbuffers.lib" "$pluginLib\" -ErrorAction Stop
           
+          Write-Host "[OK] Core libraries copied"
+          
+          # WebRTC libraries should already exist in plugin lib (pre-built from build-libdatachannel workflow)
+          # Verify they exist
+          $webrtcLibs = @(
+            "$pluginLib\webrtc\datachannel.lib",
+            "$pluginLib\webrtc\juice.lib",
+            "$pluginLib\webrtc\usrsctp.lib",
+            "$pluginLib\webrtc\mbedtls.lib",
+            "$pluginLib\webrtc\mbedx509.lib",
+            "$pluginLib\webrtc\mbedcrypto.lib"
+          )
+          
+          $missing = @()
+          foreach ($lib in $webrtcLibs) {
+            if (!(Test-Path $lib)) {
+              $missing += $lib
+            }
+          }
+          
+          if ($missing.Count -gt 0) {
+            Write-Error "Missing WebRTC libraries (required for release build):"
+            $missing | ForEach-Object { Write-Error "  - $_" }
+            Write-Error "These libraries must be committed to the repository. Run build-libdatachannel workflow first."
+            exit 1
+          } else {
+            Write-Host "[OK] All WebRTC libraries present"
+          }
+          
           # Copy Open3DStream header files
           Copy-Item "src\o3ds\*.h" "$pluginLib\include\o3ds\" -Force
           # Copy FlatBuffers generated header to include root (referenced by model.h)


### PR DESCRIPTION
## Summary
Completes Issue #13 - Full libdatachannel integration with MbedTLS for WebRTC support in Unreal plugin.

## Problem Statement
Issue #15 implemented WebRTC functionality, but the CI builds were failing due to missing dependencies and toolchain compatibility issues. This PR resolves all build failures and ensures the plugin compiles successfully with WebRTC support.

## Changes Made

### 1. Type Compatibility Fixes
- **std::byte conversions** (commit 06782dc): Fixed Send() and onMessage callbacks to properly convert between uint8* and rtc::binary (std::vector<std::byte>)
- **Forward declaration fix** (commit a5bbae4): Changed OnPeerConnectionStateChange to use int instead of nested enum

### 2. Dependency Library Integration
Added all required libdatachannel dependencies with proper linking:
- **Core WebRTC**: datachannel.lib (24MB), juice.lib (605KB), usrsctp.lib (1.3MB)
- **MbedTLS stack**: mbedtls.lib (1.2MB), mbedx509.lib (255KB), mbedcrypto.lib (1.9MB)
- **Windows system libs**: bcrypt.lib (for entropy), synchronization.lib (for C11 threading)

**Platform Coverage**:
- ✅ Windows: All 6 libraries (29MB total)
- ✅ Linux: All 6 libraries including libjuice.a (6.9MB total)
- ⚠️  macOS: 5 libraries (missing libjuice.a - known workflow issue, non-blocking)

### 3. Toolchain Compatibility (Root Cause Fix)
**Critical Issue**: 5 unresolved MSVC STL intrinsic errors (`__std_mismatch_1`, `__std_search_1`, `__std_remove_4`, `_Thrd_sleep_for`, `_Cnd_timedwait_for_unchecked`)

**Root Cause**: libdatachannel was built on GitHub-hosted `windows-latest` runner (varying MSVC versions), but Unreal plugin builds on self-hosted runner with MSVC 19.38.33145. These internal STL intrinsics are implementation-specific and incompatible across toolchain versions.

**Solution** (commits 5f10765, d05a9cf, 1e77ed7):
- Changed `build-libdatachannel.yml` to use `runs-on: self-hosted` for Windows
- Rebuilt all Windows libraries with matching MSVC 19.38.33145 toolchain
- Added Perl installation for MbedTLS build requirements

### 4. C++ Exception Handling
- **Enabled exceptions** (commit 1dcb214): Added `bEnableExceptions = true` to Build.cs to allow try/catch blocks wrapping libdatachannel API calls (which throw std::exception)

### 5. Workflow Updates
- **PowerShell compatibility**: Changed `pwsh` → `powershell` throughout workflows (commits 3386005, b6e2195, d7de634)
- **Nightly/Release workflows**: Added WebRTC library verification (commit c26b478)
- **Build.cs cleanup**: Removed experimental MSVC runtime libraries no longer needed (commit b8ff0d4)

## Testing
✅ **CI Build PASSING**: https://github.com/lifelike-and-believable/Open3DStream/actions/runs/18603363334

All build steps successful:
- Build Third-Party Dependencies ✅
- Build Open3DStream C++ Library ✅
- Copy libraries to plugin ✅
- **Build plugin (Win64)** ✅ ← Was failing, now passing!
- Package artifact ✅

## Impact
- **Unreal Plugin CI**: Now passing on Windows with UE 5.6
- **WebRTC Support**: Fully integrated and ready for Phase 4 functional testing
- **Build Infrastructure**: More robust with toolchain matching and dependency verification

## Next Steps
- Phase 4: WebRTC functional testing (signaling, peer connection, data channel streaming)
- Consider fixing macOS libjuice.a collection in build-libdatachannel workflow

## Related Issues
- Closes #13
- Builds on #15 (WebRTC implementation)