### PR TITLE
ci: reuse composite build step across PR CI/Nightly/Release

### DIFF
--- a/.github/actions/build-plugin-core/action.yml
+++ b/.github/actions/build-plugin-core/action.yml
@@ -77,7 +77,8 @@ runs:
 
         $webrtcFlag = if ("${{ inputs.enable_webrtc }}" -eq "true") { "ON" } else { "OFF" }
         $ldcRoot = "${{ inputs.libdatachannel_root }}"
-        $ldcParam = if ($ldcRoot -ne "") { "-DO3DS_LIBDATACHANNEL_ROOT=\`"$ldcRoot\`"" } else { "" }
+        # Pass without embedded quotes to avoid literal quote characters in CMake variable
+        $ldcParam = if ($ldcRoot -ne "") { "-DO3DS_LIBDATACHANNEL_ROOT=$ldcRoot" } else { "" }
 
         cmake -B vsbuild -S . -G "Visual Studio 17 2022" -A x64 `
           -DCMAKE_PREFIX_PATH="$PWD/usr" `

--- a/.github/actions/build-plugin-core/action.yml
+++ b/.github/actions/build-plugin-core/action.yml
@@ -1,0 +1,114 @@
+name: Build Plugin Core
+description: Checkout, cache, build third-party and core, copy headers/libs, and locate .uplugin
+inputs:
+  ue_root:
+    required: true
+    description: Path to Unreal Engine root (e.g., C:\\Program Files\\Epic Games\\UE_5.6)
+  plugin_name:
+    required: true
+    description: Plugin name (e.g., Open3DStream)
+  build_type:
+    required: true
+    description: CMake build type (e.g., RelWithDebInfo or Release)
+  enable_webrtc:
+    required: true
+    description: Enable WebRTC in core (true/false)
+  libdatachannel_root:
+    required: false
+    description: Optional root for prebuilt libdatachannel stack
+outputs:
+  plugin_dir:
+    description: Resolved plugin directory
+    value: ${{ steps.find.outputs.plugin_dir }}
+  uplugin_path:
+    description: Resolved .uplugin path
+    value: ${{ steps.find.outputs.plugin_path }}
+runs:
+  using: composite
+  steps:
+    - name: Checkout (full)
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        lfs: true
+        submodules: recursive
+
+    - name: Setup MSBuild
+      uses: microsoft/setup-msbuild@v2
+
+    - name: Link plugin into Sandbox
+      shell: powershell
+      run: |
+        & .\Build\Scripts\Link-PluginIntoSandbox.ps1
+
+    - name: Setup UE
+      shell: powershell
+      run: |
+        & .\Build\Scripts\Setup-UE.ps1 -UEPath "${{ inputs.ue_root }}"
+
+    - name: Cache native libraries
+      uses: actions/cache@v4
+      id: cache-libs
+      with:
+        path: |
+          vsbuild
+          usr
+          thirdparty/build
+        key: o3ds-libs-${{ runner.os }}-${{ hashFiles('src/**/*.cpp', 'src/**/*.h', 'thirdparty/CMakeLists.txt', 'CMakeLists.txt', '.gitmodules') }}
+        restore-keys: |
+          o3ds-libs-${{ runner.os }}-
+
+    - name: Build Third-Party Dependencies
+      if: steps.cache-libs.outputs.cache-hit != 'true'
+      shell: powershell
+      run: |
+        cd thirdparty
+        cmake -B build -S . -G "Visual Studio 17 2022" -A x64 -DO3DS_BUILD_WEBRTC=OFF
+        cmake --build build --config ${{ inputs.build_type }} --parallel
+        cmake --install build --config ${{ inputs.build_type }} --prefix ../usr
+
+    - name: Build Open3DStream C++ Library
+      if: steps.cache-libs.outputs.cache-hit != 'true'
+      shell: powershell
+      run: |
+        $flatcCfg = "${{ inputs.build_type }}"
+        $flatcPath = "thirdparty\build\flatbuffers\$flatcCfg\flatc.exe"
+        & "$flatcPath" --cpp -o src src\o3ds.fbs
+
+        $webrtcFlag = if ("${{ inputs.enable_webrtc }}" -eq "true") { "ON" } else { "OFF" }
+        $ldcRoot = "${{ inputs.libdatachannel_root }}"
+        $ldcParam = if ($ldcRoot -ne "") { "-DO3DS_LIBDATACHANNEL_ROOT=\`"$ldcRoot\`"" } else { "" }
+
+        cmake -B vsbuild -S . -G "Visual Studio 17 2022" -A x64 `
+          -DCMAKE_PREFIX_PATH="$PWD/usr" `
+          -DO3DS_ENABLE_WEBRTC=$webrtcFlag `
+          $ldcParam
+
+        cmake --build vsbuild --config ${{ inputs.build_type }} --parallel
+
+    - name: Copy libraries and headers to plugin
+      shell: powershell
+      run: |
+        $pluginLib = "plugins\unreal\${{ inputs.plugin_name }}\lib"
+        New-Item -ItemType Directory -Force -Path "$pluginLib\include\o3ds" | Out-Null
+        New-Item -ItemType Directory -Force -Path "$pluginLib\include\nng" | Out-Null
+        New-Item -ItemType Directory -Force -Path "$pluginLib\include\flatbuffers" | Out-Null
+
+        Copy-Item "vsbuild\src\${{ inputs.build_type }}\open3dstreamstatic.lib" "$pluginLib\"
+        Copy-Item "thirdparty\build\nng\${{ inputs.build_type }}\nng.lib" "$pluginLib\"
+        Copy-Item "thirdparty\build\flatbuffers\${{ inputs.build_type }}\flatbuffers.lib" "$pluginLib\"
+
+        Copy-Item "src\o3ds\*.h" "$pluginLib\include\o3ds\" -Force
+        Copy-Item "src\o3ds_generated.h" "$pluginLib\include\" -Force
+        if (Test-Path "usr\include\nng") { Copy-Item "usr\include\nng\*" "$pluginLib\include\nng\" -Recurse -Force }
+        if (Test-Path "usr\include\flatbuffers") { Copy-Item "usr\include\flatbuffers\*" "$pluginLib\include\flatbuffers\" -Recurse -Force }
+
+    - name: Locate plugin (.uplugin)
+      id: find
+      shell: powershell
+      run: |
+        $pluginDir = Join-Path $PWD "plugins\unreal\${{ inputs.plugin_name }}"
+        $upluginPath = Join-Path $pluginDir "${{ inputs.plugin_name }}.uplugin"
+        if (!(Test-Path -LiteralPath $upluginPath)) { Write-Error "Plugin file not found: $upluginPath"; exit 1 }
+        "plugin_path=$upluginPath" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+        "plugin_dir=$pluginDir" | Out-File -FilePath $env:GITHUB_OUTPUT -Append

--- a/.github/workflows/unreal-plugin-ci.yml
+++ b/.github/workflows/unreal-plugin-ci.yml
@@ -61,143 +61,15 @@ jobs:
               body: `🚀 **Unreal Plugin CI build started** for this PR!\n\n[View build logs →](${runUrl})`
             });
 
-      - name: Setup MSBuild
-        uses: microsoft/setup-msbuild@v2
-
-      - name: Link plugin into Sandbox
-        shell: powershell
-        run: |
-          & .\Build\Scripts\Link-PluginIntoSandbox.ps1
-
-      - name: Setup UE
-        shell: powershell
-        run: |
-          & .\Build\Scripts\Setup-UE.ps1 -UEPath "$env:UE_ROOT"
-
-      # Cache native library builds to speed up workflow
-      - name: Cache native libraries
-        uses: actions/cache@v4
-        id: cache-libs
+      - name: Build plugin core (composite)
+        id: core
+        uses: ./.github/actions/build-plugin-core
         with:
-          path: |
-            vsbuild
-            usr
-            thirdparty/build
-          key: o3ds-libs-${{ runner.os }}-${{ hashFiles('src/**/*.cpp', 'src/**/*.h', 'thirdparty/CMakeLists.txt', 'CMakeLists.txt', '.gitmodules') }}
-          restore-keys: |
-            o3ds-libs-${{ runner.os }}-
-
-  # Build third-party dependencies FIRST (nng, flatbuffers) - required by main library
-  # Note: In CI we exclude the core library's WebRTC connector; the Unreal plugin links
-  # prebuilt libdatachannel-based WebRTC binaries instead (see Issue #10).
-      - name: Build Third-Party Dependencies
-        if: steps.cache-libs.outputs.cache-hit != 'true'
-        shell: powershell
-        run: |
-          Write-Host "Building third-party dependencies..."
-          
-          cd thirdparty
-          
-          # Configure CMake (exclude core WebRTC connector in CI; plugin uses prebuilt WebRTC)
-          cmake -B build -S . -G "Visual Studio 17 2022" -A x64 -DO3DS_BUILD_WEBRTC=OFF
-          
-          # Build RelWithDebInfo configuration
-          cmake --build build --config RelWithDebInfo --parallel
-          
-          # Install to make packages available
-          cmake --install build --config RelWithDebInfo --prefix ../usr
-          
-          cd ..
-          Write-Host "[OK] Third-party dependencies built successfully"
-
-      # Build Open3DStream C++ library (depends on third-party libs)
-      - name: Build Open3DStream C++ Library
-        if: steps.cache-libs.outputs.cache-hit != 'true'
-        shell: powershell
-        run: |
-          Write-Host "Building Open3DStream C++ library..."
-          
-          # Regenerate FlatBuffers header with the version we just built
-          Write-Host "Regenerating o3ds_generated.h with current FlatBuffers version..."
-          & ".\thirdparty\build\flatbuffers\RelWithDebInfo\flatc.exe" --cpp -o src src\o3ds.fbs
-          
-          # Configure CMake with prefix path; use plugin's prebuilt WebRTC stack in the core via O3DS_LIBDATACHANNEL_ROOT
-          cmake -B vsbuild -S . -G "Visual Studio 17 2022" -A x64 `
-            -DCMAKE_PREFIX_PATH="$PWD/usr" `
-            -DO3DS_ENABLE_WEBRTC=ON `
-            -DO3DS_LIBDATACHANNEL_ROOT="$PWD/plugins/unreal/$env:PLUGIN_NAME/lib/webrtc"
-          
-          # Build RelWithDebInfo configuration
-          cmake --build vsbuild --config RelWithDebInfo --parallel
-          
-          Write-Host "[OK] Open3DStream library built successfully"
-
-      # Copy built libraries and headers to plugin directory
-      - name: Copy libraries to plugin
-        shell: powershell
-        run: |
-          Write-Host "Copying libraries to plugin directory..."
-          
-          $pluginLib = "plugins\unreal\$env:PLUGIN_NAME\lib"
-          
-          # Create directories
-          New-Item -ItemType Directory -Force -Path "$pluginLib" | Out-Null
-          New-Item -ItemType Directory -Force -Path "$pluginLib\include\o3ds" | Out-Null
-          New-Item -ItemType Directory -Force -Path "$pluginLib\include\nng" | Out-Null
-          New-Item -ItemType Directory -Force -Path "$pluginLib\include\flatbuffers" | Out-Null
-          
-          # Copy library files
-          Copy-Item "vsbuild\src\RelWithDebInfo\open3dstreamstatic.lib" "$pluginLib\" -ErrorAction Stop
-          Copy-Item "thirdparty\build\nng\RelWithDebInfo\nng.lib" "$pluginLib\" -ErrorAction Stop
-          Copy-Item "thirdparty\build\flatbuffers\RelWithDebInfo\flatbuffers.lib" "$pluginLib\" -ErrorAction Stop
-          
-          # Copy Open3DStream header files
-          Copy-Item "src\o3ds\*.h" "$pluginLib\include\o3ds\" -Force
-          # Copy FlatBuffers generated header to include root (referenced by model.h)
-          Copy-Item "src\o3ds_generated.h" "$pluginLib\include\" -Force
-          
-          # Copy third-party headers from source directories
-          # NNG headers
-          if (Test-Path "thirdparty\nng\include") {
-            Copy-Item "thirdparty\nng\include\nng\*" "$pluginLib\include\nng\" -Recurse -Force
-          }
-          
-          # Flatbuffers headers
-          if (Test-Path "thirdparty\flatbuffers\include\flatbuffers") {
-            Copy-Item "thirdparty\flatbuffers\include\flatbuffers\*" "$pluginLib\include\flatbuffers\" -Recurse -Force
-          }
-          
-          # Also check usr/include if it exists (from install)
-          if (Test-Path "usr\include\nng") {
-            Copy-Item "usr\include\nng\*" "$pluginLib\include\nng\" -Recurse -Force
-          }
-          if (Test-Path "usr\include\flatbuffers") {
-            Copy-Item "usr\include\flatbuffers\*" "$pluginLib\include\flatbuffers\" -Recurse -Force
-          }
-          if (Test-Path "usr\include\*.h") {
-            Copy-Item "usr\include\*.h" "$pluginLib\include\" -Force
-          }
-          
-          Write-Host "[OK] Libraries and headers copied successfully"
-          Write-Host "Plugin lib directory contents:"
-          Get-ChildItem "$pluginLib" -Recurse | Select-Object FullName
-
-      - name: Locate plugin (.uplugin)
-        id: find
-        shell: powershell
-        run: |
-          $pluginDir = Join-Path $PWD "plugins\unreal\$env:PLUGIN_NAME"
-          $upluginPath = Join-Path $pluginDir "$env:PLUGIN_NAME.uplugin"
-          
-          if (!(Test-Path -LiteralPath $upluginPath)) {
-            Write-Error "Plugin file not found at: $upluginPath"
-            exit 1
-          }
-          
-          "plugin_path=$upluginPath" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
-          "plugin_dir=$pluginDir" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
-          "plugin_name=$env:PLUGIN_NAME" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
-          Write-Host "[OK] Using plugin: $upluginPath"
+          ue_root: ${{ env.UE_ROOT }}
+          plugin_name: ${{ env.PLUGIN_NAME }}
+          build_type: RelWithDebInfo
+          enable_webrtc: true
+          libdatachannel_root: ${{ github.workspace }}\plugins\unreal\${{ env.PLUGIN_NAME }}\lib\webrtc
 
       - name: Build plugin (Win64)
         shell: powershell
@@ -205,14 +77,14 @@ jobs:
           $pkg = Join-Path $env:RUNNER_TEMP 'PluginPackage'
           & .\Build\Scripts\Build-Plugin.ps1 `
             -UEPath "$env:UE_ROOT" `
-            -PluginUPluginPath "${{ steps.find.outputs.plugin_path }}" `
+            -PluginUPluginPath "${{ steps.core.outputs.uplugin_path }}" `
             -OutDir "$pkg" `
             -TargetPlatforms @("Win64")
 
       - name: Package artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ steps.find.outputs.plugin_name }}-Win64-${{ github.sha }}
