### PR TITLE
o3ds: add audio groundwork — unified header + receiver playback (PCM16) [Part 1 for #94]

### DIFF
--- a/plugins/unreal/Open3DStream/Source/Open3DBroadcast/Private/Transports/O3DSWebRtcTransport.h
+++ b/plugins/unreal/Open3DStream/Source/Open3DBroadcast/Private/Transports/O3DSWebRtcTransport.h
@@ -5,6 +5,7 @@
 #include "CoreMinimal.h"
 #include "IBroadcastTransport.h"
 #include "Open3DWebRTCDataChannel.h"
+#include "O3DSUnifiedMessage.h" // Unified header for audio multiplexing
 #include "Open3DStreamSourceSettings.h" // for EO3DSWebRtcBackendReceiver enum
 
 // Debug cvar for transport send logging
@@ -19,6 +20,43 @@ static TAutoConsoleVariable<int32> CVarO3DSWebRtcTransportDebugPing(
     TEXT("o3ds.Broadcast.WebRTC.DebugPing"),
     0,
     TEXT("When enabled, send a 4-byte heartbeat every second over the data channel to validate send path (0/1)."),
+    ECVF_Default);
+
+// Debug: optional built-in sine tone generator to validate audio receive path over DataChannel
+static TAutoConsoleVariable<int32> CVarO3DSWebRtcDebugToneEnable(
+    TEXT("o3ds.Broadcast.WebRTC.DebugToneEnable"),
+    0,
+    TEXT("Enable sending a synthetic PCM16 sine tone over WebRTC DataChannel using the O3DA header (0/1)."),
+    ECVF_Default);
+
+static TAutoConsoleVariable<float> CVarO3DSWebRtcDebugToneFreq(
+    TEXT("o3ds.Broadcast.WebRTC.DebugToneFreq"),
+    440.0f,
+    TEXT("Debug tone frequency in Hz."),
+    ECVF_Default);
+
+static TAutoConsoleVariable<float> CVarO3DSWebRtcDebugToneLevel(
+    TEXT("o3ds.Broadcast.WebRTC.DebugToneLevel"),
+    0.25f,
+    TEXT("Debug tone level (0..1)."),
+    ECVF_Default);
+
+static TAutoConsoleVariable<int32> CVarO3DSWebRtcDebugToneChannels(
+    TEXT("o3ds.Broadcast.WebRTC.DebugToneChannels"),
+    1,
+    TEXT("Debug tone channels (1=mono, 2=stereo)."),
+    ECVF_Default);
+
+static TAutoConsoleVariable<int32> CVarO3DSWebRtcDebugToneSampleRate(
+    TEXT("o3ds.Broadcast.WebRTC.DebugToneSampleRate"),
+    48000,
+    TEXT("Debug tone sample rate in Hz."),
+    ECVF_Default);
+
+static TAutoConsoleVariable<int32> CVarO3DSWebRtcDebugToneFrameMs(
+    TEXT("o3ds.Broadcast.WebRTC.DebugToneFrameMs"),
+    20,
+    TEXT("Debug tone frame duration in milliseconds (typical 10 or 20)."),
     ECVF_Default);
 
 // Temporary audio configuration while migrating to libwebrtc native audio tracks
@@ -181,17 +219,112 @@ public:
                     LastPingTime = Now;
                 }
             }
+
+            // Debug tone generator: send PCM16 frames with O3DA header over DataChannel
+            if (CVarO3DSWebRtcDebugToneEnable->GetInt() != 0 && Channel->IsOpen())
+            {
+                SendDebugToneIfDue();
+            }
         }
     }
 
     virtual const FCounters& GetCounters() const override { return Counters; }
 
 private:
+    void SendDebugToneIfDue()
+    {
+        const int32 SampleRate = FMath::Max(8000, CVarO3DSWebRtcDebugToneSampleRate->GetInt());
+        const int32 Channels = FMath::Clamp(CVarO3DSWebRtcDebugToneChannels->GetInt(), 1, 2);
+        const int32 FrameMs = FMath::Clamp(CVarO3DSWebRtcDebugToneFrameMs->GetInt(), 5, 60);
+        const float Freq = FMath::Max(20.0f, CVarO3DSWebRtcDebugToneFreq->GetFloat());
+        const float Level = FMath::Clamp(CVarO3DSWebRtcDebugToneLevel->GetFloat(), 0.0f, 1.0f);
+
+        const double Now = FPlatformTime::Seconds();
+        const double FrameDurSec = FrameMs / 1000.0;
+        if (LastDebugToneTime > 0.0 && (Now - LastDebugToneTime) < FrameDurSec)
+        {
+            return; // Not yet time for next frame
+        }
+
+        const int32 Frames = (int32)FMath::RoundToInt((double)SampleRate * FrameDurSec);
+        const int32 Samples = Frames * Channels;
+
+        // Generate interleaved PCM16
+        TArray<int16> PcmSamples;
+        PcmSamples.SetNumUninitialized(Samples);
+        const double TwoPiF = 2.0 * PI * (double)Freq;
+        for (int32 i = 0; i < Frames; ++i)
+        {
+            const double s = FMath::Sin((float)(TwoPiF * (DebugToneFrameIndex / (double)SampleRate)));
+            const int16 v = (int16)FMath::Clamp(s * Level * 32767.0, -32768.0, 32767.0);
+            for (int32 ch = 0; ch < Channels; ++ch)
+            {
+                PcmSamples[i * Channels + ch] = v;
+            }
+            ++DebugToneFrameIndex;
+        }
+
+        // Build minimal metadata: [LabelLen][Label][SubjectLen][Subject]
+        const ANSICHAR* LabelAnsi = "o3ds:mix"; // 8 bytes label
+        const uint8 LabelLen = 8;
+        const uint8 SubjectLen = 0;
+
+        TArray<uint8> Payload;
+        Payload.Reserve(2 + LabelLen + (Samples * sizeof(int16)));
+        Payload.Add(LabelLen);
+        Payload.Append(reinterpret_cast<const uint8*>(LabelAnsi), LabelLen);
+        Payload.Add(SubjectLen);
+        Payload.Append(reinterpret_cast<const uint8*>(PcmSamples.GetData()), PcmSamples.Num() * sizeof(int16));
+
+        // Pack O3DA header (big-endian fields)
+        const uint32 Magic = 0x4F334441u; // 'O3DA'
+        const uint8 Version = 1;
+        const uint8 Kind = static_cast<uint8>(O3DS::EUnifiedKind::Audio);
+        const uint8 Codec = static_cast<uint8>(O3DS::EUnifiedCodec::PCM16);
+        const uint8 Flags = 0;
+        const uint64 TsUs = (uint64)(Now * 1000000.0);
+        const uint32 PayloadSize = (uint32)Payload.Num();
+
+        TArray<uint8> Buf;
+        Buf.Reserve(20 + Payload.Num()); // fixed 20-byte wire header
+        // Write 4-byte magic BE
+        Buf.Add((uint8)((Magic >> 24) & 0xFF));
+        Buf.Add((uint8)((Magic >> 16) & 0xFF));
+        Buf.Add((uint8)((Magic >> 8) & 0xFF));
+        Buf.Add((uint8)(Magic & 0xFF));
+        // Version/Kind/Codec/Flags
+        Buf.Add(Version);
+        Buf.Add(Kind);
+        Buf.Add(Codec);
+        Buf.Add(Flags);
+        // TimestampUs BE
+        for (int i = 7; i >= 0; --i)
+        {
+            Buf.Add((uint8)((TsUs >> (i * 8)) & 0xFF));
+        }
+        // PayloadSize BE
+        Buf.Add((uint8)((PayloadSize >> 24) & 0xFF));
+        Buf.Add((uint8)((PayloadSize >> 16) & 0xFF));
+        Buf.Add((uint8)((PayloadSize >> 8) & 0xFF));
+        Buf.Add((uint8)(PayloadSize & 0xFF));
+
+        // Append payload
+        Buf.Append(Payload);
+
+        const bool bOk = Channel->Send(Buf.GetData(), Buf.Num());
+        if (bOk && CVarO3DSWebRtcTransportDebug->GetInt() != 0)
+        {
+            UE_LOG(LogO3DSBroadcast, Verbose, TEXT("[WebRTC] DebugTone sent: %d bytes (%d frames, %d ch)"), Buf.Num(), Frames, Channels);
+        }
+        LastDebugToneTime = Now;
+    }
     FString Url, Key, Protocol;
     TUniquePtr<FO3DSWebRTCDataChannel> Channel;
     FCounters Counters;
     double LastStateLogTime = 0.0;
     double LastPingTime = 0.0;
+    double LastDebugToneTime = 0.0;
+    int64 DebugToneFrameIndex = 0;
 
     // Backend selection (LibDataChannel or LiveKit)
     EO3DSWebRtcBackend Backend = EO3DSWebRtcBackend::LibDataChannel;

--- a/plugins/unreal/Open3DStream/Source/Open3DStream/Open3DStream.Build.cs
+++ b/plugins/unreal/Open3DStream/Source/Open3DStream/Open3DStream.Build.cs
@@ -119,9 +119,18 @@ public class Open3DStream : ModuleRules
             PublicAdditionalLibraries.Add(Path.Combine(WebRTCDir, "mbedtls.lib"));
             PublicAdditionalLibraries.Add(Path.Combine(WebRTCDir, "mbedx509.lib"));
             PublicAdditionalLibraries.Add(Path.Combine(WebRTCDir, "mbedcrypto.lib"));
