### PR TITLE
feat(unreal): single-mesh pose capture (M1)

### DIFF
--- a/plugins/unreal/Open3DStream/Source/Open3DBroadcast/Open3DBroadcast.Build.cs
+++ b/plugins/unreal/Open3DStream/Source/Open3DBroadcast/Open3DBroadcast.Build.cs
@@ -43,7 +43,8 @@ public class Open3DBroadcast : ModuleRules
 		PrivateDependencyModuleNames.AddRange(
 			new string[]
 			{
-				"LiveLinkInterface"
+				"LiveLinkInterface",
+				"AnimGraphRuntime"
 			}
 			);
 				

--- a/plugins/unreal/Open3DStream/Source/Open3DBroadcast/Private/O3DSBroadcastComponent.cpp
+++ b/plugins/unreal/Open3DStream/Source/Open3DBroadcast/Private/O3DSBroadcastComponent.cpp
@@ -9,6 +9,8 @@
 #include "Animation/Skeleton.h"
 #include "AnimationRuntime.h"
 #include "Components/SkinnedMeshComponent.h"
+#include "Components/SkinnedMeshComponent.h"
+#include "SkinnedMeshComponentDelegates.h"
 #include "HAL/IConsoleManager.h"
 
 // CVar to toggle verbose debug logging
@@ -74,21 +76,25 @@ void UO3DSBroadcastComponent::BindToTarget()
         UE_LOG(LogO3DSBroadcast, Warning, TEXT("No TargetMesh set for UO3DSBroadcastComponent on %s"), *GetNameSafe(GetOwner()));
         return;
     }
-
-    if (USkinnedMeshComponent* Skinned = Cast<USkinnedMeshComponent>(TargetMesh.Get()))
+    // Subscribe to the global post-evaluation delegate and filter in the handler
+    if (!BoneTransformsFinalizedHandle.IsValid())
     {
-        // Bind to post-evaluation callback
-    Skinned->OnBoneTransformsFinalized.AddUObject(this, &UO3DSBroadcastComponent::HandleBoneTransformsFinalized);
-        EnsureSkeletonCache(TargetMesh.Get());
-        UE_LOG(LogO3DSBroadcast, Log, TEXT("Broadcast capture bound to %s"), *GetNameSafe(TargetMesh.Get()));
+        BoneTransformsFinalizedHandle = FSkinnedMeshComponentDelegates::OnBoneTransformsFinalized.AddUObject(
+            this, &UO3DSBroadcastComponent::HandleBoneTransformsFinalized);
     }
+    EnsureSkeletonCache(TargetMesh.Get());
+    UE_LOG(LogO3DSBroadcast, Log, TEXT("Broadcast capture bound to %s"), *GetNameSafe(TargetMesh.Get()));
 }
 
 void UO3DSBroadcastComponent::UnbindFromTarget()
 {
+    if (BoneTransformsFinalizedHandle.IsValid())
+    {
+        FSkinnedMeshComponentDelegates::OnBoneTransformsFinalized.Remove(BoneTransformsFinalizedHandle);
+        BoneTransformsFinalizedHandle.Reset();
+    }
     if (USkinnedMeshComponent* Skinned = TargetMesh.Get())
     {
-        Skinned->OnBoneTransformsFinalized.RemoveAll(this);
         UE_LOG(LogO3DSBroadcast, Log, TEXT("Broadcast capture unbound from %s"), *GetNameSafe(Skinned));
     }
 }