+          name: ${{ env.PLUGIN_NAME }}-Win64-${{ github.sha }}
           path: ${{ runner.temp }}/PluginPackage
           retention-days: 30
 

--- a/.github/workflows/unreal-plugin-nightly.yml
+++ b/.github/workflows/unreal-plugin-nightly.yml
@@ -23,177 +23,14 @@ jobs:
     runs-on: [ self-hosted, ue5, windows ]
 
     steps:
-      - name: Checkout (full)
-        uses: actions/checkout@v4
+      - name: Build plugin core (composite)
+        uses: ./.github/actions/build-plugin-core
         with:
-          fetch-depth: 0
-          lfs: true
-          submodules: recursive
-
-      - name: Setup MSBuild
-        uses: microsoft/setup-msbuild@v2
-
-      - name: Link plugin into Sandbox
-        shell: powershell
-        run: |
-          & .\Build\Scripts\Link-PluginIntoSandbox.ps1
-
-      - name: Setup UE
-        shell: powershell
-        run: |
-          & .\Build\Scripts\Setup-UE.ps1 -UEPath "$env:UE_ROOT"
-
-      # Cache native library builds to speed up workflow
-      - name: Cache native libraries
-        uses: actions/cache@v4
-        id: cache-libs
-        with:
-          path: |
-            vsbuild
-            usr
-            thirdparty/build
-          key: o3ds-libs-${{ runner.os }}-${{ hashFiles('src/**/*.cpp', 'src/**/*.h', 'thirdparty/CMakeLists.txt', 'CMakeLists.txt', '.gitmodules') }}
-          restore-keys: |
-            o3ds-libs-${{ runner.os }}-
-
-      # Build third-party dependencies FIRST (nng, flatbuffers) - required by main library
-      # Note: WebRTC is disabled in nightly - pre-built libraries are used instead (see Issue #10)
-      - name: Build Third-Party Dependencies
-        if: steps.cache-libs.outputs.cache-hit != 'true'
-        shell: powershell
-        run: |
-          Write-Host "Building third-party dependencies..."
-          
-          cd thirdparty
-          
-          # Configure CMake (WebRTC disabled in nightly, using pre-built libraries)
-          cmake -B build -S . -G "Visual Studio 17 2022" -A x64 -DO3DS_BUILD_WEBRTC=OFF
-          
-          # Build RelWithDebInfo configuration
-          cmake --build build --config RelWithDebInfo --parallel
-          
-          # Install to make packages available
-          cmake --install build --config RelWithDebInfo --prefix ../usr
-          
-          cd ..
-          Write-Host "[OK] Third-party dependencies built successfully"
-
-      # Build Open3DStream C++ library (depends on third-party libs)
-      - name: Build Open3DStream C++ Library
-        if: steps.cache-libs.outputs.cache-hit != 'true'
-        shell: powershell
-        run: |
-          Write-Host "Building Open3DStream C++ library..."
-          
-          # Regenerate FlatBuffers header with the version we just built
-          Write-Host "Regenerating o3ds_generated.h with current FlatBuffers version..."
-          & ".\thirdparty\build\flatbuffers\RelWithDebInfo\flatc.exe" --cpp -o src src\o3ds.fbs
-          
-          # Configure CMake with prefix path; use the plugin's prebuilt WebRTC stack for the core library via O3DS_LIBDATACHANNEL_ROOT
-          cmake -B vsbuild -S . -G "Visual Studio 17 2022" -A x64 `
-            -DCMAKE_PREFIX_PATH="$PWD/usr" `
-            -DO3DS_ENABLE_WEBRTC=ON `
-            -DO3DS_LIBDATACHANNEL_ROOT="$PWD/plugins/unreal/$env:PLUGIN_NAME/lib/webrtc"
-          
-          # Build RelWithDebInfo configuration
-          cmake --build vsbuild --config RelWithDebInfo --parallel
-          
-          Write-Host "[OK] Open3DStream library built successfully"
-
-      # Copy built libraries and headers to plugin directory
-      - name: Copy libraries to plugin
-        shell: powershell
-        run: |
-          Write-Host "Copying libraries to plugin directory..."
-          
-          $pluginLib = "plugins\unreal\$env:PLUGIN_NAME\lib"
-          
-          # Create directories
-          New-Item -ItemType Directory -Force -Path "$pluginLib" | Out-Null
-          New-Item -ItemType Directory -Force -Path "$pluginLib\include\o3ds" | Out-Null
-          New-Item -ItemType Directory -Force -Path "$pluginLib\include\nng" | Out-Null
-          New-Item -ItemType Directory -Force -Path "$pluginLib\include\flatbuffers" | Out-Null
-          
-          # Copy library files
-          Copy-Item "vsbuild\src\RelWithDebInfo\open3dstreamstatic.lib" "$pluginLib\" -ErrorAction Stop
-          Copy-Item "thirdparty\build\nng\RelWithDebInfo\nng.lib" "$pluginLib\" -ErrorAction Stop
-          Copy-Item "thirdparty\build\flatbuffers\RelWithDebInfo\flatbuffers.lib" "$pluginLib\" -ErrorAction Stop
-          
-          Write-Host "[OK] Core libraries copied"
-          
-          # WebRTC libraries should already exist in plugin lib (pre-built from build-libdatachannel workflow)
-          # Verify they exist
-          $webrtcLibs = @(
-            "$pluginLib\webrtc\datachannel.lib",
-            "$pluginLib\webrtc\juice.lib",
-            "$pluginLib\webrtc\usrsctp.lib",
-            "$pluginLib\webrtc\mbedtls.lib",
-            "$pluginLib\webrtc\mbedx509.lib",
-            "$pluginLib\webrtc\mbedcrypto.lib"
-          )
-          
-          $missing = @()
-          foreach ($lib in $webrtcLibs) {
-            if (!(Test-Path $lib)) {
-              $missing += $lib
-            }
-          }
-          
-          if ($missing.Count -gt 0) {
-            Write-Warning "Missing WebRTC libraries (expected to be pre-built):"
-            $missing | ForEach-Object { Write-Warning "  - $_" }
-            Write-Warning "Run build-libdatachannel workflow to generate these libraries"
-          } else {
-            Write-Host "[OK] All WebRTC libraries present"
-          }
-          
-          # Copy Open3DStream header files
-          Copy-Item "src\o3ds\*.h" "$pluginLib\include\o3ds\" -Force
-          # Copy FlatBuffers generated header to include root (referenced by model.h)
-          Copy-Item "src\o3ds_generated.h" "$pluginLib\include\" -Force
-          
-          # Copy third-party headers from source directories
-          # NNG headers
-          if (Test-Path "thirdparty\nng\include") {
-            Copy-Item "thirdparty\nng\include\nng\*" "$pluginLib\include\nng\" -Recurse -Force
-          }
-          
-          # Flatbuffers headers
-          if (Test-Path "thirdparty\flatbuffers\include\flatbuffers") {
-            Copy-Item "thirdparty\flatbuffers\include\flatbuffers\*" "$pluginLib\include\flatbuffers\" -Recurse -Force
-          }
-          
-          # Also check usr/include if it exists (from install)
-          if (Test-Path "usr\include\nng") {
-            Copy-Item "usr\include\nng\*" "$pluginLib\include\nng\" -Recurse -Force
-          }
-          if (Test-Path "usr\include\flatbuffers") {
-            Copy-Item "usr\include\flatbuffers\*" "$pluginLib\include\flatbuffers\" -Recurse -Force
-          }
-          if (Test-Path "usr\include\*.h") {
-            Copy-Item "usr\include\*.h" "$pluginLib\include\" -Force
-          }
-          
-          Write-Host "[OK] Libraries and headers copied successfully"
-          Write-Host "Plugin lib directory contents:"
-          Get-ChildItem "$pluginLib" -Recurse | Select-Object FullName
-
-      - name: Locate plugin (.uplugin)
-        id: find
-        shell: powershell
-        run: |
-          $pluginDir = Join-Path $PWD "plugins\unreal\$env:PLUGIN_NAME"
-          $upluginPath = Join-Path $pluginDir "$env:PLUGIN_NAME.uplugin"
-          
-          if (!(Test-Path -LiteralPath $upluginPath)) {
-            Write-Error "Plugin file not found at: $upluginPath"
-            exit 1
-          }
-          
-          "plugin_path=$upluginPath" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
-          "plugin_dir=$pluginDir" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
-          "plugin_name=$env:PLUGIN_NAME" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
-          Write-Host "[OK] Using plugin: $upluginPath"
+          ue_root: ${{ env.UE_ROOT }}
+          plugin_name: ${{ env.PLUGIN_NAME }}
+          build_type: RelWithDebInfo
+          enable_webrtc: true
+          libdatachannel_root: ${{ github.workspace }}\plugins\unreal\${{ env.PLUGIN_NAME }}\lib\webrtc
 
       - name: Build plugin (Win64)
         shell: powershell
@@ -201,14 +38,14 @@ jobs:
           $pkg = Join-Path $env:RUNNER_TEMP 'PluginPackage'
           & .\Build\Scripts\Build-Plugin.ps1 `
             -UEPath "$env:UE_ROOT" `
-            -PluginUPluginPath "${{ steps.find.outputs.plugin_path }}" `
+            -PluginUPluginPath "${{ steps.build-plugin-core.outputs.uplugin_path }}" `
             -OutDir "$pkg" `
             -TargetPlatforms @("Win64")
 
       - name: Upload plugin package
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ steps.find.outputs.plugin_name }}-Nightly-Win64-${{ github.sha }}
+          name: ${{ env.PLUGIN_NAME }}-Nightly-Win64-${{ github.sha }}
           path: ${{ runner.temp }}/PluginPackage
           retention-days: 14  # Keep nightly builds for 2 weeks
 