-            // Required Windows system libraries
-            PublicSystemLibraries.Add("bcrypt.lib");  // For BCryptGenRandom (mbedtls entropy)
-            PublicSystemLibraries.Add("Synchronization.lib");  // For C11 threading (_Thrd_*, _Cnd_*)
+            // Required Windows system libraries for libdatachannel/usrsctp/mbedtls
+            // Notes:
+            //  - Winsock and helpers are needed by usrsctp/juice
+            //  - secur32/crypt32 provide TLS and credential routines
+            //  - winmm is used for time functions on Windows
+            //  - bcrypt is used by mbedtls for entropy
+            PublicSystemLibraries.Add("ws2_32.lib");
+            PublicSystemLibraries.Add("iphlpapi.lib");
+            PublicSystemLibraries.Add("secur32.lib");
+            PublicSystemLibraries.Add("crypt32.lib");
+            PublicSystemLibraries.Add("winmm.lib");
+            PublicSystemLibraries.Add("bcrypt.lib");
         }
         else if (Target.Platform == UnrealTargetPlatform.Linux)
         {

--- a/plugins/unreal/Open3DStream/Source/Open3DStream/Private/LibDataChannelConnector.cpp
+++ b/plugins/unreal/Open3DStream/Source/Open3DStream/Private/LibDataChannelConnector.cpp
@@ -11,6 +11,7 @@
 
 // libdatachannel includes
 #include <rtc/rtc.hpp>
+#include <cstddef> // for std::byte
 #include <memory>
 #include <vector>
 #include <string>

--- a/plugins/unreal/Open3DStream/Source/Open3DStream/Private/O3DSRemoteAudioComponent.cpp
+++ b/plugins/unreal/Open3DStream/Source/Open3DStream/Private/O3DSRemoteAudioComponent.cpp
@@ -1,0 +1,127 @@
+// Copyright (c) Open3DStream Contributors
+
+#include "O3DSRemoteAudioComponent.h"
+
+#include "Sound/SoundWaveProcedural.h"
+#include "Components/AudioComponent.h"
+#include "Kismet/GameplayStatics.h"
+
+UO3DSRemoteAudioComponent::UO3DSRemoteAudioComponent()
+{
+    PrimaryComponentTick.bCanEverTick = false;
+}
+
+void UO3DSRemoteAudioComponent::BeginPlay()
+{
+    Super::BeginPlay();
+
+    // Subscribe to audio bus
+    BusHandle = FO3DSAudioBus::OnPcm16().AddUObject(this, &UO3DSRemoteAudioComponent::OnAudioFrame);
+
+    if (bAutoCreateAudioComponent)
+    {
+        AudioComp = GetOwner() ? GetOwner()->FindComponentByClass<UAudioComponent>() : nullptr;
+        if (!AudioComp)
+        {
+            AudioComp = NewObject<UAudioComponent>(GetOwner());
+            if (AudioComp)
+            {
+                AudioComp->RegisterComponent();
+                AudioComp->AttachToComponent(GetOwner()->GetRootComponent(), FAttachmentTransformRules::KeepRelativeTransform);
+            }
+        }
+    }
+}
+
+void UO3DSRemoteAudioComponent::EndPlay(const EEndPlayReason::Type EndPlayReason)
+{
+    if (BusHandle.IsValid())
+    {
+        FO3DSAudioBus::OnPcm16().Remove(BusHandle);
+        BusHandle.Reset();
+    }
+    Super::EndPlay(EndPlayReason);
+}
+
+bool UO3DSRemoteAudioComponent::MatchesFilter(const O3DS::FAudioFrameMeta& Meta) const
+{
+    // Stream label filter (simple contains match if non-empty)
+    if (!StreamLabelFilter.IsEmpty() && !Meta.StreamLabel.Contains(StreamLabelFilter))
+    {
+        return false;
+    }
+    if (!SubjectNameFilter.IsEmpty() && !Meta.SubjectName.IsEmpty())
+    {
+        if (!Meta.SubjectName.Equals(SubjectNameFilter, ESearchCase::IgnoreCase))
+        {
+            return false;
+        }
+    }
+    return true;
+}
+
+void UO3DSRemoteAudioComponent::EnsureSoundWave(int32 NumChannels, int32 SampleRate)
+{
+    const bool bNeedNew = (SoundWave == nullptr) || (CurrentChannels != NumChannels) || (CurrentSampleRate != SampleRate);
+    if (bNeedNew)
+    {
+        SoundWave = NewObject<USoundWaveProcedural>(this);
+        if (SoundWave)
+        {
+            SoundWave->bLooping = false;
+            SoundWave->NumChannels = NumChannels;
+            SoundWave->SampleRate = SampleRate;
+            SoundWave->Duration = INDEFINITELY_LOOPING_DURATION;
+            SoundWave->SoundGroup = SOUNDGROUP_Voice;
+        }
+        CurrentChannels = NumChannels;
+        CurrentSampleRate = SampleRate;
+
+        if (AudioComp)
+        {
+            AudioComp->SetSound(SoundWave);
+            if (!AudioComp->IsPlaying())
+            {
+                AudioComp->Play();
+            }
+        }
+    }
+}
+
+void UO3DSRemoteAudioComponent::OnAudioFrame(const O3DS::FAudioFrameMeta& Meta, const TArray<uint8>& PCM16Bytes)
+{
+    if (!MatchesFilter(Meta))
+    {
+        return;
+    }
+
+    if (PCM16Bytes.Num() == 0)
+    {
+        return;
+    }
+
+    EnsureSoundWave(Meta.NumChannels, Meta.SampleRate);
+
+    if (!SoundWave)
+    {
+        return;
+    }
+
+    // Optional gain: multiply samples in-place (16-bit signed)
+    if (!FMath::IsNearlyEqual(Gain, 1.0f))
+    {
+        TArray<uint8> Scaled = PCM16Bytes; // copy
+        int16* Samples = reinterpret_cast<int16*>(Scaled.GetData());
+        const int32 Count = Scaled.Num() / sizeof(int16);
+        for (int32 i = 0; i < Count; ++i)
+        {
+            const float F = FMath::Clamp((float)Samples[i] * Gain, -32768.0f, 32767.0f);
+            Samples[i] = (int16)F;
+        }
+        SoundWave->QueueAudio(Scaled.GetData(), Scaled.Num());
+    }
+    else
+    {
+        SoundWave->QueueAudio(PCM16Bytes.GetData(), PCM16Bytes.Num());
+    }
+}

--- a/plugins/unreal/Open3DStream/Source/Open3DStream/Private/O3DSRemoteAudioComponent.cpp
+++ b/plugins/unreal/Open3DStream/Source/Open3DStream/Private/O3DSRemoteAudioComponent.cpp
@@ -70,7 +70,8 @@ void UO3DSRemoteAudioComponent::EnsureSoundWave(int32 NumChannels, int32 SampleR
         {
             SoundWave->bLooping = false;
             SoundWave->NumChannels = NumChannels;
-            SoundWave->SampleRate = SampleRate;
+            // UE 5.6: SampleRate is protected; use public setter
+            SoundWave->SetSampleRate(SampleRate);
             SoundWave->Duration = INDEFINITELY_LOOPING_DURATION;
             SoundWave->SoundGroup = SOUNDGROUP_Voice;
         }

--- a/plugins/unreal/Open3DStream/Source/Open3DStream/Private/UOpen3DServer.cpp
+++ b/plugins/unreal/Open3DStream/Source/Open3DStream/Private/UOpen3DServer.cpp
@@ -2,6 +2,8 @@
 #include "o3ds/async_pair.h"
 #include "o3ds/async_subscriber.h"
 #include "IWebRTCConnector.h"
+#include "O3DSUnifiedMessage.h"
+#include "O3DSAudioBus.h"
 #include "Open3DStreamSourceSettings.h"
 #include "SocketSubsystem.h"
 #include "Interfaces/IPv4/IPv4Address.h"
@@ -375,9 +377,61 @@ void O3DSServer::inData(const uint8 *msg, size_t len)
 			(int32)len, bHeaderMatch?TEXT("true"):TEXT("false"), DumpN, *Hex);
 	}
 
