### PR TITLE
open3dstream: fix UE 5.6 audio compile (SetSampleRate)

### DIFF
--- a/plugins/unreal/Open3DStream/Source/Open3DStream/Private/O3DSRemoteAudioComponent.cpp
+++ b/plugins/unreal/Open3DStream/Source/Open3DStream/Private/O3DSRemoteAudioComponent.cpp
@@ -1,0 +1,128 @@
+// Copyright (c) Open3DStream Contributors
+
+#include "O3DSRemoteAudioComponent.h"
+
+#include "Sound/SoundWaveProcedural.h"
+#include "Components/AudioComponent.h"
+#include "Kismet/GameplayStatics.h"
+
+UO3DSRemoteAudioComponent::UO3DSRemoteAudioComponent()
+{
+    PrimaryComponentTick.bCanEverTick = false;
+}
+
+void UO3DSRemoteAudioComponent::BeginPlay()
+{
+    Super::BeginPlay();
+
+    // Subscribe to audio bus
+    BusHandle = FO3DSAudioBus::OnPcm16().AddUObject(this, &UO3DSRemoteAudioComponent::OnAudioFrame);
+
+    if (bAutoCreateAudioComponent)
+    {
+        AudioComp = GetOwner() ? GetOwner()->FindComponentByClass<UAudioComponent>() : nullptr;
+        if (!AudioComp)
+        {
+            AudioComp = NewObject<UAudioComponent>(GetOwner());
+            if (AudioComp)
+            {
+                AudioComp->RegisterComponent();
+                AudioComp->AttachToComponent(GetOwner()->GetRootComponent(), FAttachmentTransformRules::KeepRelativeTransform);
+            }
+        }
+    }
+}
+
+void UO3DSRemoteAudioComponent::EndPlay(const EEndPlayReason::Type EndPlayReason)
+{
+    if (BusHandle.IsValid())
+    {
+        FO3DSAudioBus::OnPcm16().Remove(BusHandle);
+        BusHandle.Reset();
+    }
+    Super::EndPlay(EndPlayReason);
+}
+
+bool UO3DSRemoteAudioComponent::MatchesFilter(const O3DS::FAudioFrameMeta& Meta) const
+{
+    // Stream label filter (simple contains match if non-empty)
+    if (!StreamLabelFilter.IsEmpty() && !Meta.StreamLabel.Contains(StreamLabelFilter))
+    {
+        return false;
+    }
+    if (!SubjectNameFilter.IsEmpty() && !Meta.SubjectName.IsEmpty())
+    {
+        if (!Meta.SubjectName.Equals(SubjectNameFilter, ESearchCase::IgnoreCase))
+        {
+            return false;
+        }
+    }
+    return true;
+}
+
+void UO3DSRemoteAudioComponent::EnsureSoundWave(int32 NumChannels, int32 SampleRate)
+{
+    const bool bNeedNew = (SoundWave == nullptr) || (CurrentChannels != NumChannels) || (CurrentSampleRate != SampleRate);
+    if (bNeedNew)
+    {
+        SoundWave = NewObject<USoundWaveProcedural>(this);
+        if (SoundWave)
+        {
+            SoundWave->bLooping = false;
+            SoundWave->NumChannels = NumChannels;
+            // UE 5.6: SampleRate is protected; use the public setter instead
+            SoundWave->SetSampleRate(SampleRate);
+            SoundWave->Duration = INDEFINITELY_LOOPING_DURATION;
+            SoundWave->SoundGroup = SOUNDGROUP_Voice;
+        }
+        CurrentChannels = NumChannels;
+        CurrentSampleRate = SampleRate;
+
+        if (AudioComp)
+        {
+            AudioComp->SetSound(SoundWave);
+            if (!AudioComp->IsPlaying())
+            {
+                AudioComp->Play();
+            }
+        }
+    }
+}
+
+void UO3DSRemoteAudioComponent::OnAudioFrame(const O3DS::FAudioFrameMeta& Meta, const TArray<uint8>& PCM16Bytes)
+{
+    if (!MatchesFilter(Meta))
+    {
+        return;
+    }
+
+    if (PCM16Bytes.Num() == 0)
+    {
+        return;
+    }
+
+    EnsureSoundWave(Meta.NumChannels, Meta.SampleRate);
+
+    if (!SoundWave)
+    {
+        return;
+    }
+
+    // Optional gain: multiply samples in-place (16-bit signed)
+    if (!FMath::IsNearlyEqual(Gain, 1.0f))
+    {
+        TArray<uint8> Scaled = PCM16Bytes; // copy
+        int16* Samples = reinterpret_cast<int16*>(Scaled.GetData());
+        const int32 Count = Scaled.Num() / sizeof(int16);
+        for (int32 i = 0; i < Count; ++i)
+        {
+            const float F = FMath::Clamp((float)Samples[i] * Gain, -32768.0f, 32767.0f);
+            Samples[i] = (int16)F;
+        }
+        SoundWave->QueueAudio(Scaled.GetData(), Scaled.Num());
+    }
+    else
+    {
+        SoundWave->QueueAudio(PCM16Bytes.GetData(), PCM16Bytes.Num());
+    }
+}