--- a/.github/workflows/unreal-plugin-nightly.yml
+++ b/.github/workflows/unreal-plugin-nightly.yml
@@ -24,6 +24,7 @@ jobs:
 
     steps:
       - name: Build plugin core (composite)
+        id: core
         uses: ./.github/actions/build-plugin-core
         with:
           ue_root: ${{ env.UE_ROOT }}
@@ -38,7 +39,7 @@ jobs:
           $pkg = Join-Path $env:RUNNER_TEMP 'PluginPackage'
           & .\Build\Scripts\Build-Plugin.ps1 `
             -UEPath "$env:UE_ROOT" `
-            -PluginUPluginPath "${{ steps.build-plugin-core.outputs.uplugin_path }}" `
+            -PluginUPluginPath "${{ steps.core.outputs.uplugin_path }}" `
             -OutDir "$pkg" `
             -TargetPlatforms @("Win64")
 

--- a/.github/workflows/unreal-plugin-release.yml
+++ b/.github/workflows/unreal-plugin-release.yml
@@ -28,25 +28,15 @@ jobs:
     runs-on: [ self-hosted, ue5, windows ]
 
     steps:
-      - name: Checkout (full)
-        uses: actions/checkout@v4
+      - name: Build plugin core (composite)
+        id: core
+        uses: ./.github/actions/build-plugin-core
         with:
-          fetch-depth: 0
-          lfs: true
-          submodules: recursive
-
-      - name: Setup MSBuild
-        uses: microsoft/setup-msbuild@v2
-
-      - name: Setup Perl (required for MbedTLS GEN_FILES)
-        uses: shogo82148/actions-setup-perl@v1
-        with:
-          perl-version: '5.32'
-
-      - name: Link plugin into Sandbox
-        shell: powershell
-        run: |
-          & .\Build\Scripts\Link-PluginIntoSandbox.ps1
+          ue_root: ${{ env.UE_ROOT }}
+          plugin_name: ${{ env.PLUGIN_NAME }}
+          build_type: Release
+          enable_webrtc: true
+          libdatachannel_root: ${{ github.workspace }}\plugins\unreal\${{ env.PLUGIN_NAME }}\lib\webrtc
 
       - name: Get version
         id: version
@@ -63,91 +53,10 @@ jobs:
           Write-Host "Version: $version"
           Write-Host "Version number: $versionWithoutPrefix"
 
-      - name: Setup UE
+      - name: Verify WebRTC libraries (prebuilt)
         shell: powershell
         run: |
-          & .\Build\Scripts\Setup-UE.ps1 -UEPath "$env:UE_ROOT"
-
-      # Cache native library builds to speed up workflow
-      - name: Cache native libraries
-        uses: actions/cache@v4
-        id: cache-libs
-        with:
-          path: |
-            vsbuild
-            usr
-            thirdparty/build
-          key: o3ds-libs-${{ runner.os }}-${{ hashFiles('src/**/*.cpp', 'src/**/*.h', 'thirdparty/CMakeLists.txt', 'CMakeLists.txt', '.gitmodules') }}
-          restore-keys: |
-            o3ds-libs-${{ runner.os }}-
-
-      # Build third-party dependencies FIRST (nng, flatbuffers) - required by main library
-      # Note: WebRTC is disabled - pre-built libraries are used instead (see build-libdatachannel workflow)
-      - name: Build Third-Party Dependencies
-        if: steps.cache-libs.outputs.cache-hit != 'true'
-        shell: powershell
-        run: |
-          Write-Host "Building third-party dependencies (Release)..."
-          
-          cd thirdparty
-          
-          # Configure CMake (WebRTC disabled, using pre-built libraries)
-          cmake -B build -S . -G "Visual Studio 17 2022" -A x64 -DO3DS_BUILD_WEBRTC=OFF
-          
-          # Build Release configuration for shipping builds
-          cmake --build build --config Release --parallel
-          
-          # Install to make packages available
-          cmake --install build --config Release --prefix ../usr
-          
-          cd ..
-          Write-Host "[OK] Third-party dependencies built successfully"
-
-      # Build Open3DStream C++ library (depends on third-party libs)
-      - name: Build Open3DStream C++ Library
-        if: steps.cache-libs.outputs.cache-hit != 'true'
-        shell: powershell
-        run: |
-          Write-Host "Building Open3DStream C++ library (Release)..."
-          
-          # Regenerate FlatBuffers header with the version we just built
-          Write-Host "Regenerating o3ds_generated.h with current FlatBuffers version..."
-          & ".\thirdparty\build\flatbuffers\Release\flatc.exe" --cpp -o src src\o3ds.fbs
-          
-          # Configure CMake with prefix path; use the plugin's prebuilt WebRTC stack for the core library via O3DS_LIBDATACHANNEL_ROOT
-          cmake -B vsbuild -S . -G "Visual Studio 17 2022" -A x64 `
-            -DCMAKE_PREFIX_PATH="$PWD/usr" `
-            -DO3DS_ENABLE_WEBRTC=ON `
-            -DO3DS_LIBDATACHANNEL_ROOT="$PWD/plugins/unreal/$env:PLUGIN_NAME/lib/webrtc"
-          
-          # Build Release configuration for shipping builds
-          cmake --build vsbuild --config Release --parallel
-          
-          Write-Host "[OK] Open3DStream library built successfully"
-
-      # Copy built libraries and headers to plugin directory
-      - name: Copy libraries to plugin
-        shell: powershell
-        run: |
-          Write-Host "Copying libraries to plugin directory..."
-          
           $pluginLib = "plugins\unreal\$env:PLUGIN_NAME\lib"