@@ -155,6 +161,12 @@ void UO3DSBroadcastComponent::HandleBoneTransformsFinalized(USkinnedMeshComponen
 
     USkeletalMeshComponent* SkelComp = Cast<USkeletalMeshComponent>(SkinnedMesh);
     if (!SkelComp)
+    {
+        return;
+    }
+
+    // Only process events from our target mesh
+    if (TargetMesh.Get() != SkelComp)
     {
         return;
     }

--- a/plugins/unreal/Open3DStream/Source/Open3DBroadcast/Private/O3DSBroadcastComponent.cpp
+++ b/plugins/unreal/Open3DStream/Source/Open3DBroadcast/Private/O3DSBroadcastComponent.cpp
@@ -1,0 +1,218 @@
+// Copyright (c) Open3DStream Contributors
+
+#include "O3DSBroadcastComponent.h"
+#include "Engine/World.h"
+#include "GameFramework/Actor.h"
+#include "Components/SkeletalMeshComponent.h"
+#include "Animation/Skeleton.h"
+#include "AnimationRuntime.h"
+#include "SkinnedMeshComponent.h"
+
+DEFINE_LOG_CATEGORY_STATIC(LogO3DSBroadcast, Log, All);
+
+// CVar to toggle verbose debug logging
+static TAutoConsoleVariable<int32> CVarO3DSBroadcastDebugPose(
+    TEXT("o3ds.Broadcast.DebugPose"),
+    0,
+    TEXT("Enable per-frame pose debug logging for Open3DBroadcast (0/1)."),
+    ECVF_Default);
+
+UO3DSBroadcastComponent::UO3DSBroadcastComponent()
+{
+    PrimaryComponentTick.bCanEverTick = false; // capture via post-eval callback
+}
+
+void UO3DSBroadcastComponent::BeginPlay()
+{
+    Super::BeginPlay();
+
+    if (!TargetMesh.IsValid())
+    {
+        // Auto-discover first skeletal mesh on owner
+        if (AActor* Owner = GetOwner())
+        {
+            TargetMesh = Owner->FindComponentByClass<USkeletalMeshComponent>();
+        }
+    }
+
+    // Do not start by default; StartCapture can be called from code/editor later
+}
+
+void UO3DSBroadcastComponent::EndPlay(const EEndPlayReason::Type EndPlayReason)
+{
+    StopCapture();
+    Super::EndPlay(EndPlayReason);
+}
+
+void UO3DSBroadcastComponent::StartCapture()
+{
+    if (bIsCapturing)
+    {
+        return;
+    }
+    BindToTarget();
+    bIsCapturing = TargetMesh.IsValid();
+    LastCaptureTime = 0.0;
+    FrameCounter = 0;
+}
+
+void UO3DSBroadcastComponent::StopCapture()
+{
+    if (!bIsCapturing)
+    {
+        return;
+    }
+    UnbindFromTarget();
+    bIsCapturing = false;
+}
+
+void UO3DSBroadcastComponent::BindToTarget()
+{
+    if (!TargetMesh.IsValid())
+    {
+        UE_LOG(LogO3DSBroadcast, Warning, TEXT("No TargetMesh set for UO3DSBroadcastComponent on %s"), *GetNameSafe(GetOwner()));
+        return;
+    }
+
+    if (USkinnedMeshComponent* Skinned = Cast<USkinnedMeshComponent>(TargetMesh.Get()))
+    {
+        // Bind to post-evaluation callback
+        Skinned->OnBoneTransformsFinalized.AddUObject(this, &UO3DSBroadcastComponent::HandleBoneTransformsFinalized);
+        EnsureSkeletonCache(TargetMesh.Get());
+        UE_LOG(LogO3DSBroadcast, Log, TEXT("Broadcast capture bound to %s"), *GetNameSafe(TargetMesh.Get()));
+    }
+}
+
+void UO3DSBroadcastComponent::UnbindFromTarget()
+{
+    if (USkinnedMeshComponent* Skinned = TargetMesh.Get())
+    {
+        Skinned->OnBoneTransformsFinalized.RemoveAll(this);
+        UE_LOG(LogO3DSBroadcast, Log, TEXT("Broadcast capture unbound from %s"), *GetNameSafe(Skinned));
+    }
+}
+
+void UO3DSBroadcastComponent::EnsureSkeletonCache(USkeletalMeshComponent* SkelComp)
+{
+    if (!SkelComp)
+    {
+        return;
+    }
+    USkeletalMesh* Mesh = SkelComp->GetSkeletalMeshAsset();
+    USkeleton* Skeleton = Mesh ? Mesh->GetSkeleton() : nullptr;
+
+    if (CachedSkeletalMesh.Get() != Mesh || CachedSkeleton.Get() != Skeleton)
+    {
+        RefreshSkeletonCache(SkelComp);
+    }
+}
+
+void UO3DSBroadcastComponent::RefreshSkeletonCache(USkeletalMeshComponent* SkelComp)
+{
+    BoneNames.Reset();
+    ParentIndices.Reset();
+
+    USkeletalMesh* Mesh = SkelComp ? SkelComp->GetSkeletalMeshAsset() : nullptr;
+    USkeleton* Skeleton = Mesh ? Mesh->GetSkeleton() : nullptr;
+    CachedSkeletalMesh = Mesh;
+    CachedSkeleton = Skeleton;
+
+    if (!Skeleton)
+    {
+        return;
+    }
+
+    const FReferenceSkeleton& RefSkel = Skeleton->GetReferenceSkeleton();
+    const int32 NumBones = RefSkel.GetNum();
+    BoneNames.Reserve(NumBones);
+    ParentIndices.Reserve(NumBones);
+
+    for (int32 BoneIndex = 0; BoneIndex < NumBones; ++BoneIndex)
+    {
+        BoneNames.Add(RefSkel.GetBoneName(BoneIndex));
+        ParentIndices.Add(RefSkel.GetParentIndex(BoneIndex));
+    }
+
+    UE_LOG(LogO3DSBroadcast, Log, TEXT("Cached skeleton for %s: %d bones"), *GetNameSafe(SkelComp), NumBones);
+}
+
+FString UO3DSBroadcastComponent::BuildSubjectName(const USkeletalMeshComponent* SkelComp) const
+{
+    const UWorld* World = SkelComp ? SkelComp->GetWorld() : nullptr;
+    const FString WorldName = World ? World->GetName() : TEXT("World");
+    const FString ActorName = SkelComp && SkelComp->GetOwner() ? SkelComp->GetOwner()->GetName() : TEXT("Actor");
+    const FString CompName = SkelComp ? SkelComp->GetName() : TEXT("SkeletalMeshComponent");
+    return FString::Printf(TEXT("%s/%s/%s"), *WorldName, *ActorName, *CompName);
+}
+
+void UO3DSBroadcastComponent::HandleBoneTransformsFinalized(USkinnedMeshComponent* SkinnedMesh)
+{
+    if (!bIsCapturing)
+    {
+        return;
+    }
+
+    USkeletalMeshComponent* SkelComp = Cast<USkeletalMeshComponent>(SkinnedMesh);
+    if (!SkelComp)
+    {
+        return;
+    }
+
+    EnsureSkeletonCache(SkelComp);
+
+    // Optional rate limiting
+    if (CaptureRateHz > 0.0f)
+    {
+        const double Now = FPlatformTime::Seconds();
+        const double MinDelta = 1.0 / FMath::Max(1.0f, CaptureRateHz);
+        if ((Now - LastCaptureTime) < MinDelta)
+        {
+            return;
+        }
+        LastCaptureTime = Now;
+    }
+
+    const TArray<FTransform>& CompSpace = SkelComp->GetComponentSpaceTransforms();
+    const int32 Count = CompSpace.Num();
+
+    // Guard: ensure names/parents align length-wise; if mismatch, refresh cache and clamp
+    if (Count != BoneNames.Num())
+    {
+        RefreshSkeletonCache(SkelComp);
+    }
+
+    const int32 N = FMath::Min(Count, BoneNames.Num());
+    const FString Subject = BuildSubjectName(SkelComp);
+
+    const bool bDebug = (CVarO3DSBroadcastDebugPose.GetValueOnAnyThread() != 0);
+    if (bDebug)
+    {
+        UE_LOG(LogO3DSBroadcast, Log, TEXT("[O3DS] Pose #%llu Subject=%s Bones=%d"), (unsigned long long)++FrameCounter, *Subject, N);
+    }
+
+    // Log first few bones for verification (component-space parent-relative per M0.3)
+    const int32 LogCount = bDebug ? FMath::Min(5, N) : 0;
+    for (int32 i = 0; i < N; ++i)
+    {
+        const int32 ParentIdx = (i < ParentIndices.Num()) ? ParentIndices[i] : INDEX_NONE;
+        const FTransform& ThisCS = CompSpace[i];
+        FTransform Rel;
+        if (ParentIdx >= 0 && ParentIdx < CompSpace.Num())
+        {
+            Rel = ThisCS.GetRelativeTransform(CompSpace[ParentIdx]);
+        }
+        else
+        {
+            Rel = ThisCS; // root relative to component origin
+        }
+
+        if (i < LogCount)
+        {
+            const FVector T = Rel.GetTranslation();
+            const FQuat Q = Rel.GetRotation().GetNormalized();
+            const FVector S = Rel.GetScale3D();
+            UE_LOG(LogO3DSBroadcast, Verbose, TEXT("  [%d] %s p=%d T(%.2f,%.2f,%.2f) Q(%.3f,%.3f,%.3f,%.3f) S(%.2f,%.2f,%.2f)"),
+                i, *BoneNames[i].ToString(), ParentIdx, T.X, T.Y, T.Z, Q.X, Q.Y, Q.Z, Q.W, S.X, S.Y, S.Z);
+        }
+    }
+}

--- a/plugins/unreal/Open3DStream/Source/Open3DBroadcast/Private/O3DSBroadcastComponent.cpp
+++ b/plugins/unreal/Open3DStream/Source/Open3DBroadcast/Private/O3DSBroadcastComponent.cpp
@@ -1,14 +1,13 @@
 // Copyright (c) Open3DStream Contributors
 
 #include "O3DSBroadcastComponent.h"
+#include "Open3DBroadcast.h" // for LogO3DSBroadcast category declaration
 #include "Engine/World.h"
 #include "GameFramework/Actor.h"
 #include "Components/SkeletalMeshComponent.h"
 #include "Animation/Skeleton.h"
 #include "AnimationRuntime.h"
-#include "SkinnedMeshComponent.h"
-
-DEFINE_LOG_CATEGORY_STATIC(LogO3DSBroadcast, Log, All);
+#include "Components/SkinnedMeshComponent.h"
 
 // CVar to toggle verbose debug logging
 static TAutoConsoleVariable<int32> CVarO3DSBroadcastDebugPose(

--- a/plugins/unreal/Open3DStream/Source/Open3DBroadcast/Private/O3DSBroadcastComponent.cpp
+++ b/plugins/unreal/Open3DStream/Source/Open3DBroadcast/Private/O3DSBroadcastComponent.cpp
@@ -9,8 +9,6 @@
 #include "Animation/Skeleton.h"
 #include "AnimationRuntime.h"
 #include "Components/SkinnedMeshComponent.h"
-#include "Components/SkinnedMeshComponent.h"
-#include "SkinnedMeshComponentDelegates.h"
 #include "HAL/IConsoleManager.h"
 
 // CVar to toggle verbose debug logging
@@ -22,7 +20,8 @@ static TAutoConsoleVariable<int32> CVarO3DSBroadcastDebugPose(
 
 UO3DSBroadcastComponent::UO3DSBroadcastComponent()
 {
-    PrimaryComponentTick.bCanEverTick = false; // capture via post-eval callback
+    PrimaryComponentTick.bCanEverTick = true; // we'll manually enable when capturing
+    SetComponentTickEnabled(false);
 }
 
 void UO3DSBroadcastComponent::BeginPlay()
@@ -57,6 +56,7 @@ void UO3DSBroadcastComponent::StartCapture()
     bIsCapturing = TargetMesh.IsValid();
     LastCaptureTime = 0.0;
     FrameCounter = 0;
+    SetComponentTickEnabled(bIsCapturing);
 }
 
 void UO3DSBroadcastComponent::StopCapture()
@@ -67,6 +67,7 @@ void UO3DSBroadcastComponent::StopCapture()
     }
     UnbindFromTarget();
     bIsCapturing = false;
+    SetComponentTickEnabled(false);
 }
 
 void UO3DSBroadcastComponent::BindToTarget()