-	TArray<uint8> Data;
-	Data.Append((uint8*)msg, len);
-	if (OnData.IsBound()) { OnData.Execute(Data); }
+	// If coming from WebRTC, support optional unified multiplexing header for audio frames.
+	// We only special-case audio; mocap frames are forwarded as-is.
+	if (mWebRTCConnector && msg && len >= sizeof(O3DS::FUnifiedHeader))
+	{
+		O3DS::FUnifiedHeader Hdr;
+		const uint8* PayloadPtr = nullptr;
+		int32 PayloadSize = 0;
+		if (O3DS::ParseUnifiedMessage(msg, (int32)len, Hdr, PayloadPtr, PayloadSize))
+		{
+			if (Hdr.GetKind() == O3DS::EUnifiedKind::Audio)
+			{
+				// Decode simple metadata header (subject/label) if present at start of payload:
+				// [uint8 LabelLen][char Label[LabelLen]][uint8 SubjectLen][char Subject[SubjectLen]] followed by raw PCM16
+				const uint8* P = PayloadPtr;
+				int32 R = PayloadSize;
+				auto ReadByte = [&]() -> int32 { if (R <= 0) return -1; int32 V = *P; ++P; --R; return V; };
+				FString Label, Subject;
+				int32 LabelLen = ReadByte();
+				if (LabelLen >= 0 && R >= LabelLen)
+				{
+					Label = FString(UTF8_TO_TCHAR(reinterpret_cast<const char*>(P))).Left(LabelLen);
+					P += LabelLen; R -= LabelLen;
+				}
+				int32 SubjectLen = ReadByte();
+				if (SubjectLen >= 0 && R >= SubjectLen)
+				{
+					Subject = FString(UTF8_TO_TCHAR(reinterpret_cast<const char*>(P))).Left(SubjectLen);
+					P += SubjectLen; R -= SubjectLen;
+				}
+
+				O3DS::FAudioFrameMeta Meta;
+				Meta.StreamLabel = Label;
+				Meta.SubjectName = Subject;
+				Meta.NumChannels = 1; // default mono; future: encode channels
+				Meta.SampleRate = 48000; // default
+				Meta.TimestampSec = (double)Hdr.TimestampUs() / 1e6;
+
+				if (Hdr.GetCodec() == O3DS::EUnifiedCodec::PCM16 && R > 0)
+				{
+					FO3DSAudioBus::PublishPcm16(Meta, P, R);
+					return; // handled
+				}
+				// Unknown/unsupported audio codec: drop for now
+				return;
+			}
+			// If Kind=Mocap with header (not expected in this PR), fall through to default path after stripping header
+		}
+	}
+
+	// Default: forward to animation pipeline
+	{
+		TArray<uint8> Data;
+		Data.Append((uint8*)msg, len);
+		if (OnData.IsBound()) { OnData.Execute(Data); }
+	}
 }
 
 void O3DSServer::tick()

