### PR TITLE
o3ds: Add WebRTC backend selection UI (libdatachannel vs LiveKit) - Issue #94

### DIFF
--- a/plugins/unreal/Open3DStream/Source/Open3DBroadcast/Public/O3DSBroadcastComponent.h
+++ b/plugins/unreal/Open3DStream/Source/Open3DBroadcast/Public/O3DSBroadcastComponent.h
@@ -136,6 +136,20 @@ public:
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Open3DStream|Broadcast|Transport", meta=(EditCondition="bAutoCreateTransport && TransportFamily == EO3DSTransportFamily::WebRTC", EditConditionHides))
     EO3DSWebRtcMode WebRtcMode = EO3DSWebRtcMode::Client;
 
+    // WebRTC backend selection (libdatachannel P2P or LiveKit SFU)
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Open3DStream|Broadcast|Transport", meta=(EditCondition="bAutoCreateTransport && TransportFamily == EO3DSTransportFamily::WebRTC", EditConditionHides))
+    EO3DSWebRtcBackend WebRtcBackend = EO3DSWebRtcBackend::LibDataChannel;
+
+    // LiveKit-specific configuration (only shown when WebRTC + LiveKit backend)
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Open3DStream|Broadcast|Transport|LiveKit", meta=(EditCondition="bAutoCreateTransport && TransportFamily == EO3DSTransportFamily::WebRTC && WebRtcBackend == EO3DSWebRtcBackend::LiveKit", EditConditionHides))
+    FString LiveKitServerUrl = TEXT("wss://livekit.example.com");
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Open3DStream|Broadcast|Transport|LiveKit", meta=(EditCondition="bAutoCreateTransport && TransportFamily == EO3DSTransportFamily::WebRTC && WebRtcBackend == EO3DSWebRtcBackend::LiveKit", EditConditionHides))
+    FString LiveKitRoom = TEXT("room1");
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Open3DStream|Broadcast|Transport|LiveKit", meta=(EditCondition="bAutoCreateTransport && TransportFamily == EO3DSTransportFamily::WebRTC && WebRtcBackend == EO3DSWebRtcBackend::LiveKit", EditConditionHides))
+    FString LiveKitToken;
+
     // Endpoint and key (new names)
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Open3DStream|Broadcast|Transport", meta=(EditCondition="bAutoCreateTransport"))
     FString Url = TEXT("tcp://127.0.0.1:9000");

--- a/plugins/unreal/Open3DStream/Source/Open3DBroadcast/Public/O3DSBroadcastTransportAdapter.h
+++ b/plugins/unreal/Open3DStream/Source/Open3DBroadcast/Public/O3DSBroadcastTransportAdapter.h
@@ -58,6 +58,14 @@ enum class EO3DSWebRtcMode : uint8
     Server UMETA(DisplayName="Server")
 };
 