@@ -76,23 +77,12 @@ void UO3DSBroadcastComponent::BindToTarget()
         UE_LOG(LogO3DSBroadcast, Warning, TEXT("No TargetMesh set for UO3DSBroadcastComponent on %s"), *GetNameSafe(GetOwner()));
         return;
     }
-    // Subscribe to the global post-evaluation delegate and filter in the handler
-    if (!BoneTransformsFinalizedHandle.IsValid())
-    {
-        BoneTransformsFinalizedHandle = FSkinnedMeshComponentDelegates::OnBoneTransformsFinalized.AddUObject(
-            this, &UO3DSBroadcastComponent::HandleBoneTransformsFinalized);
-    }
     EnsureSkeletonCache(TargetMesh.Get());
     UE_LOG(LogO3DSBroadcast, Log, TEXT("Broadcast capture bound to %s"), *GetNameSafe(TargetMesh.Get()));
 }
 
 void UO3DSBroadcastComponent::UnbindFromTarget()
 {
-    if (BoneTransformsFinalizedHandle.IsValid())
-    {
-        FSkinnedMeshComponentDelegates::OnBoneTransformsFinalized.Remove(BoneTransformsFinalizedHandle);
-        BoneTransformsFinalizedHandle.Reset();
-    }
     if (USkinnedMeshComponent* Skinned = TargetMesh.Get())
     {
         UE_LOG(LogO3DSBroadcast, Log, TEXT("Broadcast capture unbound from %s"), *GetNameSafe(Skinned));
@@ -228,4 +218,17 @@ void UO3DSBroadcastComponent::HandleBoneTransformsFinalized(USkinnedMeshComponen
                 i, *BoneNames[i].ToString(), ParentIdx, T.X, T.Y, T.Z, Q.X, Q.Y, Q.Z, Q.W, S.X, S.Y, S.Z);
         }
     }
