### PR TITLE
ci: add self-hosted Windows option for libwebrtc build

### DIFF
--- a/.github/workflows/build-webrtc.yml
+++ b/.github/workflows/build-webrtc.yml
@@ -7,6 +7,12 @@ name: Build native WebRTC libraries
 
 on:
   workflow_dispatch:
+    inputs:
+      use_self_hosted_windows:
+        description: "Run Windows build on self-hosted runner"
+        type: boolean
+        required: false
+        default: false
 
 permissions:
   contents: read
@@ -19,6 +25,7 @@ jobs:
   windows:
     name: Windows x64
     runs-on: windows-latest
+    if: ${{ !inputs.use_self_hosted_windows }}
     steps:
       - name: Prepare workspace directories
         run: |
@@ -58,7 +65,7 @@ jobs:
       - name: Generate GN files (Release, static)
         run: |
           cd "$GITHUB_WORKSPACE/webrtc_build/src"
-          python3 tools_webrtc/mb/mb.py gen -m webrtc -c Release //out/Release --args="is_debug=false is_component_build=false rtc_include_tests=false rtc_build_examples=false rtc_build_tools=false rtc_use_h264=false treat_warnings_as_errors=false symbol_level=0"
+          python3 tools_webrtc/mb/mb.py gen -m webrtc -c Release //out/Release --args="is_debug=false is_component_build=false rtc_include_tests=false rtc_build_examples=false rtc_build_tools=false rtc_use_h264=false treat_warnings_as_errors=false symbol_level=0 target_cpu=\"x64\" is_clang=false visual_studio_version=\"2022\""
 
       - name: Build static libraries (target webrtc)
         run: |
@@ -151,6 +158,79 @@ jobs:
         with:
           name: libwebrtc-linux
           path: artifacts/linux
+
+  windows-selfhosted:
+    name: Windows x64 (self-hosted)
+    runs-on: [self-hosted, Windows]
+    if: ${{ inputs.use_self_hosted_windows }}
+    env:
+      # Use the locally installed Visual Studio toolchain on the self-hosted runner
+      DEPOT_TOOLS_WIN_TOOLCHAIN: "0"
+    steps:
+      - name: Prepare workspace directories
+        run: |
+          mkdir -p "$GITHUB_WORKSPACE/webrtc_build"
+          cd "$GITHUB_WORKSPACE/webrtc_build"
+
+      - name: Install Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Fetch depot_tools
+        run: |
+          cd "$GITHUB_WORKSPACE/webrtc_build"
+          git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
+          echo "${{ github.workspace }}\webrtc_build\depot_tools" >> $GITHUB_PATH
+
+      - name: Bootstrap gclient
+        run: |
+          gclient --version
+
+      - name: Checkout WebRTC fork (lifelike-and-believable/webrtc)
+        run: |
+          cd "$GITHUB_WORKSPACE/webrtc_build"
+          git clone --depth=1 https://github.com/lifelike-and-believable/webrtc.git src
+
+      - name: Create .gclient and sync DEPS (CIPD)
+        run: |
+          cd "$GITHUB_WORKSPACE/webrtc_build"
+          cat > .gclient << 'EOF'
+          solutions = [
+            { "name": "src", "url": "https://github.com/lifelike-and-believable/webrtc.git", "deps_file": "DEPS", "managed": False, "custom_deps": {} },
+          ]
+          EOF
+          gclient sync --nohooks --with_branch_heads --with_tags -v
+
+      - name: Generate GN files (Release, static)
+        run: |
+          cd "$GITHUB_WORKSPACE/webrtc_build/src"
+          python3 tools_webrtc/mb/mb.py gen -m webrtc -c Release //out/Release --args="is_debug=false is_component_build=false rtc_include_tests=false rtc_build_examples=false rtc_build_tools=false rtc_use_h264=false treat_warnings_as_errors=false symbol_level=0 target_cpu=\"x64\" is_clang=false visual_studio_version=\"2022\""
+
+      - name: Build static libraries (target webrtc)
+        run: |
+          cd "$GITHUB_WORKSPACE/webrtc_build/src"
+          python3 tools_webrtc/mb/mb.py build -m webrtc -c Release //out/Release webrtc
+
+      - name: Collect artifacts
+        run: |
+          set -e
+          ART="$GITHUB_WORKSPACE/artifacts/windows"
+          mkdir -p "$ART/lib" "$ART/include"
+          # Copy all .lib from out/Release
+          find "$GITHUB_WORKSPACE/webrtc_build/src/out/Release" -maxdepth 2 -type f -name "*.lib" -print -exec cp {} "$ART/lib/" \;
+          # Copy a subset of public headers, then prune non-headers
+          cp -r "$GITHUB_WORKSPACE/webrtc_build/src/api" "$ART/include/"
+          cp -r "$GITHUB_WORKSPACE/webrtc_build/src/rtc_base" "$ART/include/"
+          cp -r "$GITHUB_WORKSPACE/webrtc_build/src/pc" "$ART/include/"
+          find "$ART/include" -type f ! -name "*.h" -delete
+          echo "Collected $(ls -1 "$ART/lib" | wc -l) libs"
+
+      - name: Upload Windows artifacts (self-hosted)
+        uses: actions/upload-artifact@v4
+        with:
+          name: libwebrtc-windows
+          path: artifacts/windows
 
   macos:
     name: macOS x64


### PR DESCRIPTION
This follow-up PR adds an opt-in self-hosted Windows job to the libwebrtc build workflow.\n\nWhy\n- Windows libs built on a self-hosted runner (matching our Unreal build toolchain) are often required for ABI/link compatibility.\n\nWhat changed\n- workflow_dispatch now has an input: use_self_hosted_windows (default false).\n- Hosted Windows job runs when the input is false (default).\n- Self-hosted Windows job runs when the input is true; sets DEPOT_TOOLS_WIN_TOOLCHAIN=0 to use the locally installed Visual Studio toolchain.\n- For Windows we explicitly pin MSVC via GN args: is_clang=false, visual_studio_version="2022", target_cpu="x64".\n- Fixed job layout; macOS, Linux unaffected.\n\nHow to use\n- From Actions: Run "Build native WebRTC libraries" and set "use_self_hosted_windows" to true to target a self-hosted runner with Windows + VS2022 installed.\n\nFollow-ups\n- Update composite action and plugin CI to consume libwebrtc artifacts.\n- Prepare Build.cs toggle to link libwebrtc during transition.\n\nRefs: #77