### PR TITLE
ci(repeater): run on develop pushes to publish :edge tag

### DIFF
--- a/.github/workflows/repeater-image.yml
+++ b/.github/workflows/repeater-image.yml
@@ -1,7 +1,7 @@
 name: Build and publish Repeater image
 on:
   push:
-    branches: [ main ]
+    branches: [ main, develop ]
     paths:
       - "docker/Dockerfile.repeater"
       - "**/*.cpp"


### PR DESCRIPTION
Fixes 'manifest unknown' when pulling :edge by ensuring the repeater-image workflow runs on develop pushes.\n\nChange\n- on.push.branches: [ main, develop ]\n\nEffect\n- After merge, pushes to develop will build and push ghcr.io/lifelike-and-believable/open3dstream-repeater:edge automatically (with smoke test).\n\nThis keeps :latest on main and :nightly on schedule.\n