### PR TITLE
fix(unreal): Add missing HAL includes for Game builds

### DIFF
--- a/plugins/unreal/Open3DStream/Source/Open3DStream/Private/UOpen3DServer.cpp
+++ b/plugins/unreal/Open3DStream/Source/Open3DStream/Private/UOpen3DServer.cpp
@@ -6,6 +6,7 @@
 #include "Interfaces/IPv4/IPv4Address.h"
 #include "Common/UdpSocketBuilder.h"
 #include "HAL/PlatformTime.h"
+#include "HAL/IConsoleManager.h"
 
 #define LOCTEXT_NAMESPACE "Open3DStream"
 

--- a/plugins/unreal/Open3DStream/Source/Open3DStream/Private/WebRTCConnector.cpp
+++ b/plugins/unreal/Open3DStream/Source/Open3DStream/Private/WebRTCConnector.cpp
@@ -6,6 +6,8 @@
 #include "Serialization/JsonReader.h"
 #include "IPAddress.h"
 #include "Misc/ScopeLock.h"
+#include "HAL/IConsoleManager.h"
+#include "HAL/PlatformTime.h"
 
 // libdatachannel includes
 #include <rtc/rtc.hpp>


### PR DESCRIPTION
## Summary
Fixes compilation errors in UnrealGame builds by adding missing HAL header includes.

## Problem
GitHub Actions build run [18790453564](https://github.com/lifelike-and-believable/Open3DStream/actions/runs/18790453564) failed with compilation errors in UnrealGame configuration, while UnrealEditor builds succeeded.

**Root Cause:**
- **Editor builds** use `SharedPCH.UnrealEd.Cpp20.cpp` which transitively includes comprehensive headers including `HAL/IConsoleManager.h` and `HAL/PlatformTime.h`
- **Game builds** use minimal PCH for leaner runtime, requiring explicit includes for these headers

## Changes
Added explicit includes to fix missing template instantiation errors:

### WebRTCConnector.cpp
- `#include "HAL/IConsoleManager.h"` - Required for `TAutoConsoleVariable` template (7 CVar declarations)
- `#include "HAL/PlatformTime.h"` - Required for `FPlatformTime::Seconds()` calls

### UOpen3DServer.cpp  
- `#include "HAL/IConsoleManager.h"` - Required for `TAutoConsoleVariable` (CVarO3DSDumpFirstPacket)

## Testing
- [ ] Verify UnrealGame Win64 Development build succeeds in CI
- [ ] Verify UnrealEditor Win64 Development build still succeeds (regression check)

## Notes
These console variables control runtime behavior (auto-reconnect, backoff timing, debug logging) and should **not** be wrapped in `#if WITH_EDITOR` blocks as they are needed in shipping builds. They use `ECVF_Default` which is appropriate for all build configurations.