### PR TITLE
ci(repeater): publish :edge tag on develop for cloud testing

### DIFF
--- a/.github/workflows/repeater-image.yml
+++ b/.github/workflows/repeater-image.yml
@@ -83,6 +83,24 @@ jobs:
         env:
           IMAGE: ${{ env.IMAGE_NAME }}:latest
 
+      # Develop branch push publishes an :edge tag for immediate testing
+      - name: Build and push (develop)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile.repeater
+          push: true
+          tags: ${{ env.IMAGE_NAME }}:edge
+
+      - name: Pull and smoke test (edge)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
+        run: |
+          docker pull $IMAGE
+          docker run --rm --entrypoint /bin/sh $IMAGE -c "echo ok"
+        env:
+          IMAGE: ${{ env.IMAGE_NAME }}:edge
+
       # Nightly scheduled build to 'nightly' tag
       - name: Build and push (nightly)
         if: github.event_name == 'schedule'


### PR DESCRIPTION
This enables the Repeater image to be published as :edge when commits land on develop.

Why
- The repository doesn’t have a 'main' branch, so pushing :latest only on main won’t run.
- This change preserves :latest on 'main' for future, adds :edge on 'develop' for immediate use.

What
- .github/workflows/repeater-image.yml: add develop-path push step with :edge tag and post-push smoke test.

Outcome
- After merging, a push to develop (this PR merge) will publish ghcr.io/${{ github.repository_owner }}/open3dstream-repeater:edge for cloud testing.

Follow-up
- Optionally retag to :latest once a main branch exists or when cutting a release.