+// WebRTC backend selection
+UENUM(BlueprintType)
+enum class EO3DSWebRtcBackend : uint8
+{
+    LibDataChannel UMETA(DisplayName="Peer-to-Peer (libdatachannel)"),
+    LiveKit UMETA(DisplayName="LiveKit SFU")
+};
+
 UCLASS(ClassGroup=(Open3DStream), meta=(BlueprintSpawnableComponent))
 class OPEN3DBROADCAST_API UO3DSBroadcastTransportAdapter : public UActorComponent
 {
@@ -86,6 +94,20 @@ public:
 
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Open3DStream|Broadcast|Transport", meta=(EditCondition="TransportFamily == EO3DSTransportFamily::WebRTC", EditConditionHides))
     EO3DSWebRtcMode WebRtcMode = EO3DSWebRtcMode::Client;
+
+    // WebRTC backend selection (libdatachannel P2P or LiveKit SFU)
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Open3DStream|Broadcast|Transport", meta=(EditCondition="TransportFamily == EO3DSTransportFamily::WebRTC", EditConditionHides))
+    EO3DSWebRtcBackend WebRtcBackend = EO3DSWebRtcBackend::LibDataChannel;
+
+    // LiveKit-specific configuration (only shown when WebRTC + LiveKit backend)
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Open3DStream|Broadcast|Transport|LiveKit", meta=(EditCondition="TransportFamily == EO3DSTransportFamily::WebRTC && WebRtcBackend == EO3DSWebRtcBackend::LiveKit", EditConditionHides))
+    FString LiveKitServerUrl = TEXT("wss://livekit.example.com");
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Open3DStream|Broadcast|Transport|LiveKit", meta=(EditCondition="TransportFamily == EO3DSTransportFamily::WebRTC && WebRtcBackend == EO3DSWebRtcBackend::LiveKit", EditConditionHides))
+    FString LiveKitRoom = TEXT("room1");
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Open3DStream|Broadcast|Transport|LiveKit", meta=(EditCondition="TransportFamily == EO3DSTransportFamily::WebRTC && WebRtcBackend == EO3DSWebRtcBackend::LiveKit", EditConditionHides))
+    FString LiveKitToken;
 
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Open3DStream|Broadcast|Transport")
     FString Url = TEXT("tcp://127.0.0.1:9000");

--- a/plugins/unreal/Open3DStream/Source/Open3DStream/Private/SOpen3DStreamFactory.cpp
+++ b/plugins/unreal/Open3DStream/Source/Open3DStream/Private/SOpen3DStreamFactory.cpp
@@ -1,6 +1,7 @@
 #include "SOpen3DStreamFactory.h"
 #include "Widgets/Input/SEditableTextBox.h"
 #include "Widgets/Input/SButton.h"
+#include "Widgets/Text/STextBlock.h"
 
 #include "Open3DStreamSource.h"
 #include "o3ds/o3ds_version.h"  // for version
@@ -13,6 +14,7 @@
 
 FText SOpen3DStreamFactory::LastUrl;
 int SOpen3DStreamFactory::LastComboId = 0;
+int SOpen3DStreamFactory::LastBackendComboId = 0;
 
 void SOpen3DStreamFactory::Construct(const FArguments& Args)
 {
@@ -28,12 +30,17 @@ void SOpen3DStreamFactory::Construct(const FArguments& Args)
 	Options.Add(MakeShareable(new FString("WebRTC Server")));
 	Options.Add(MakeShareable(new FString("Loopback (In-Editor Test)")));
 
+	// WebRTC backend options
+	BackendOptions.Add(MakeShareable(new FString("Peer-to-Peer (libdatachannel)")));
+	BackendOptions.Add(MakeShareable(new FString("LiveKit SFU")));
+
 	if (SOpen3DStreamFactory::LastUrl.IsEmpty())
 	{
 		LastUrl = LOCTEXT("Open3DStreamUrlValue", "tcp://meta.o3ds.net:9001");
 	}
 
 	CurrentProtocol = Options[LastComboId];
+	CurrentBackend = BackendOptions[LastBackendComboId];
 
 	mUrl = LastUrl;
 	const char* verstr = O3DS::getVersion();
@@ -80,6 +87,88 @@ void SOpen3DStreamFactory::Construct(const FArguments& Args)
 					SNew(STextBlock)
 					.Text(this, &SOpen3DStreamFactory::GetCurrentProtocol)
 				]
+			]
+		]
+		+ SVerticalBox::Slot()
+		.Padding(5)
+		.AutoHeight()
+		[
+			SAssignNew(WebRtcBackendRow, SHorizontalBox)
+			.Visibility(this, &SOpen3DStreamFactory::GetWebRtcBackendVisibility)
+			+ SHorizontalBox::Slot()
+			.FillWidth(0.3f)
+			[
+				SNew(STextBlock).Text(LOCTEXT("Open3DStreamBackend", "Backend")).MinDesiredWidth(150)
+			]
+			+ SHorizontalBox::Slot()
+			.FillWidth(0.7f)
+			[	
+				SNew(SComboBox<FComboItemType>)
+				.OptionsSource(&BackendOptions)
+				.OnSelectionChanged(this, &SOpen3DStreamFactory::OnBackendChanged)
+				.OnGenerateWidget(this, &SOpen3DStreamFactory::MakeWidgetForOption)
+				.InitiallySelectedItem(CurrentBackend)
+				[
+					SNew(STextBlock)
+					.Text(this, &SOpen3DStreamFactory::GetCurrentBackend)
+				]
+			]
+		]
+		+ SVerticalBox::Slot()
+		.Padding(5)
+		.AutoHeight()
+		[
+			SAssignNew(LiveKitServerUrlRow, SHorizontalBox)
+			.Visibility(this, &SOpen3DStreamFactory::GetLiveKitFieldsVisibility)
+			+ SHorizontalBox::Slot()
+			.FillWidth(0.3f)
+			[
+				SNew(STextBlock).Text(LOCTEXT("LiveKitServerUrl", "LiveKit Server URL")).MinDesiredWidth(150)
+			]
+			+ SHorizontalBox::Slot()
+			.FillWidth(0.7f)
+			[	
+				SNew(SEditableTextBox)
+				.Text(this, &SOpen3DStreamFactory::GetLiveKitServerUrl)
+				.OnTextChanged(this, &SOpen3DStreamFactory::SetLiveKitServerUrl)
+			]
+		]
+		+ SVerticalBox::Slot()
+		.Padding(5)
+		.AutoHeight()
+		[
+			SAssignNew(LiveKitRoomRow, SHorizontalBox)
+			.Visibility(this, &SOpen3DStreamFactory::GetLiveKitFieldsVisibility)
+			+ SHorizontalBox::Slot()
+			.FillWidth(0.3f)
+			[
+				SNew(STextBlock).Text(LOCTEXT("LiveKitRoom", "LiveKit Room")).MinDesiredWidth(150)
+			]
+			+ SHorizontalBox::Slot()
+			.FillWidth(0.7f)
+			[	
+				SNew(SEditableTextBox)
+				.Text(this, &SOpen3DStreamFactory::GetLiveKitRoom)
+				.OnTextChanged(this, &SOpen3DStreamFactory::SetLiveKitRoom)
+			]
+		]
+		+ SVerticalBox::Slot()
+		.Padding(5)
+		.AutoHeight()
+		[
+			SAssignNew(LiveKitTokenRow, SHorizontalBox)
+			.Visibility(this, &SOpen3DStreamFactory::GetLiveKitFieldsVisibility)
+			+ SHorizontalBox::Slot()
+			.FillWidth(0.3f)
+			[
+				SNew(STextBlock).Text(LOCTEXT("LiveKitToken", "LiveKit Token (JWT)")).MinDesiredWidth(150)
+			]
+			+ SHorizontalBox::Slot()
+			.FillWidth(0.7f)
+			[	
+				SNew(SEditableTextBox)
+				.Text(this, &SOpen3DStreamFactory::GetLiveKitToken)
+				.OnTextChanged(this, &SOpen3DStreamFactory::SetLiveKitToken)
 			]
 		]
 		+ SVerticalBox::Slot()