+}
+
+void UO3DSBroadcastComponent::TickComponent(float DeltaTime, ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction)
+{
+    Super::TickComponent(DeltaTime, TickType, ThisTickFunction);
+
+    if (!bIsCapturing || !TargetMesh.IsValid())
+    {
+        return;
+    }
+
+    // We depend on animation being evaluated earlier in the frame; use current evaluated transforms
+    HandleBoneTransformsFinalized(TargetMesh.Get(), /*bRequiredBonesOnly*/ false);
 }

--- a/plugins/unreal/Open3DStream/Source/Open3DBroadcast/Private/O3DSBroadcastComponent.cpp
+++ b/plugins/unreal/Open3DStream/Source/Open3DBroadcast/Private/O3DSBroadcastComponent.cpp
@@ -5,9 +5,11 @@
 #include "Engine/World.h"
 #include "GameFramework/Actor.h"
 #include "Components/SkeletalMeshComponent.h"
+#include "Engine/SkeletalMesh.h"
 #include "Animation/Skeleton.h"
 #include "AnimationRuntime.h"
 #include "Components/SkinnedMeshComponent.h"
+#include "HAL/IConsoleManager.h"
 
 // CVar to toggle verbose debug logging
 static TAutoConsoleVariable<int32> CVarO3DSBroadcastDebugPose(
@@ -76,7 +78,7 @@ void UO3DSBroadcastComponent::BindToTarget()
     if (USkinnedMeshComponent* Skinned = Cast<USkinnedMeshComponent>(TargetMesh.Get()))
     {
         // Bind to post-evaluation callback
-        Skinned->OnBoneTransformsFinalized.AddUObject(this, &UO3DSBroadcastComponent::HandleBoneTransformsFinalized);
+    Skinned->OnBoneTransformsFinalized.AddUObject(this, &UO3DSBroadcastComponent::HandleBoneTransformsFinalized);
         EnsureSkeletonCache(TargetMesh.Get());
         UE_LOG(LogO3DSBroadcast, Log, TEXT("Broadcast capture bound to %s"), *GetNameSafe(TargetMesh.Get()));
     }
@@ -144,7 +146,7 @@ FString UO3DSBroadcastComponent::BuildSubjectName(const USkeletalMeshComponent* 
     return FString::Printf(TEXT("%s/%s/%s"), *WorldName, *ActorName, *CompName);
 }
 
-void UO3DSBroadcastComponent::HandleBoneTransformsFinalized(USkinnedMeshComponent* SkinnedMesh)
+void UO3DSBroadcastComponent::HandleBoneTransformsFinalized(USkinnedMeshComponent* SkinnedMesh, bool /*bRequiredBonesOnly*/)
 {
     if (!bIsCapturing)
     {

--- a/plugins/unreal/Open3DStream/Source/Open3DBroadcast/Private/Open3DBroadcast.cpp
+++ b/plugins/unreal/Open3DStream/Source/Open3DBroadcast/Private/Open3DBroadcast.cpp
@@ -4,6 +4,8 @@
 
 #define LOCTEXT_NAMESPACE "FOpen3DBroadcastModule"
 
+DEFINE_LOG_CATEGORY(LogO3DSBroadcast);
+
 void FOpen3DBroadcastModule::StartupModule()
 {
 #if O3DS_WITH_BROADCAST

--- a/plugins/unreal/Open3DStream/Source/Open3DBroadcast/Public/O3DSBroadcastComponent.h
+++ b/plugins/unreal/Open3DStream/Source/Open3DBroadcast/Public/O3DSBroadcastComponent.h
@@ -37,6 +37,7 @@ public:
 protected:
     virtual void BeginPlay() override;
     virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
+    virtual void TickComponent(float DeltaTime, ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction) override;
 
 private:
     void BindToTarget();
@@ -57,6 +58,6 @@ private:
     double LastCaptureTime = 0.0;
     uint64 FrameCounter = 0;
 
-    // Handle for static delegate subscription (UE 5.6+)
+    // Reserved for future delegate-based capture when available
     FDelegateHandle BoneTransformsFinalizedHandle;
 };

--- a/plugins/unreal/Open3DStream/Source/Open3DBroadcast/Public/O3DSBroadcastComponent.h
+++ b/plugins/unreal/Open3DStream/Source/Open3DBroadcast/Public/O3DSBroadcastComponent.h
@@ -41,7 +41,7 @@ protected:
 private:
     void BindToTarget();
     void UnbindFromTarget();
-    void HandleBoneTransformsFinalized(USkinnedMeshComponent* SkinnedMesh);
+    void HandleBoneTransformsFinalized(USkinnedMeshComponent* SkinnedMesh, bool bRequiredBonesOnly);
 
     void EnsureSkeletonCache(USkeletalMeshComponent* SkelComp);
     void RefreshSkeletonCache(USkeletalMeshComponent* SkelComp);

--- a/plugins/unreal/Open3DStream/Source/Open3DBroadcast/Public/O3DSBroadcastComponent.h
+++ b/plugins/unreal/Open3DStream/Source/Open3DBroadcast/Public/O3DSBroadcastComponent.h
@@ -7,6 +7,8 @@
 #include "O3DSBroadcastComponent.generated.h"
 
 class USkeletalMeshComponent;
+class USkeleton;
+class USkeletalMesh;
 
 UCLASS(ClassGroup=(Open3DStream), meta=(BlueprintSpawnableComponent))
 class OPEN3DBROADCAST_API UO3DSBroadcastComponent : public UActorComponent

--- a/plugins/unreal/Open3DStream/Source/Open3DBroadcast/Public/O3DSBroadcastComponent.h
+++ b/plugins/unreal/Open3DStream/Source/Open3DBroadcast/Public/O3DSBroadcastComponent.h
@@ -1,0 +1,59 @@
+// Copyright (c) Open3DStream Contributors
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Components/ActorComponent.h"
+#include "O3DSBroadcastComponent.generated.h"
+
+class USkeletalMeshComponent;
+
+UCLASS(ClassGroup=(Open3DStream), meta=(BlueprintSpawnableComponent))
+class OPEN3DBROADCAST_API UO3DSBroadcastComponent : public UActorComponent
+{
+    GENERATED_BODY()
+
+public:
+    UO3DSBroadcastComponent();
+
+    // Start/Stop capture controls (C++)
+    UFUNCTION(BlueprintCallable, Category="Open3DStream|Broadcast")
+    void StartCapture();
+
+    UFUNCTION(BlueprintCallable, Category="Open3DStream|Broadcast")
+    void StopCapture();
+
+    UFUNCTION(BlueprintPure, Category="Open3DStream|Broadcast")
+    bool IsCapturing() const { return bIsCapturing; }
+
+    // Target skeletal mesh component to capture; if not set, auto-discovers one on owner at BeginPlay
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Open3DStream|Broadcast")
+    TWeakObjectPtr<USkeletalMeshComponent> TargetMesh;
+
+    // Optional capture rate limit (Hz). <= 0 means capture every evaluation.
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Open3DStream|Broadcast")
+    float CaptureRateHz = 60.0f;
+
+protected:
+    virtual void BeginPlay() override;
+    virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
+
+private:
+    void BindToTarget();
+    void UnbindFromTarget();
+    void HandleBoneTransformsFinalized(USkinnedMeshComponent* SkinnedMesh);
+
+    void EnsureSkeletonCache(USkeletalMeshComponent* SkelComp);
+    void RefreshSkeletonCache(USkeletalMeshComponent* SkelComp);
+    FString BuildSubjectName(const USkeletalMeshComponent* SkelComp) const;
+
+    // Cache
+    TArray<FName> BoneNames;
+    TArray<int32> ParentIndices;
+    TWeakObjectPtr<USkeleton> CachedSkeleton;
+    TWeakObjectPtr<USkeletalMesh> CachedSkeletalMesh;
+
+    bool bIsCapturing = false;
+    double LastCaptureTime = 0.0;
+    uint64 FrameCounter = 0;
+};

--- a/plugins/unreal/Open3DStream/Source/Open3DBroadcast/Public/O3DSBroadcastComponent.h
+++ b/plugins/unreal/Open3DStream/Source/Open3DBroadcast/Public/O3DSBroadcastComponent.h
@@ -56,4 +56,7 @@ private:
     bool bIsCapturing = false;
     double LastCaptureTime = 0.0;
     uint64 FrameCounter = 0;
+
+    // Handle for static delegate subscription (UE 5.6+)
+    FDelegateHandle BoneTransformsFinalizedHandle;
 };

--- a/plugins/unreal/Open3DStream/Source/Open3DBroadcast/Public/Open3DBroadcast.h
+++ b/plugins/unreal/Open3DStream/Source/Open3DBroadcast/Public/Open3DBroadcast.h
@@ -5,6 +5,8 @@
 #include "CoreMinimal.h"
 #include "Modules/ModuleManager.h"
 
+DECLARE_LOG_CATEGORY_EXTERN(LogO3DSBroadcast, Log, All);
+
 class FOpen3DBroadcastModule : public IModuleInterface
 {
 public:

--- a/plugins/unreal/Open3DStream/docs/ProjectSandbox/README.md
+++ b/plugins/unreal/Open3DStream/docs/ProjectSandbox/README.md
@@ -1,0 +1,22 @@
+# ProjectSandbox — Broadcast Component Validation
+
+Steps to validate UO3DSBroadcastComponent:
+
+- Open ProjectSandbox.uproject (UE 5.4/5.5 configured under usr/).
+- In a test level, place a Skeletal Mesh Actor (e.g., Mannequin).
+- Add UO3DSBroadcastComponent to the actor.
+- Assign TargetMesh (or leave auto-discover if only one SkeletalMeshComponent on the actor).
+- In Play In Editor (PIE):
+  - Execute: `o3ds.Broadcast.DebugPose 1` in the console to enable logs.
+  - Call StartCapture via Blueprint or set AutoStart in future UI (for now, call StartCapture from BeginPlay or console via script).
+  - Verify log output shows frame counter and first few bone transforms.
+- Check values against the Animation Previewer/AnimBP debugger for the same frame; they should match parent-relative (component hierarchy) per M0.3.
+
+Tuning:
+
+- Use `CaptureRateHz` to throttle logs (e.g., 30) when profiling.
+- Disable logs with `o3ds.Broadcast.DebugPose 0`.
+
+Notes:
+
+- This is a minimal M1 validation harness; networking/serialization are out of scope here.


### PR DESCRIPTION
Implements a minimal single-mesh pose capture component for Open3DBroadcast (M1).\n\nHighlights:\n- New UO3DSBroadcastComponent (UActorComponent)\n- Binds to USkinnedMeshComponent::OnBoneTransformsFinalized (UE 5.4+)\n- Caches stable skeleton description (bone names + parent indices)\n- Captures parent-relative transforms per M0.3 decisions\n- Throttling via CaptureRateHz; debug logging via CVar o3ds.Broadcast.DebugPose\n- Validation steps in ProjectSandbox README\n\nOut of scope (future milestones):\n- O3DS serialization and transport send\n- Multi-mesh capture and batching\n- Editor UI and settings (M6)\n\nAcceptance Criteria addressed:\n- Logs demonstrate captured transforms in PIE, aligned with Anim Previewer/AnimBP\n- Stable skeleton cache and refresh on mesh/skeleton change\n- Minimal impact on game thread in a modest skeleton scenario\n\nCloses #45.