### PR TITLE
ci: Repeater image submodule init + PR/nightly build + smoke test (refs #83)

### DIFF
--- a/.github/workflows/repeater-image.yml
+++ b/.github/workflows/repeater-image.yml
@@ -7,6 +7,17 @@ on:
       - "**/*.cpp"
       - "**/*.h"
       - "CMakeLists.txt"
+      - "thirdparty/**"
+  pull_request:
+    branches: [ develop, main ]
+    paths:
+      - "docker/Dockerfile.repeater"
+      - "**/*.cpp"
+      - "**/*.h"
+      - "CMakeLists.txt"
+      - "thirdparty/**"
+  schedule:
+    - cron: '0 6 * * *' # daily 06:00 UTC nightly build
   workflow_dispatch:
 
 jobs:
@@ -15,23 +26,77 @@ jobs:
     permissions:
       contents: read
       packages: write
+    env:
+      IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/open3dstream-repeater
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout repository (with submodules)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: recursive
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Log in to GHCR
+      - name: Log in to GHCR (for pushes and pulls)
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push
+      # Build for PRs (no push), load to local Docker for smoke test
+      - name: Build (PR)
+        if: github.event_name == 'pull_request' && (github.event.pull_request.draft == false)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile.repeater
+          push: false
+          load: true
+          tags: ${{ env.IMAGE_NAME }}:pr-${{ github.sha }}
+
+      - name: Smoke test (PR)
+        if: github.event_name == 'pull_request' && (github.event.pull_request.draft == false)
+        run: |
+          docker run --rm --entrypoint /bin/sh $IMAGE -c "echo ok"
+          # Optional usage check; don't fail on exit code
+          docker run --rm $IMAGE || true
+        env:
+          IMAGE: ${{ env.IMAGE_NAME }}:pr-${{ github.sha }}
+
+      # Build and push on main branch pushes
+      - name: Build and push (main)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: docker/build-push-action@v6
         with:
           context: .
           file: docker/Dockerfile.repeater
           push: true
-          tags: ghcr.io/${{ github.repository_owner }}/open3dstream-repeater:latest
+          tags: ${{ env.IMAGE_NAME }}:latest
+
+      - name: Pull and smoke test (latest)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          docker pull $IMAGE
+          docker run --rm --entrypoint /bin/sh $IMAGE -c "echo ok"
+        env:
+          IMAGE: ${{ env.IMAGE_NAME }}:latest
+
+      # Nightly scheduled build to 'nightly' tag
+      - name: Build and push (nightly)
+        if: github.event_name == 'schedule'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile.repeater
+          push: true
+          tags: ${{ env.IMAGE_NAME }}:nightly
+
+      - name: Pull and smoke test (nightly)
+        if: github.event_name == 'schedule'
+        run: |
+          docker pull $IMAGE
+          docker run --rm --entrypoint /bin/sh $IMAGE -c "echo ok"
+        env:
+          IMAGE: ${{ env.IMAGE_NAME }}:nightly

--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@ Open3DStream is a standardized protocol and library for real-time streaming of s
 
 ## Quick Start
 
+### Initialize Git submodules
+
+This repository uses Git submodules for third-party dependencies (e.g., FlatBuffers, NNG, CRC). Before building locally or creating Docker images, initialize submodules:
+
+```bash
+git submodule update --init --recursive
+```
+
 ### Building the Library
 
 ```bash
@@ -46,6 +54,21 @@ make -j4
 # Build with WebRTC support (optional)
 cmake .. -DO3DS_ENABLE_WEBRTC=ON
 make -j4
+```
+
+### Docker: Repeater image
+
+We provide a minimal Docker image for the Repeater app. Ensure submodules are initialized locally before building so the Docker build context contains third-party sources.
+
+```bash
+# From repo root (after submodule init)
+docker build -f docker/Dockerfile.repeater -t open3dstream-repeater:local .
+
+# Smoke test the image (non-root entrypoint)
+docker run --rm --entrypoint /bin/sh open3dstream-repeater:local -c "echo ok"
+
+# Run (example addresses)
+docker run --rm open3dstream-repeater:local tcp://0.0.0.0:7000 tcp://0.0.0.0:7001
 ```
 
 ### Using in Unreal Engine
@@ -260,6 +283,12 @@ We welcome contributions! Areas of interest:
 - Performance optimizations
 - Documentation
 - Bug fixes
+
+### CI expectations for contributors
+
+- Submodules are required for all CI builds. Local development and CI expect `git submodule update --init --recursive` to have been run.
+- The Docker Repeater image is built in CI for pull requests that touch code or the Dockerfile and is pushed for `main` and nightly scheduled runs.
+- Workflows use a lean trigger set and smoke-test the image by running a no-op command inside the container to catch regressions early.
 
 ## Community
 


### PR DESCRIPTION
This PR addresses Issue #83 by safely reintroducing the minimal CI/Docker changes needed to build and validate the Repeater image without breaking builds.\n\nWhat changed\n- Workflow: .github/workflows/repeater-image.yml\n  - Checkout with submodules: recursive.\n  - Added pull_request trigger (develop, main) and nightly schedule.\n  - Extended trigger paths to include thirdparty/**.\n  - PR runs: build with load and run a container smoke test (entrypoint override), no push.\n  - main pushes: build+push :latest, then pull and smoke-test.\n  - nightly schedule: build+push :nightly, then pull and smoke-test.\n- Docs: README.md\n  - Added "Initialize Git submodules" section.\n  - Added "Docker: Repeater image" build + smoke test instructions.\n  - Added "CI expectations for contributors".\n\nWhy\n- Ensures submodules (e.g., thirdparty/crccpp) are available for Docker builds.\n- Adds coverage to catch regressions early on PRs and nightly runs.\n- Keeps docs and contributor expectations up-to-date with the finalized workflow.\n\nAcceptance criteria (mapped)\n- CI jobs pass on develop/PRs: Repeater image workflow now runs on PRs and nightly; Linux/Windows/Unreal CI already use submodules.\n- Docker image builds in CI (and locally with submodules): ensured via submodule checkout and PR smoke runs.\n- No vendored third-party headers: thirdparty/crccpp remains a submodule; no vendored headers added.\n- Documentation updated: README includes submodule + Docker guidance and CI expectations.\n\nNotes\n- We relied on on.paths filtering to keep the workflow quiet on docs-only changes.\n- Optional follow-up: add a --help/--version zero-exit path in the Repeater binary for an even simpler smoke test.\n