### PR TITLE
unreal: replace deprecated RightChopInline(bool) with EAllowShrinking::No

### DIFF
--- a/plugins/unreal/Open3DStream/Source/Open3DBroadcast/Private/Transports/O3DSTcpServerTransport.cpp
+++ b/plugins/unreal/Open3DStream/Source/Open3DBroadcast/Private/Transports/O3DSTcpServerTransport.cpp
@@ -22,7 +22,7 @@ bool FO3DSTcpServerTransport::ParseTcpUrl(const FString& InUrl, FString& OutHost
     FString Work = InUrl;
     if (Work.StartsWith(TEXT("tcp://")))
     {
-        Work.RightChopInline(6, false);
+    Work.RightChopInline(6, EAllowShrinking::No);
     }
     int32 ColonIdx;
     if (!Work.FindChar(':', ColonIdx))

--- a/plugins/unreal/Open3DStream/Source/Open3DBroadcast/Private/Transports/O3DSTcpTransport.cpp
+++ b/plugins/unreal/Open3DStream/Source/Open3DBroadcast/Private/Transports/O3DSTcpTransport.cpp
@@ -20,7 +20,7 @@ bool FO3DSTcpTransport::ParseTcpUrl(const FString& InUrl, FString& OutHost, int3
     FString Work = InUrl;
     if (Work.StartsWith(TEXT("tcp://")))
     {
-        Work.RightChopInline(6, false);
+    Work.RightChopInline(6, EAllowShrinking::No);
     }
     int32 ColonIdx;
     if (!Work.FindChar(':', ColonIdx))

--- a/plugins/unreal/Open3DStream/Source/Open3DStream/Private/UOpen3DServer.cpp
+++ b/plugins/unreal/Open3DStream/Source/Open3DStream/Private/UOpen3DServer.cpp
@@ -46,7 +46,7 @@ static bool ParseTcpUrl(const FString& In, FString& OutIp, int32& OutPort)
 	FString Work = In;
 	if (Work.StartsWith(TEXT("tcp://")))
 	{
-		Work.RightChopInline(6, false);
+		   Work.RightChopInline(6, EAllowShrinking::No);
 	}
 	int32 Colon = INDEX_NONE;
 	if (!Work.FindChar(':', Colon))


### PR DESCRIPTION
Cleanup: swap deprecated FString::RightChopInline(bool) for EAllowShrinking::No in transports and server to remove UE 5.6 warnings.\n\n- No behavior changes; string slicing preserved.\n- Matches existing usage in O3DSUdpTransport.cpp.\n- Verified previous CI green; this PR targets warning removal only.