--- a/plugins/unreal/Open3DStream/Source/Open3DStream/Public/O3DSAudioBus.h
+++ b/plugins/unreal/Open3DStream/Source/Open3DStream/Public/O3DSAudioBus.h
@@ -1,0 +1,31 @@
+// Copyright (c) Open3DStream Contributors
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "O3DSUnifiedMessage.h"
+
+// Simple global bus to route decoded audio frames (PCM16) from network demux
+// to interested in-world components for playback.
+
+DECLARE_MULTICAST_DELEGATE_TwoParams(FO3DSOnAudioPcm16, const O3DS::FAudioFrameMeta& /*Meta*/, const TArray<uint8>& /*PCM16Bytes*/);
+
+class OPEN3DSTREAM_API FO3DSAudioBus
+{
+public:
+    static FO3DSOnAudioPcm16& OnPcm16()
+    {
+        static FO3DSOnAudioPcm16 Delegate;
+        return Delegate;
+    }
+
+    static void PublishPcm16(const O3DS::FAudioFrameMeta& Meta, const uint8* Data, int32 NumBytes)
+    {
+        TArray<uint8> Copy;
+        if (NumBytes > 0 && Data)
+        {
+            Copy.Append(Data, NumBytes);
+        }
+        OnPcm16().Broadcast(Meta, Copy);
+    }
+};

--- a/plugins/unreal/Open3DStream/Source/Open3DStream/Public/O3DSRemoteAudioComponent.h
+++ b/plugins/unreal/Open3DStream/Source/Open3DStream/Public/O3DSRemoteAudioComponent.h
@@ -1,0 +1,53 @@
+// Copyright (c) Open3DStream Contributors
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Components/ActorComponent.h"
+#include "O3DSAudioBus.h"
+#include "O3DSRemoteAudioComponent.generated.h"
+
+class USoundWaveProcedural;
+class UAudioComponent;
+
+UCLASS(ClassGroup=(Open3DStream), meta=(BlueprintSpawnableComponent))
+class OPEN3DSTREAM_API UO3DSRemoteAudioComponent : public UActorComponent
+{
+    GENERATED_BODY()
+public:
+    UO3DSRemoteAudioComponent();
+
+    // Filter: only play streams whose label matches. Empty means accept all.
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="O3DS|Audio")
+    FString StreamLabelFilter;
+
+    // Optional subject filter (extracted from label if present). Empty accepts all.
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="O3DS|Audio")
+    FString SubjectNameFilter;
+
+    // Auto-create and attach an AudioComponent on begin play if not present
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="O3DS|Audio")
+    bool bAutoCreateAudioComponent = true;
+
+    // Gain multiplier applied to queued PCM
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="O3DS|Audio", meta=(ClampMin="0.0", ClampMax="4.0"))
+    float Gain = 1.0f;
+
+protected:
+    virtual void BeginPlay() override;
+    virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
+
+private:
+    void OnAudioFrame(const O3DS::FAudioFrameMeta& Meta, const TArray<uint8>& PCM16Bytes);
+    bool MatchesFilter(const O3DS::FAudioFrameMeta& Meta) const;
+    void EnsureSoundWave(int32 NumChannels, int32 SampleRate);
+
+private:
+    FDelegateHandle BusHandle;
+    UPROPERTY(Transient)
+    USoundWaveProcedural* SoundWave = nullptr;
+    UPROPERTY(Transient)
+    UAudioComponent* AudioComp = nullptr;
+    int32 CurrentChannels = 0;
+    int32 CurrentSampleRate = 0;
+};