@@ -166,6 +255,21 @@ FReply SOpen3DStreamFactory::OnSource()
 	Settings->TimeOffset = 0;
 	Settings->Url = mUrl;
 	Settings->Protocol = GetCurrentProtocol();
+	
+	// Populate WebRTC backend and LiveKit configuration
+	FString CurrentBackendStr = CurrentBackend.IsValid() ? *CurrentBackend : TEXT("");
+	if (CurrentBackendStr.Contains(TEXT("LiveKit")))
+	{
+		Settings->WebRtcBackend = EO3DSWebRtcBackendReceiver::LiveKit;
+		Settings->LiveKitServerUrl = mLiveKitServerUrl.ToString();
+		Settings->LiveKitRoom = mLiveKitRoom.ToString();
+		Settings->LiveKitToken = mLiveKitToken.ToString();
+	}
+	else
+	{
+		Settings->WebRtcBackend = EO3DSWebRtcBackendReceiver::LibDataChannel;
+	}
+	
 	OnSelectedEvent.ExecuteIfBound(Settings);
 	return FReply::Handled();
 }
@@ -186,6 +290,51 @@ void SOpen3DStreamFactory::OnProtocolChanged(FComboItemType NewValue, ESelectInf
 			break;
 		}
 	}
+}
+
+void SOpen3DStreamFactory::OnBackendChanged(FComboItemType NewValue, ESelectInfo::Type)
+{
+	CurrentBackend = NewValue;
+	for (int i = 0; i < BackendOptions.Num(); i++)
+	{
+		if (BackendOptions[i] == NewValue)
+		{
+			LastBackendComboId = i;
+			break;
+		}
+	}
+}
+
+EVisibility SOpen3DStreamFactory::GetWebRtcBackendVisibility() const
+{
+	FString ProtocolStr = CurrentProtocol.IsValid() ? *CurrentProtocol : TEXT("");
+	if (ProtocolStr.Contains(TEXT("WebRTC")))
+	{
+		return EVisibility::Visible;
+	}
+	return EVisibility::Collapsed;
+}
+
+EVisibility SOpen3DStreamFactory::GetLiveKitFieldsVisibility() const
+{
+	FString ProtocolStr = CurrentProtocol.IsValid() ? *CurrentProtocol : TEXT("");
+	FString BackendStr = CurrentBackend.IsValid() ? *CurrentBackend : TEXT("");
+	
+	if (ProtocolStr.Contains(TEXT("WebRTC")) && BackendStr.Contains(TEXT("LiveKit")))
+	{
+		return EVisibility::Visible;
+	}
+	return EVisibility::Collapsed;
+}
+
+FText SOpen3DStreamFactory::GetCurrentBackend() const
+{
+	if (CurrentBackend.IsValid())
+	{
+		return FText::FromString(*CurrentBackend);
+	}
+
+	return LOCTEXT("InvalidComboEntryText", "<<Invalid option>>");
 }
 
 FText SOpen3DStreamFactory::GetCurrentProtocol() const