-          
-          # Create directories
-          New-Item -ItemType Directory -Force -Path "$pluginLib" | Out-Null
-          New-Item -ItemType Directory -Force -Path "$pluginLib\include\o3ds" | Out-Null
-          New-Item -ItemType Directory -Force -Path "$pluginLib\include\nng" | Out-Null
-          New-Item -ItemType Directory -Force -Path "$pluginLib\include\flatbuffers" | Out-Null
-          
-          # Copy library files (Release config for shipping)
-          Copy-Item "vsbuild\src\Release\open3dstreamstatic.lib" "$pluginLib\" -ErrorAction Stop
-          Copy-Item "thirdparty\build\nng\Release\nng.lib" "$pluginLib\" -ErrorAction Stop
-          Copy-Item "thirdparty\build\flatbuffers\Release\flatbuffers.lib" "$pluginLib\" -ErrorAction Stop
-          
-          Write-Host "[OK] Core libraries copied"
-          
-          # WebRTC libraries should already exist in plugin lib (pre-built from build-libdatachannel workflow)
-          # Verify they exist
           $webrtcLibs = @(
             "$pluginLib\webrtc\datachannel.lib",
             "$pluginLib\webrtc\juice.lib",
@@ -156,53 +65,14 @@ jobs:
             "$pluginLib\webrtc\mbedx509.lib",
             "$pluginLib\webrtc\mbedcrypto.lib"
           )