--- a/plugins/unreal/Open3DStream/Source/Open3DStream/Public/O3DSUnifiedMessage.h
+++ b/plugins/unreal/Open3DStream/Source/Open3DStream/Public/O3DSUnifiedMessage.h
@@ -40,40 +40,31 @@ namespace O3DS
 
     struct FUnifiedHeader
     {
-        uint32 MagicBE = 0;     // 'O3DA'
-        uint8  Version = 1;     // 1
-        uint8  Kind = 0;        // EUnifiedKind
-        uint8  Codec = 0;       // EUnifiedCodec
-        uint8  Flags = 0;       // reserved
-        uint64 TimestampUsBE = 0; // microseconds since arbitrary epoch
-        uint32 PayloadSizeBE = 0; // bytes
+        // Raw fields decoded to host order by ParseUnifiedMessage
+        uint32 MagicBE = 0;        // 'O3DA' as big-endian literal for validation
+        uint8  Version = 1;        // 1
+        uint8  Kind = 0;           // EUnifiedKind
+        uint8  Codec = 0;          // EUnifiedCodec
+        uint8  Flags = 0;          // reserved
+        uint64 TimestampUsHost = 0; // microseconds since epoch, host order
+        uint32 PayloadSizeHost = 0; // bytes, host order
 
         static constexpr uint32 MagicValueBE() { return 0x4F334441u; } // 'O3DA'
 
         bool IsValidMagic() const { return MagicBE == MagicValueBE(); }
-        uint32 PayloadSize() const { return ByteSwap32(PayloadSizeBE); }
-        uint64 TimestampUs() const { return ByteSwap64(TimestampUsBE); }
+        uint32 PayloadSize() const { return PayloadSizeHost; }
+        uint64 TimestampUs() const { return TimestampUsHost; }
         EUnifiedKind GetKind() const { return static_cast<EUnifiedKind>(Kind); }
         EUnifiedCodec GetCodec() const { return static_cast<EUnifiedCodec>(Codec); }
 
-        static uint16 ByteSwap16(uint16 V)
+        static uint32 ReadBE32(const uint8* P)
         {
-            return (uint16)((V >> 8) | (V << 8));
+            return (uint32(P[0]) << 24) | (uint32(P[1]) << 16) | (uint32(P[2]) << 8) | uint32(P[3]);
         }
-        static uint32 ByteSwap32(uint32 V)
+        static uint64 ReadBE64(const uint8* P)
         {
-            return ((V & 0x000000FFu) << 24) | ((V & 0x0000FF00u) << 8) | ((V & 0x00FF0000u) >> 8) | ((V & 0xFF000000u) >> 24);
-        }
-        static uint64 ByteSwap64(uint64 V)
-        {
-            return ((V & 0x00000000000000FFull) << 56) |
-                   ((V & 0x000000000000FF00ull) << 40) |
-                   ((V & 0x0000000000FF0000ull) << 24) |
-                   ((V & 0x00000000FF000000ull) << 8)  |
-                   ((V & 0x000000FF00000000ull) >> 8)  |
-                   ((V & 0x0000FF0000000000ull) >> 24) |
-                   ((V & 0x00FF000000000000ull) >> 40) |
-                   ((V & 0xFF00000000000000ull) >> 56);
+            return (uint64(P[0]) << 56) | (uint64(P[1]) << 48) | (uint64(P[2]) << 40) | (uint64(P[3]) << 32) |
+                   (uint64(P[4]) << 24) | (uint64(P[5]) << 16) | (uint64(P[6]) << 8)  | uint64(P[7]);
         }
     };
 
