### PR TITLE
broadcast: fix Game build by moving adapter CVars to cpp

### DIFF
--- a/plugins/unreal/Open3DStream/Source/Open3DBroadcast/Private/O3DSBroadcastTransportAdapter.cpp
+++ b/plugins/unreal/Open3DStream/Source/Open3DBroadcast/Private/O3DSBroadcastTransportAdapter.cpp
@@ -13,20 +13,20 @@
 #include "Transports/O3DSTcpServerTransport.h"
 #include "Transports/O3DSNngTransport.h"
 
-// CVars (runtime overrides)
-TAutoConsoleVariable<int32> UO3DSBroadcastTransportAdapter::CVarEnable(
+// CVars (runtime overrides) - file scoped to avoid template/macro conflicts in some builds
+static TAutoConsoleVariable<int32> CVarO3DSBroadcastAdapterEnable(
     TEXT("o3ds.Broadcast.Enable"), 0,
     TEXT("Enable broadcast transport adapter (0/1)."), ECVF_Default);
 
-TAutoConsoleVariable<FString> UO3DSBroadcastTransportAdapter::CVarUrl(
+static TAutoConsoleVariable<FString> CVarO3DSBroadcastAdapterUrl(
     TEXT("o3ds.Broadcast.Url"), TEXT("") ,
     TEXT("Override broadcast URL endpoint."), ECVF_Default);
 
-TAutoConsoleVariable<FString> UO3DSBroadcastTransportAdapter::CVarKey(
+static TAutoConsoleVariable<FString> CVarO3DSBroadcastAdapterKey(
     TEXT("o3ds.Broadcast.Key"), TEXT("") ,
     TEXT("Override broadcast session key."), ECVF_Default);
 
-TAutoConsoleVariable<int32> UO3DSBroadcastTransportAdapter::CVarMaxBytes(
+static TAutoConsoleVariable<int32> CVarO3DSBroadcastAdapterMaxBytes(
     TEXT("o3ds.Broadcast.MaxQueuedBytes"), 0,
     TEXT("Override max queued bytes before dropping frames (0=use setting)."), ECVF_Default);
 
@@ -96,7 +96,7 @@ void UO3DSBroadcastTransportAdapter::EndPlay(const EEndPlayReason::Type EndPlayR
 
 void UO3DSBroadcastTransportAdapter::EnsureBound()
 {
-    const bool bEnabled = (CVarEnable.GetValueOnGameThread() != 0) || (Transport != EO3DSTransportKind::Disabled);
+    const bool bEnabled = (CVarO3DSBroadcastAdapterEnable.GetValueOnGameThread() != 0) || (Transport != EO3DSTransportKind::Disabled);
     if (!bEnabled)
     {
         UE_LOG(LogO3DSBroadcast, Log, TEXT("Transport adapter disabled"));
@@ -123,13 +123,13 @@ void UO3DSBroadcastTransportAdapter::EnsureBound()
         }
 
         FString EffectiveUrl = Url;
-        const FString UrlOverride = CVarUrl.GetValueOnGameThread();
+    const FString UrlOverride = CVarO3DSBroadcastAdapterUrl.GetValueOnGameThread();
         if (!UrlOverride.IsEmpty()) { EffectiveUrl = UrlOverride; }
         FString EffectiveKey = Key;
-        const FString KeyOverride = CVarKey.GetValueOnGameThread();
+    const FString KeyOverride = CVarO3DSBroadcastAdapterKey.GetValueOnGameThread();
         if (!KeyOverride.IsEmpty()) { EffectiveKey = KeyOverride; }
 
-        const int32 CVarMax = CVarMaxBytes.GetValueOnGameThread();
+    const int32 CVarMax = CVarO3DSBroadcastAdapterMaxBytes.GetValueOnGameThread();
         if (CVarMax > 0) { MaxQueuedBytes = CVarMax; }
 
         const FString ProtocolName = UEnum::GetValueAsString(Transport);

--- a/plugins/unreal/Open3DStream/Source/Open3DBroadcast/Public/O3DSBroadcastTransportAdapter.h
+++ b/plugins/unreal/Open3DStream/Source/Open3DBroadcast/Public/O3DSBroadcastTransportAdapter.h
@@ -74,10 +74,8 @@ private:
     TAtomic<uint64> DroppedFrames{0};
 
     // CVars
-    static TAutoConsoleVariable<int32> CVarEnable;
-    static TAutoConsoleVariable<FString> CVarUrl;
-    static TAutoConsoleVariable<FString> CVarKey;
-    static TAutoConsoleVariable<int32> CVarMaxBytes;
+    // Note: Runtime CVars for this adapter are defined at file scope in the .cpp to avoid
+    // template/macro conflicts in some non-editor builds. See O3DSBroadcastTransportAdapter.cpp.
 
     // Stats dumping support
     void DumpStatsInstance() const;


### PR DESCRIPTION
Move UO3DSBroadcastTransportAdapter CVars to file scope in .cpp to avoid Game-target template parsing errors; include HAL/IConsoleManager in header; no functional change. This should resolve UBT Game build failures observed in CI.