-          
           $missing = @()
-          foreach ($lib in $webrtcLibs) {
-            if (!(Test-Path $lib)) {
-              $missing += $lib
-            }
-          }
-          
+          foreach ($lib in $webrtcLibs) { if (!(Test-Path $lib)) { $missing += $lib } }
           if ($missing.Count -gt 0) {
             Write-Error "Missing WebRTC libraries (required for release build):"
             $missing | ForEach-Object { Write-Error "  - $_" }
-            Write-Error "These libraries must be committed to the repository. Run build-libdatachannel workflow first."
+            Write-Error "Provide these via the prebuilt artifact process or commit them under plugins/unreal/$env:PLUGIN_NAME/lib/webrtc. Run the build-libdatachannel helper if needed."
             exit 1
-          } else {
-            Write-Host "[OK] All WebRTC libraries present"
-          }
-          
-          # Copy Open3DStream header files
-          Copy-Item "src\o3ds\*.h" "$pluginLib\include\o3ds\" -Force
-          # Copy FlatBuffers generated header to include root (referenced by model.h)
-          Copy-Item "src\o3ds_generated.h" "$pluginLib\include\" -Force
-          
-          # Copy third-party headers from source directories
-          # NNG headers
-          if (Test-Path "thirdparty\nng\include") {
-            Copy-Item "thirdparty\nng\include\nng\*" "$pluginLib\include\nng\" -Recurse -Force
-          }
-          
-          # Flatbuffers headers
-          if (Test-Path "thirdparty\flatbuffers\include\flatbuffers") {
-            Copy-Item "thirdparty\flatbuffers\include\flatbuffers\*" "$pluginLib\include\flatbuffers\" -Recurse -Force
-          }
-          
-          # Also check usr/include if it exists (from install)
-          if (Test-Path "usr\include\nng") {
-            Copy-Item "usr\include\nng\*" "$pluginLib\include\nng\" -Recurse -Force
-          }
-          if (Test-Path "usr\include\flatbuffers") {
-            Copy-Item "usr\include\flatbuffers\*" "$pluginLib\include\flatbuffers\" -Recurse -Force
-          }
-          if (Test-Path "usr\include\*.h") {
-            Copy-Item "usr\include\*.h" "$pluginLib\include\" -Force
-          }
-          
-          Write-Host "[OK] Libraries and headers copied successfully"
-          Write-Host "Plugin lib directory contents:"
-          Get-ChildItem "$pluginLib" -Recurse | Select-Object FullName
+          } else { Write-Host "[OK] All WebRTC libraries present" }
 
       - name: Locate plugin (.uplugin)
         id: find