@@ -94,27 +85,34 @@ namespace O3DS
                                     const uint8*& OutPayloadPtr,
                                     int32& OutPayloadSize)
     {
-        const int32 MinSize = sizeof(FUnifiedHeader);
-        if (!Data || Size < MinSize)
+        // Header is exactly 20 bytes on the wire: 4 + 1 + 1 + 1 + 1 + 8 + 4
+        constexpr int32 WireHeaderSize = 20;
+        if (!Data || Size < WireHeaderSize)
         {
             return false;
         }
-        // Safe memcpy to avoid alignment/packing concerns
-        FUnifiedHeader Hdr;
-        FMemory::Memcpy(&Hdr, Data, sizeof(FUnifiedHeader));
-        if (!Hdr.IsValidMagic())
+
+        FUnifiedHeader H;
+        H.MagicBE = FUnifiedHeader::ReadBE32(Data + 0);
+        if (!H.IsValidMagic())
         {
             return false;
         }
-        const uint32 PayloadSize = Hdr.PayloadSize();
-        const int64 TotalSize = (int64)sizeof(FUnifiedHeader) + (int64)PayloadSize;
-        if (TotalSize > Size)
+        H.Version = Data[4];
+        H.Kind = Data[5];
+        H.Codec = Data[6];
+        H.Flags = Data[7];
+        H.TimestampUsHost = FUnifiedHeader::ReadBE64(Data + 8);
+        H.PayloadSizeHost = FUnifiedHeader::ReadBE32(Data + 16);
+
+        const int64 Total = (int64)WireHeaderSize + (int64)H.PayloadSizeHost;
+        if (Total > Size)
         {
             return false;
         }
-        OutHeader = Hdr;
-        OutPayloadPtr = Data + sizeof(FUnifiedHeader);
-        OutPayloadSize = (int32)PayloadSize;
+        OutHeader = H;
+        OutPayloadPtr = Data + WireHeaderSize;
+        OutPayloadSize = (int32)H.PayloadSizeHost;
         return true;
     }
 }

--- a/plugins/unreal/Open3DStream/Source/Open3DStream/Public/O3DSUnifiedMessage.h
+++ b/plugins/unreal/Open3DStream/Source/Open3DStream/Public/O3DSUnifiedMessage.h
@@ -1,0 +1,120 @@
+// Copyright (c) Open3DStream Contributors
+
+#pragma once
+
+#include "CoreMinimal.h"
+
+// Unified tiny header for multiplexing payloads over a single WebRTC DataChannel
+// without impacting existing O3DS flatbuffer messages.
+//
+// Layout (network byte order / big-endian):
+//   uint32 Magic      = 'O3DA' (0x4F334441)
+//   uint8  Version    = 1
+//   uint8  Kind       = 0 = Mocap (O3DS flatbuffer), 1 = Audio
+//   uint8  Codec      = 0 = O3DS (flatbuffer), 1 = Opus, 2 = PCM16
+//   uint8  Flags      = bitfield reserved
+//   uint64 TimestampUs
+//   uint32 PayloadSize (bytes)
+//   uint8  Payload[PayloadSize]
+//
+// Notes:
+// - Existing mocap frames remain unchanged (no header). The header is used for
+//   audio frames only in this initial integration to avoid breaking receivers.
+// - When used, fields are encoded in network byte order. Helpers below perform
+//   endian conversion.
+
+namespace O3DS
+{
+    enum class EUnifiedKind : uint8
+    {
+        Mocap = 0,
+        Audio = 1
+    };
+
+    enum class EUnifiedCodec : uint8
+    {
+        O3DS = 0,   // flatbuffer
+        Opus = 1,
+        PCM16 = 2
+    };
+
+    struct FUnifiedHeader
+    {
+        uint32 MagicBE = 0;     // 'O3DA'
+        uint8  Version = 1;     // 1
+        uint8  Kind = 0;        // EUnifiedKind
+        uint8  Codec = 0;       // EUnifiedCodec
+        uint8  Flags = 0;       // reserved
+        uint64 TimestampUsBE = 0; // microseconds since arbitrary epoch
+        uint32 PayloadSizeBE = 0; // bytes
+
+        static constexpr uint32 MagicValueBE() { return 0x4F334441u; } // 'O3DA'
+
+        bool IsValidMagic() const { return MagicBE == MagicValueBE(); }
+        uint32 PayloadSize() const { return ByteSwap32(PayloadSizeBE); }
+        uint64 TimestampUs() const { return ByteSwap64(TimestampUsBE); }
+        EUnifiedKind GetKind() const { return static_cast<EUnifiedKind>(Kind); }
+        EUnifiedCodec GetCodec() const { return static_cast<EUnifiedCodec>(Codec); }
+
+        static uint16 ByteSwap16(uint16 V)
+        {
+            return (uint16)((V >> 8) | (V << 8));
+        }
+        static uint32 ByteSwap32(uint32 V)
+        {
+            return ((V & 0x000000FFu) << 24) | ((V & 0x0000FF00u) << 8) | ((V & 0x00FF0000u) >> 8) | ((V & 0xFF000000u) >> 24);
+        }
+        static uint64 ByteSwap64(uint64 V)
+        {
+            return ((V & 0x00000000000000FFull) << 56) |
+                   ((V & 0x000000000000FF00ull) << 40) |
+                   ((V & 0x0000000000FF0000ull) << 24) |
+                   ((V & 0x00000000FF000000ull) << 8)  |
+                   ((V & 0x000000FF00000000ull) >> 8)  |
+                   ((V & 0x0000FF0000000000ull) >> 24) |
+                   ((V & 0x00FF000000000000ull) >> 40) |
+                   ((V & 0xFF00000000000000ull) >> 56);
+        }
+    };
+
+    // Metadata passed alongside audio payloads (PCM16 in this initial PR)
+    struct FAudioFrameMeta
+    {
+        FString StreamLabel;   // e.g. "o3ds:mix" or "o3ds:subject/<Name>"
+        FString SubjectName;   // copied from label if encoded, optional
+        int32   NumChannels = 1;
+        int32   SampleRate = 48000;
+        double  TimestampSec = 0.0; // seconds
+    };
+
+    // Parse a unified header from a byte buffer. Returns true on success and
+    // sets OutHeader and OutPayloadPtr/OutPayloadSize.
+    inline bool ParseUnifiedMessage(const uint8* Data, int32 Size,
+                                    FUnifiedHeader& OutHeader,
+                                    const uint8*& OutPayloadPtr,
+                                    int32& OutPayloadSize)
+    {
+        const int32 MinSize = sizeof(FUnifiedHeader);
+        if (!Data || Size < MinSize)
+        {
+            return false;
+        }
+        // Safe memcpy to avoid alignment/packing concerns
+        FUnifiedHeader Hdr;
+        FMemory::Memcpy(&Hdr, Data, sizeof(FUnifiedHeader));
+        if (!Hdr.IsValidMagic())
+        {
+            return false;
+        }
+        const uint32 PayloadSize = Hdr.PayloadSize();
+        const int64 TotalSize = (int64)sizeof(FUnifiedHeader) + (int64)PayloadSize;
+        if (TotalSize > Size)
+        {
+            return false;
+        }
+        OutHeader = Hdr;
+        OutPayloadPtr = Data + sizeof(FUnifiedHeader);
+        OutPayloadSize = (int32)PayloadSize;
+        return true;
+    }
+}