--- a/plugins/unreal/Open3DStream/Source/Open3DStream/Public/Open3DStreamSourceSettings.h
+++ b/plugins/unreal/Open3DStream/Source/Open3DStream/Public/Open3DStreamSourceSettings.h
@@ -6,6 +6,16 @@
 
 #include "Open3DStreamSourceSettings.generated.h"
 
+// Forward declare the enum from Open3DBroadcast module (use int when the module isn't loaded)
+// Note: We cannot include the broadcast module header here due to module dependencies,
+// so we'll use a plain enum that matches EO3DSWebRtcBackend
+UENUM(BlueprintType)
+enum class EO3DSWebRtcBackendReceiver : uint8
+{
+    LibDataChannel UMETA(DisplayName="Peer-to-Peer (libdatachannel)"),
+    LiveKit UMETA(DisplayName="LiveKit SFU")
+};
+
 
 USTRUCT(BlueprintType)
 struct FOpen3DStreamSettings
@@ -29,6 +39,20 @@ public:
 
 	UPROPERTY(EditAnywhere, Category="Open3DStream")
 	double  TimeOffset;
+
+	// WebRTC backend selection (only relevant when Protocol is "WebRTC Client" or "WebRTC Server")
+	UPROPERTY(EditAnywhere, Category="Open3DStream|WebRTC")
+	EO3DSWebRtcBackendReceiver WebRtcBackend = EO3DSWebRtcBackendReceiver::LibDataChannel;
+
+	// LiveKit-specific configuration (only used when WebRtcBackend is LiveKit)
+	UPROPERTY(EditAnywhere, Category="Open3DStream|WebRTC|LiveKit")
+	FString LiveKitServerUrl = TEXT("wss://livekit.example.com");
+
+	UPROPERTY(EditAnywhere, Category="Open3DStream|WebRTC|LiveKit")
+	FString LiveKitRoom = TEXT("room1");
+
+	UPROPERTY(EditAnywhere, Category="Open3DStream|WebRTC|LiveKit")
+	FString LiveKitToken;
 
 	// Receiver-side: enable native WebRTC audio track playback (when available)
 	UPROPERTY(EditAnywhere, Category="Open3DStream|Audio")

