### PR TITLE
ci: avoid hashFiles timeout in Nightly/Release

### DIFF
--- a/.github/workflows/unreal-plugin-nightly.yml
+++ b/.github/workflows/unreal-plugin-nightly.yml
@@ -52,7 +52,7 @@ jobs:
             vsbuild
             usr
             thirdparty/build
-          key: o3ds-libs-${{ runner.os }}-${{ hashFiles('src/**', 'thirdparty/**', 'CMakeLists.txt') }}
+          key: o3ds-libs-${{ runner.os }}-${{ hashFiles('src/**/*.cpp', 'src/**/*.h', 'thirdparty/CMakeLists.txt', 'CMakeLists.txt', '.gitmodules') }}
           restore-keys: |
             o3ds-libs-${{ runner.os }}-
 

--- a/.github/workflows/unreal-plugin-release.yml
+++ b/.github/workflows/unreal-plugin-release.yml
@@ -77,7 +77,7 @@ jobs:
             vsbuild
             usr
             thirdparty/build
-          key: o3ds-libs-${{ runner.os }}-${{ hashFiles('src/**', 'thirdparty/**', 'CMakeLists.txt') }}
+          key: o3ds-libs-${{ runner.os }}-${{ hashFiles('src/**/*.cpp', 'src/**/*.h', 'thirdparty/CMakeLists.txt', 'CMakeLists.txt', '.gitmodules') }}
           restore-keys: |
             o3ds-libs-${{ runner.os }}-
 


### PR DESCRIPTION
Reduce cache key scope to speed up hashFiles and avoid 120s template timeout on Windows runners.\n- Nightly: use src/**/*.cpp, src/**/*.h, thirdparty/CMakeLists.txt, CMakeLists.txt, .gitmodules\n- Release: same adjustment\n\nNo functional changes to build; just more reliable caching.