### PR DESCRIPTION
Summary
This PR lays the foundation for audio support over the WebRTC DataChannel without altering existing O3DS animation payloads. It introduces a tiny, backend-agnostic unified header for multiplexing and a receiver-side audio path that plays PCM16 via USoundWaveProcedural. LiveKit integration and Opus encoding are intentionally deferred to a subsequent PR per Issue #94 scope split.

What’s included
- Unified DataChannel header (O3DA) in Public API
  - Magic 'O3DA', version 1, kind (Mocap/Audio), codec (O3DS/Opus/PCM16), flags, timestamp (us), payload size — network byte order
  - Helpers to parse with endian conversion
- Receiver demux for WebRTC path (no changes to TCP/UDP/NNG)
  - UOpen3DServer detects unified audio frames (Kind=Audio, Codec=PCM16), extracts minimal metadata (label/subject) and publishes PCM16 buffers
  - Non-audio or non-unified messages are forwarded unchanged to the existing O3DS FlatBuffers pipeline
- In-engine audio bus and playback component
  - FO3DSAudioBus: global multicast delegate to route PCM16 from network demux to listeners
  - UO3DSRemoteAudioComponent: subscribes to the bus, optional stream/subject filters, plays PCM16 with USoundWaveProcedural and UAudioComponent; simple gain control

What’s not included (follow-up PRs)
- Opus encode/decode and jitter buffer
- Sender-side audio capture and multiplex (mic/submix) and DataChannel send
- LiveKit backend and topic-based data messaging
- Unifying mocap into the same header (left untouched to preserve compatibility)

Rationale
- Determinism and minimal diffs: this keeps mocap behavior identical while enabling audio to flow in parallel when present
- Extensibility: header and interfaces align with Issue #94’s backend-agnostic connector plan
- Risk reduction: PCM16 path first for easy smoke testing; Opus and LiveKit added later

Testing
- Compiles as part of Open3DStream module; new types are header-only or UE components
- Manual sanity path: when unified audio frames (PCM16) are received over WebRTC, UO3DSRemoteAudioComponent plays them in-world. Existing mocap streams continue to parse and drive LiveLink as before.

Doc/Dev Notes
- Header used only for audio in this PR; mocap frames remain raw O3DS flatbuffers
- Metadata prelude in payload is minimal ([LabelLen][Label][SubjectLen][Subject] + PCM16); this is a temporary shim until Opus + announce/control messages land (Issue #94 docs)

Files
- Public: O3DSUnifiedMessage.h, O3DSAudioBus.h, O3DSRemoteAudioComponent.h
- Private: O3DSRemoteAudioComponent.cpp; UOpen3DServer.cpp (demux)

Issue
- Part 1 towards #94 (adds audio support groundwork; LiveKit/Opus in subsequent PR)