@@ -210,12 +80,7 @@ jobs:
         run: |
           $pluginDir = Join-Path $PWD "plugins\unreal\$env:PLUGIN_NAME"
           $upluginPath = Join-Path $pluginDir "$env:PLUGIN_NAME.uplugin"
-          
-          if (!(Test-Path -LiteralPath $upluginPath)) {
-            Write-Error "Plugin file not found at: $upluginPath"
-            exit 1
-          }
-          
+          if (!(Test-Path -LiteralPath $upluginPath)) { Write-Error "Plugin file not found at: $upluginPath"; exit 1 }
           "plugin_path=$upluginPath" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
           "plugin_dir=$pluginDir" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
           "plugin_name=$env:PLUGIN_NAME" | Out-File -FilePath $env:GITHUB_OUTPUT -Append

--- a/plugins/unreal/Open3DStream/Source/Open3DStream/Public/UOpen3DServer.h
+++ b/plugins/unreal/Open3DStream/Source/Open3DStream/Public/UOpen3DServer.h
@@ -36,7 +36,7 @@ public:
 	void tick();
 
 	O3DS::AsyncConnector* mServer;
-	FWebRTCConnector* mWebRTCConnector;  // Unreal's Pixel Streaming WebRTC
+	FWebRTCConnector* mWebRTCConnector; 
 	FSocket* mTcp;
 	FSocket* mUdp;
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,6 +24,8 @@ endif()
 if(O3DS_WITH_WEBRTC)
 	# Prefer prebuilt artifacts when a root path is provided; otherwise use find_package
 	if(O3DS_LIBDATACHANNEL_ROOT)
+		# Sanitize potential surrounding quotes passed from CI/workflows
+		string(REGEX REPLACE "^\"(.*)\"$" "\\1" O3DS_LIBDATACHANNEL_ROOT "${O3DS_LIBDATACHANNEL_ROOT}")
 		# Expect headers under <root>/include (or <root> if include not present)
 		set(LDC_INCLUDE_DIR "${O3DS_LIBDATACHANNEL_ROOT}/include")
 		if(NOT EXISTS "${LDC_INCLUDE_DIR}")


### PR DESCRIPTION
Introduce a composite action (./.github/actions/build-plugin-core) to consolidate shared steps: checkout, MSBuild/UE setup, cache, thirdparty build, core build (with optional WebRTC + O3DS_LIBDATACHANNEL_ROOT), header/lib copy, and .uplugin resolution.\n\nRefactor: \n- Unreal Plugin Nightly now uses the composite, workflow stays focused on packaging.\n- Unreal Plugin CI uses the composite, then builds + uploads artifact.\n- Unreal Plugin Release uses the composite for the heavy build; keeps versioning, packaging, and GH Release.\n\nBenefit: single source of truth for the build bits; easier maintenance and fewer sync issues.