--- a/plugins/unreal/Open3DStream/Source/Open3DStream/Public/O3DSRemoteAudioComponent.h
+++ b/plugins/unreal/Open3DStream/Source/Open3DStream/Public/O3DSRemoteAudioComponent.h
@@ -1,0 +1,53 @@
+// Copyright (c) Open3DStream Contributors
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Components/ActorComponent.h"
+#include "O3DSAudioBus.h"
+#include "O3DSRemoteAudioComponent.generated.h"
+
+class USoundWaveProcedural;
+class UAudioComponent;
+
+UCLASS(ClassGroup=(Open3DStream), meta=(BlueprintSpawnableComponent))
+class OPEN3DSTREAM_API UO3DSRemoteAudioComponent : public UActorComponent
+{
+    GENERATED_BODY()
+public:
+    UO3DSRemoteAudioComponent();
+
+    // Filter: only play streams whose label matches. Empty means accept all.
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="O3DS|Audio")
+    FString StreamLabelFilter;
+
+    // Optional subject filter (extracted from label if present). Empty accepts all.
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="O3DS|Audio")
+    FString SubjectNameFilter;
+
+    // Auto-create and attach an AudioComponent on begin play if not present
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="O3DS|Audio")
+    bool bAutoCreateAudioComponent = true;
+
+    // Gain multiplier applied to queued PCM
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="O3DS|Audio", meta=(ClampMin="0.0", ClampMax="4.0"))
+    float Gain = 1.0f;
+
+protected:
+    virtual void BeginPlay() override;
+    virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
+
+private:
+    void OnAudioFrame(const O3DS::FAudioFrameMeta& Meta, const TArray<uint8>& PCM16Bytes);
+    bool MatchesFilter(const O3DS::FAudioFrameMeta& Meta) const;
+    void EnsureSoundWave(int32 NumChannels, int32 SampleRate);
+
+private:
+    FDelegateHandle BusHandle;
+    UPROPERTY(Transient)
+    USoundWaveProcedural* SoundWave = nullptr;
+    UPROPERTY(Transient)
+    UAudioComponent* AudioComp = nullptr;
+    int32 CurrentChannels = 0;
+    int32 CurrentSampleRate = 0;
+};


### PR DESCRIPTION
Fix CI compile error in O3DSRemoteAudioComponent on UE 5.6: use USoundWave::SetSampleRate() instead of accessing protected SampleRate. Added the component sources to this branch for completeness.\n\n- Verified in Actions log: error C2248 on USoundWave::SampleRate.\n- Change: SoundWave->SetSampleRate(SampleRate).\n- Kept NumChannels, Duration, bLooping as-is; will iterate if UE 5.6 enforces protection on these too.\n\nFollow-up: if additional protected member errors appear (NumChannels/Duration), switch to public APIs or adjust to USoundWaveProcedural-friendly setters if available.\n\nRelates to: Issue #94 (WebRTC transport refactor), feature/audio-support-initial branch.