--- a/plugins/unreal/Open3DStream/Source/Open3DStream/Public/SOpen3DStreamFactory.h
+++ b/plugins/unreal/Open3DStream/Source/Open3DStream/Public/SOpen3DStreamFactory.h
@@ -39,6 +39,24 @@ class OPEN3DSTREAM_API SOpen3DStreamFactory : public SCompoundWidget
 	void OnProtocolChanged(FComboItemType NewValue, ESelectInfo::Type);
 	FText GetCurrentProtocol() const;
 
+	// Backend Combo
+	void OnBackendChanged(FComboItemType NewValue, ESelectInfo::Type);
+	FText GetCurrentBackend() const;
+
+	// LiveKit configuration
+	void SetLiveKitServerUrl(const FText& InText) { mLiveKitServerUrl = InText; }
+	FText GetLiveKitServerUrl() const { return mLiveKitServerUrl; }
+	
+	void SetLiveKitRoom(const FText& InText) { mLiveKitRoom = InText; }
+	FText GetLiveKitRoom() const { return mLiveKitRoom; }
+	
+	void SetLiveKitToken(const FText& InText) { mLiveKitToken = InText; }
+	FText GetLiveKitToken() const { return mLiveKitToken; }
+
+	// Visibility helpers
+	EVisibility GetWebRtcBackendVisibility() const;
+	EVisibility GetLiveKitFieldsVisibility() const;
+
 	// Ensure we can handle Enter even when focus is not in a text box
 	virtual bool SupportsKeyboardFocus() const override { return true; }
 	virtual FReply OnKeyDown(const FGeometry& MyGeometry, const FKeyEvent& InKeyEvent) override;
@@ -51,11 +69,24 @@ private:
 
 	FText mUrl;
 	FText mKey;
+	FText mLiveKitServerUrl = FText::FromString(TEXT("wss://livekit.example.com"));
+	FText mLiveKitRoom = FText::FromString(TEXT("room1"));
+	FText mLiveKitToken;
 
 	TArray<FComboItemType> Options;
 	FComboItemType CurrentProtocol;
 
+	TArray<FComboItemType> BackendOptions;
+	FComboItemType CurrentBackend;
+
+	// Slate widgets for conditional visibility
+	TSharedPtr<SHorizontalBox> WebRtcBackendRow;
+	TSharedPtr<SHorizontalBox> LiveKitServerUrlRow;
+	TSharedPtr<SHorizontalBox> LiveKitRoomRow;
+	TSharedPtr<SHorizontalBox> LiveKitTokenRow;
+
 	static FText LastUrl;
 	static int LastComboId;
+	static int LastBackendComboId;
 
 };


### PR DESCRIPTION
## Summary

This PR implements UI updates for Issue #94, adding backend selection (libdatachannel P2P vs LiveKit SFU) to both the Open3DBroadcast component and the LiveLink receiver source dialog.

## Changes Made

### 1. Backend Selection Enum
- Added `EO3DSWebRtcBackend` enum with two options:
  - `LibDataChannel` - "Peer-to-Peer (libdatachannel)"
  - `LiveKit` - "LiveKit SFU"
- Added corresponding receiver-side enum `EO3DSWebRtcBackendReceiver` to avoid module dependency issues

### 2. Broadcast Component (`UO3DSBroadcastComponent`)
- Added `WebRtcBackend` property with conditional visibility (shown only when `TransportFamily == WebRTC`)
- Added LiveKit configuration fields with conditional visibility (shown only when `WebRTC + LiveKit` selected):
  - `LiveKitServerUrl` (e.g., `wss://livekit.example.com`)
  - `LiveKitRoom` (e.g., `room1`)
  - `LiveKitToken` (JWT token)

### 3. Transport Adapter (`UO3DSBroadcastTransportAdapter`)
- Same backend selection and LiveKit config fields as broadcast component
- Maintains consistency between standalone adapter and built-in component transport

### 4. LiveLink Source Factory UI (`SOpen3DStreamFactory`)
- Added "Backend" dropdown that appears when WebRTC protocol is selected
- Added three LiveKit configuration fields that appear when LiveKit backend is selected:
  - LiveKit Server URL
  - LiveKit Room
  - LiveKit Token (JWT)
- Implemented conditional visibility using Slate's visibility attributes
- Persists backend selection across dialog reopens

### 5. Settings Structure (`FOpen3DStreamSettings`)
- Added `WebRtcBackend` field
- Added `LiveKitServerUrl`, `LiveKitRoom`, `LiveKitToken` fields
- Updated `OnSource()` to populate LiveKit config when backend is selected

## UI Flow

### Broadcast Component
1. User enables `bAutoCreateTransport`
2. User selects `TransportFamily = WebRTC`
3. **Backend dropdown appears** → User selects "LiveKit SFU" or "Peer-to-Peer (libdatachannel)"
4. If LiveKit selected, **three LiveKit config fields appear** under a "LiveKit" category

### LiveLink Receiver
1. User creates new LiveLink source → "Open3DStream Source"
2. User selects `Protocol = "WebRTC Client"` or `"WebRTC Server"`
3. **Backend dropdown appears** → User selects backend
4. If LiveKit selected, **LiveKit config fields appear**
5. User clicks "Okay" → Settings populated with backend choice and config

## Technical Details

### Conditional Visibility
- Uses Unreal's `EditCondition` meta tag for property-based visibility
- Uses Slate's `Visibility` attribute with lambda methods for dynamic UI updates
- Backend dropdown only visible when WebRTC protocol selected
- LiveKit fields only visible when both WebRTC protocol AND LiveKit backend selected

### Backward Compatibility
- New fields have sensible defaults
- Existing WebRTC configurations default to libdatachannel backend
- No breaking changes to existing serialized data

## Testing Checklist

- [ ] Broadcast component UI shows/hides backend dropdown correctly
- [ ] LiveKit fields appear/disappear based on backend selection
- [ ] LiveLink source factory shows/hides fields correctly
- [ ] Settings are correctly populated when "Okay" is clicked
- [ ] Defaults work for both backends
- [ ] Conditional visibility works in both editor and PIE

## Next Steps (Future PRs)

This PR focuses on **UI only**. Follow-up PRs will:

1. **Backend connector interface** - Create `IWebRTCConnector` interface with factory
2. **LibDataChannel connector** - Refactor existing `FWebRTCConnector` to implement interface
3. **LiveKit connector** - Implement LiveKit SFU connector
4. **Transport integration** - Wire up backend selection to connector creation
5. **Audio support** - Add subject-aware audio track management
6. **Testing** - End-to-end tests with both backends

## References

- Issue #94
- Planning docs: `plugins/unreal/Open3DStream/docs/M3.4.1a_Docs/`
  - `WEBRTC_BACKENDS.md` - Backend overview and selection
  - `WEBRTC_CONNECTOR_INTERFACE.md` - Interface design
  - `LIVEKIT_DATA_MESSAGING.md` - LiveKit data messaging

---

**Part of:** Issue #94 - Refactor WebRTC transport: backend-agnostic interface, LiveKit SFU support, subject-aware audio, and unified data messaging
