### PR TITLE
webrtc: Opus audio encode/decode over DataChannel (unified header)

### DIFF
--- a/plugins/unreal/Open3DStream/Source/Open3DBroadcast/Private/Transports/O3DSWebRtcTransport.h
+++ b/plugins/unreal/Open3DStream/Source/Open3DBroadcast/Private/Transports/O3DSWebRtcTransport.h
@@ -6,6 +6,7 @@
 #include "IBroadcastTransport.h"
 #include "Open3DWebRTCDataChannel.h"
 #include "O3DSUnifiedMessage.h" // Unified header for audio multiplexing
+#include "O3DSOpusCodec.h"      // Opus encode (optional)
 #include "Open3DStreamSourceSettings.h" // for EO3DSWebRtcBackendReceiver enum
 
 // Debug cvar for transport send logging
@@ -57,6 +58,13 @@ static TAutoConsoleVariable<int32> CVarO3DSWebRtcDebugToneFrameMs(
     TEXT("o3ds.Broadcast.WebRTC.DebugToneFrameMs"),
     20,
     TEXT("Debug tone frame duration in milliseconds (typical 10 or 20)."),
+    ECVF_Default);
+
+// 0=PCM16, 1=Opus
+static TAutoConsoleVariable<int32> CVarO3DSWebRtcDebugToneCodec(
+    TEXT("o3ds.Broadcast.WebRTC.DebugToneCodec"),
+    0,
+    TEXT("Debug tone codec (0=PCM16, 1=Opus). Requires O3DS_WITH_OPUS for Opus."),
     ECVF_Default);
 
 // Temporary audio configuration while migrating to libwebrtc native audio tracks
@@ -274,13 +282,57 @@ private:
         Payload.Add(LabelLen);
         Payload.Append(reinterpret_cast<const uint8*>(LabelAnsi), LabelLen);
         Payload.Add(SubjectLen);
-        Payload.Append(reinterpret_cast<const uint8*>(PcmSamples.GetData()), PcmSamples.Num() * sizeof(int16));
+
+        // Choose codec
+        const bool bUseOpus = (CVarO3DSWebRtcDebugToneCodec->GetInt() == 1);
+        uint8 CodecField = static_cast<uint8>(O3DS::EUnifiedCodec::PCM16);
+        if (bUseOpus && O3DS_WITH_OPUS)
+        {
+            // Lazy-init encoder
+            if (!OpusEnc)
+            {
+                OpusEnc = MakeUnique<O3DS::FOpusEncoder>();
+                if (!OpusEnc->Init(SampleRate, Channels, /*BitrateKbps*/ 32, /*DTX*/ true))
+                {
+                    OpusEnc.Reset();
+                }
+            }
+            if (OpusEnc)
+            {
+                // Convert PCM16 to float [-1,1]
+                TArray<float> FloatBuf; FloatBuf.SetNumUninitialized(Samples);
+                for (int32 i = 0; i < Samples; ++i)
+                {
+                    FloatBuf[i] = (float)PcmSamples[i] / 32768.0f;
+                }
+                TArray<uint8> Packet;
+                if (OpusEnc->Encode(FloatBuf.GetData(), Frames, Channels, SampleRate, Packet) && Packet.Num() > 0)
+                {
+                    CodecField = static_cast<uint8>(O3DS::EUnifiedCodec::Opus);
+                    Payload.Append(Packet);
+                }
+                else
+                {
+                    // Fallback to PCM16 if encode failed
+                    CodecField = static_cast<uint8>(O3DS::EUnifiedCodec::PCM16);
+                    Payload.Append(reinterpret_cast<const uint8*>(PcmSamples.GetData()), PcmSamples.Num() * sizeof(int16));
+                }
+            }
+            else
+            {
+                Payload.Append(reinterpret_cast<const uint8*>(PcmSamples.GetData()), PcmSamples.Num() * sizeof(int16));
+            }
+        }
+        else
+        {
+            Payload.Append(reinterpret_cast<const uint8*>(PcmSamples.GetData()), PcmSamples.Num() * sizeof(int16));
+        }
 
         // Pack O3DA header (big-endian fields)
         const uint32 Magic = 0x4F334441u; // 'O3DA'
         const uint8 Version = 1;
         const uint8 Kind = static_cast<uint8>(O3DS::EUnifiedKind::Audio);
-        const uint8 Codec = static_cast<uint8>(O3DS::EUnifiedCodec::PCM16);
+    const uint8 Codec = CodecField;
         const uint8 Flags = 0;
         const uint64 TsUs = (uint64)(Now * 1000000.0);
         const uint32 PayloadSize = (uint32)Payload.Num();
@@ -331,4 +383,7 @@ private:
 
     // Stored audio config for future native audio track support
     FO3DSWebRTCAudioConfig AudioConfig;
+
+    // Optional Opus encoder for debug tone
+    TUniquePtr<O3DS::FOpusEncoder> OpusEnc;
 };

--- a/plugins/unreal/Open3DStream/Source/Open3DStream/Open3DStream.Build.cs
+++ b/plugins/unreal/Open3DStream/Source/Open3DStream/Open3DStream.Build.cs
@@ -160,45 +160,47 @@ public class Open3DStream : ModuleRules
 
         // Optional Opus (audio) support
         // Strategy:
-        // 1) If ThirdParty/opus tree exists with platform libs, prefer that
-        // 2) Else on Linux/Mac, fall back to system opus (-lopus)
-        // 3) Else, disable opus (code will compile with O3DS_WITH_OPUS=0)
+        // 1) Prefer prebuilt artifacts placed by CI in ThirdParty root:
+        //    - Headers: ThirdParty/include/opus/opus.h
+        //    - Libs:    ThirdParty/opus.lib (Win), ThirdParty/libopus.a (Linux), ThirdParty/macos/libopus.a (Mac)
+        // 2) Also support legacy layout under ThirdParty/opus/...
+        // 3) Else on Linux/Mac, fall back to system opus (-lopus)
+        // 4) Else, disable opus (O3DS_WITH_OPUS=0)
         bool bWithOpus = false;
-        string OpusRoot = Path.Combine(ThirdPartyDir, "opus");
-        if (Directory.Exists(OpusRoot))
+        string OpusHeader = Path.Combine(ThirdPartyDir, "include", "opus", "opus.h");
+
+        // Probe library locations by platform (new layout first, then legacy)
+        if (Target.Platform == UnrealTargetPlatform.Win64)
         {
-            // Try to link prebuilt opus from ThirdParty
-            string OpusInclude = Path.Combine(OpusRoot, "include");
-            if (Directory.Exists(OpusInclude))
+            string LibPathNew = Path.Combine(ThirdPartyDir, "opus.lib");
+            string LibPathLegacy = Path.Combine(ThirdPartyDir, "opus", "opus.lib");
+            string UseLib = File.Exists(LibPathNew) ? LibPathNew : (File.Exists(LibPathLegacy) ? LibPathLegacy : null);
+            if (!string.IsNullOrEmpty(UseLib) && File.Exists(OpusHeader))
             {
-                PrivateIncludePaths.Add(OpusInclude);
+                PublicAdditionalLibraries.Add(UseLib);
+                bWithOpus = true;
             }
-            if (Target.Platform == UnrealTargetPlatform.Win64)
+        }
+        else if (Target.Platform == UnrealTargetPlatform.Linux)
+        {
+            string LibPathNew = Path.Combine(ThirdPartyDir, "libopus.a");
+            string LibPathLegacy = Path.Combine(ThirdPartyDir, "opus", "libopus.a");
+            string UseLib = File.Exists(LibPathNew) ? LibPathNew : (File.Exists(LibPathLegacy) ? LibPathLegacy : null);
+            if (!string.IsNullOrEmpty(UseLib) && File.Exists(OpusHeader))
             {
-                string LibPath = Path.Combine(OpusRoot, "opus.lib");
-                if (File.Exists(LibPath))
-                {
-                    PublicAdditionalLibraries.Add(LibPath);
-                    bWithOpus = true;
-                }
+                PublicAdditionalLibraries.Add(UseLib);
+                bWithOpus = true;
             }
-            else if (Target.Platform == UnrealTargetPlatform.Linux)
+        }
+        else if (Target.Platform == UnrealTargetPlatform.Mac)
+        {
+            string LibPathNew = Path.Combine(ThirdPartyDir, "macos", "libopus.a");
+            string LibPathLegacy = Path.Combine(ThirdPartyDir, "opus", "macos", "libopus.a");
+            string UseLib = File.Exists(LibPathNew) ? LibPathNew : (File.Exists(LibPathLegacy) ? LibPathLegacy : null);
+            if (!string.IsNullOrEmpty(UseLib) && File.Exists(OpusHeader))
             {
-                string LibPath = Path.Combine(OpusRoot, "libopus.a");
-                if (File.Exists(LibPath))
-                {
-                    PublicAdditionalLibraries.Add(LibPath);
-                    bWithOpus = true;
-                }
-            }
-            else if (Target.Platform == UnrealTargetPlatform.Mac)
-            {
-                string LibPath = Path.Combine(OpusRoot, "macos", "libopus.a");
-                if (File.Exists(LibPath))
-                {
-                    PublicAdditionalLibraries.Add(LibPath);
-                    bWithOpus = true;
-                }
+                PublicAdditionalLibraries.Add(UseLib);
+                bWithOpus = true;
             }
         }
 
@@ -212,7 +214,7 @@ public class Open3DStream : ModuleRules
             }
         }
 
-        PublicDefinitions.Add(bWithOpus ? "O3DS_WITH_OPUS=1" : "O3DS_WITH_OPUS=0");
+    PublicDefinitions.Add(bWithOpus ? "O3DS_WITH_OPUS=1" : "O3DS_WITH_OPUS=0");
 
         PrivateDependencyModuleNames.AddRange(
             new string[]

--- a/plugins/unreal/Open3DStream/Source/Open3DStream/Open3DStream.Build.cs
+++ b/plugins/unreal/Open3DStream/Source/Open3DStream/Open3DStream.Build.cs
@@ -40,7 +40,7 @@ public class Open3DStream : ModuleRules
             Path.Combine(WebRTCDir, "include")
         });
 
-        // Preflight: ensure expected ThirdParty libraries are present for the active platform.
+    // Preflight: ensure expected ThirdParty libraries are present for the active platform.
         // This provides an immediate, actionable error in CI/UAT staging environments.
         string[] RequiredLibs;
         if (Target.Platform == UnrealTargetPlatform.Win64)
@@ -157,6 +157,62 @@ public class Open3DStream : ModuleRules
 
         PublicDefinitions.Add("NNG_STATIC_LIB");
         PublicDefinitions.Add("RTC_STATIC=1"); // Define RTC_STATIC for static libdatachannel
+
+        // Optional Opus (audio) support
+        // Strategy:
+        // 1) If ThirdParty/opus tree exists with platform libs, prefer that
+        // 2) Else on Linux/Mac, fall back to system opus (-lopus)
+        // 3) Else, disable opus (code will compile with O3DS_WITH_OPUS=0)
+        bool bWithOpus = false;
+        string OpusRoot = Path.Combine(ThirdPartyDir, "opus");
+        if (Directory.Exists(OpusRoot))
+        {
+            // Try to link prebuilt opus from ThirdParty
+            string OpusInclude = Path.Combine(OpusRoot, "include");
+            if (Directory.Exists(OpusInclude))
+            {
+                PrivateIncludePaths.Add(OpusInclude);
+            }
+            if (Target.Platform == UnrealTargetPlatform.Win64)
+            {
+                string LibPath = Path.Combine(OpusRoot, "opus.lib");
+                if (File.Exists(LibPath))
+                {
+                    PublicAdditionalLibraries.Add(LibPath);
+                    bWithOpus = true;
+                }
+            }
+            else if (Target.Platform == UnrealTargetPlatform.Linux)
+            {
+                string LibPath = Path.Combine(OpusRoot, "libopus.a");
+                if (File.Exists(LibPath))
+                {
+                    PublicAdditionalLibraries.Add(LibPath);
+                    bWithOpus = true;
+                }
+            }
+            else if (Target.Platform == UnrealTargetPlatform.Mac)
+            {
+                string LibPath = Path.Combine(OpusRoot, "macos", "libopus.a");
+                if (File.Exists(LibPath))
+                {
+                    PublicAdditionalLibraries.Add(LibPath);
+                    bWithOpus = true;
+                }
+            }
+        }
+
+        if (!bWithOpus)
+        {
+            // Fallback to system opus on Linux/Mac
+            if (Target.Platform == UnrealTargetPlatform.Linux || Target.Platform == UnrealTargetPlatform.Mac)
+            {
+                PublicSystemLibraries.Add("opus");
+                bWithOpus = true; // Assume headers in system include path
+            }
+        }
+
+        PublicDefinitions.Add(bWithOpus ? "O3DS_WITH_OPUS=1" : "O3DS_WITH_OPUS=0");
 
         PrivateDependencyModuleNames.AddRange(
             new string[]

--- a/plugins/unreal/Open3DStream/Source/Open3DStream/Private/LibDataChannelConnector.cpp
+++ b/plugins/unreal/Open3DStream/Source/Open3DStream/Private/LibDataChannelConnector.cpp
@@ -9,8 +9,16 @@
 #include "HAL/IConsoleManager.h"
 #include "HAL/PlatformTime.h"
 
+// Opus wrappers (guarded by O3DS_WITH_OPUS)
+#include "O3DSOpusCodec.h"
+
 // libdatachannel includes
 #include <rtc/rtc.hpp>
+#include <rtc/track.hpp>
+#include <rtc/description.hpp>
+#include <rtc/rtppacketizer.hpp>
+#include <rtc/rtpdepacketizer.hpp>
+#include <rtc/rtppacketizationconfig.hpp>
 #include <cstddef> // for std::byte
 #include <memory>
 #include <vector>
@@ -308,20 +316,123 @@ bool FLibDataChannelConnector::SendDataLossy(const uint8* Data, int32 Size)
 
 bool FLibDataChannelConnector::EnableAudioSend(const FAudioSendConfig& Config)
 {
-	// Audio tracks not yet implemented for libdatachannel connector.
-	// Will be implemented in a future PR after LiveKit connector is added.
-	UE_LOG(LogTemp, Warning, TEXT("FLibDataChannelConnector::EnableAudioSend() not yet implemented"));
+	// Enable native audio track with Opus RTP
+#if !defined(RTC_ENABLE_MEDIA) || (O3DS_WITH_OPUS==0)
+	UE_LOG(LogTemp, Warning, TEXT("WebRTC audio send unavailable (RTC_ENABLE_MEDIA or O3DS_WITH_OPUS disabled)"));
 	return false;
+#else
+	if (!PeerConnection)
+	{
+		LastError = TEXT("PeerConnection not initialized");
+		return false;
+	}
+
+	// Construct audio description with Opus codec
+	rtc::Description::Audio AudioDesc("audio", rtc::Description::Direction::SendOnly);
+	const int PayloadType = 111;
+	AudioDesc.addOpusCodec(PayloadType, rtc::DEFAULT_OPUS_AUDIO_PROFILE);
+	if (Config.BitrateKbps > 0)
+	{
+		AudioDesc.setBitrate(Config.BitrateKbps * 1000);
+	}
+
+	// SSRC / CNAME / msid
+	const uint32 SSRC = (uint32)FMath::RandHelper(MAX_int32);
+	const std::string CName = std::string("o3ds-") + std::to_string(SSRC);
+	const std::string Msid = TCHAR_TO_ANSI(*Config.StreamLabel);
+	AudioDesc.addSSRC(SSRC, CName, Msid, std::nullopt);
+
+	std::shared_ptr<rtc::Track> Track;
+	try
+	{
+		Track = PeerConnection->addTrack(AudioDesc);
+	}
+	catch (const std::exception& e)
+	{
+		LastError = FString::Printf(TEXT("addTrack(audio) failed: %s"), ANSI_TO_TCHAR(e.what()));
+		UE_LOG(LogTemp, Error, TEXT("WebRTC Connector: %s"), *LastError);
+		return false;
+	}
+	if (!Track)
+	{
+		LastError = TEXT("Failed to add audio track");
+		UE_LOG(LogTemp, Error, TEXT("WebRTC Connector: %s"), *LastError);
+		return false;
+	}
+
+	// RTP packetizer for Opus
+	auto RtpCfg = std::make_shared<rtc::RtpPacketizationConfig>(SSRC, CName, (uint8_t)PayloadType, 48000);
+	auto Packetizer = std::make_shared<rtc::OpusRtpPacketizer>(RtpCfg);
+	Track->setMediaHandler(Packetizer);
+
+	// Opus encoder
+	TUniquePtr<O3DS::FOpusEncoder> Enc = MakeUnique<O3DS::FOpusEncoder>();
+	if (!Enc->Init(Config.SampleRate, Config.NumChannels, Config.BitrateKbps, Config.bUseDTX))
+	{
+		UE_LOG(LogTemp, Warning, TEXT("WebRTC Connector: Opus encoder init failed (sr=%d ch=%d)"), Config.SampleRate, Config.NumChannels);
+		return false;
+	}
+
+	// Store state
+	FString Key = Config.StreamLabel.IsEmpty() ? FString(TEXT("o3ds:mix")) : Config.StreamLabel;
+	FAudioSendState State;
+	State.StreamLabel = Key;
+	State.SubjectName = Config.SubjectName;
+	State.SampleRate = Config.SampleRate;
+	State.NumChannels = Config.NumChannels;
+	State.BitrateKbps = Config.BitrateKbps;
+	State.Track = Track;
+	State.RtpConfig = RtpCfg;
+	State.Packetizer = Packetizer;
+	State.OpusEnc = MoveTemp(Enc);
+	AudioSenders.Add(Key, MoveTemp(State));
+
+	UE_LOG(LogTemp, Log, TEXT("WebRTC Connector: Audio track enabled (label=%s, sr=%d, ch=%d, br=%dkbps)"),
+		*Key, Config.SampleRate, Config.NumChannels, Config.BitrateKbps);
+	return true;
+#endif
 }
 
 bool FLibDataChannelConnector::PushPcm(const FString& StreamLabel, const float* Interleaved, int32 NumFrames,
                                        int32 NumChannels, int32 SampleRate, double TimestampSec)
 {
-    // Audio tracks not yet implemented for libdatachannel connector.
-    // Stub to satisfy interface; return false to indicate unsupported.
-    UE_LOG(LogTemp, Verbose, TEXT("FLibDataChannelConnector::PushPcm() not implemented (Stream=%s, Frames=%d, Ch=%d, Rate=%d)"),
-        *StreamLabel, NumFrames, NumChannels, SampleRate);
-    return false;
+	if (StreamLabel.IsEmpty()) return false;
+#if !defined(RTC_ENABLE_MEDIA) || (O3DS_WITH_OPUS==0)
+	return false;
+#else
+	FAudioSendState* State = AudioSenders.Find(StreamLabel);
+	if (!State || !State->Track || !State->OpusEnc)
+	{
+		return false;
+	}
+
+	// Encode PCM -> Opus
+	TArray<uint8> Packet;
+	if (!State->OpusEnc->Encode(Interleaved, NumFrames, NumChannels, SampleRate, Packet))
+	{
+		return false;
+	}
+
+	rtc::binary Payload;
+	Payload.reserve((size_t)Packet.Num());
+	for (int32 i = 0; i < Packet.Num(); ++i)
+	{
+		Payload.push_back(static_cast<std::byte>(Packet[i]));
+	}
+	rtc::FrameInfo Info;
+	Info.timestampSeconds = TimestampSec;
+	try
+	{
+		State->Track->sendFrame(std::move(Payload), Info);
+		return true;
+	}
+	catch (const std::exception& e)
+	{
+		LastError = FString(ANSI_TO_TCHAR(e.what()));
+		UE_LOG(LogTemp, Verbose, TEXT("WebRTC Audio: sendFrame failed: %s"), *LastError);
+		return false;
+	}
+#endif
 }
 
 void FLibDataChannelConnector::Tick()
@@ -412,6 +523,16 @@ void FLibDataChannelConnector::Tick()
             NextReconnectTimeSeconds = Now + ReconnectBackoffSeconds + Jitter;
         }
     }
+
+	// Dispatch incoming audio frames on game thread
+	FIncomingAudio Audio;
+	while (IncomingAudioQueue.Dequeue(Audio))
+	{
+		if (RemoteAudioCallback.IsBound())
+		{
+			RemoteAudioCallback.Execute(Audio.StreamLabel, Audio.SubjectName, Audio.Samples.GetData(), Audio.NumFrames, Audio.NumChannels, Audio.SampleRate);
+		}
+	}
 }
 
 void FLibDataChannelConnector::OnPeerConnectionStateChange(int StateInt)
@@ -892,6 +1013,12 @@ bool FLibDataChannelConnector::SetupPeerConnection()
 			OnLocalDescription(Description);
 		});
 
+		// Media track callback (audio/video)
+		PeerConnection->onTrack([this](std::shared_ptr<rtc::Track> InTrack)
+		{
+			OnIncomingTrack(InTrack);
+		});
+
 		// If server mode, handle incoming data channels (non-negotiated mode)
 		if (bIsServer && !bNegotiatedChannelEnabled)
 		{
@@ -1169,4 +1296,86 @@ void FLibDataChannelConnector::MaybeCreateOffer(const TCHAR* Context)
 		LastError = FString(ANSI_TO_TCHAR(e.what()));
 		UE_LOG(LogTemp, Warning, TEXT("WebRTC Connector: Failed to create offer (%s): %s"), Context, *LastError);
 	}
+}
+
+void FLibDataChannelConnector::OnIncomingTrack(std::shared_ptr<rtc::Track> Track)
+{
+#if !defined(RTC_ENABLE_MEDIA) || (O3DS_WITH_OPUS==0)
+	UE_LOG(LogTemp, Verbose, TEXT("WebRTC Connector: Incoming media track ignored (media/opus disabled)"));
+	return;
+#else
+	if (!Track)
+	{
+		return;
+	}
+
+	// Best-effort: check if it's an audio track by inspecting description
+	rtc::Description::Media Desc = Track->description();
+	const std::string Type = Desc.type();
+	const bool bIsAudio = (Type == std::string("audio"));
+	UE_LOG(LogTemp, Verbose, TEXT("WebRTC Connector: Incoming track mid=%s type=%s"), *FString(ANSI_TO_TCHAR(Track->mid().c_str())), *FString(ANSI_TO_TCHAR(Type.c_str())));
+	if (!bIsAudio)
+	{
+		return;
+	}
+
+	// Attach Opus depacketizer
+	auto Depacketizer = std::make_shared<rtc::OpusRtpDepacketizer>();
+	Track->chainMediaHandler(Depacketizer);
+
+	// Create or get decoder for this track MID
+	const FString Mid = FString(ANSI_TO_TCHAR(Track->mid().c_str()));
+	if (!AudioDecoders.Contains(Mid))
+	{
+		TUniquePtr<O3DS::FOpusDecoder> Dec = MakeUnique<O3DS::FOpusDecoder>();
+		// Assume 48kHz mono unless negotiated otherwise
+		if (!Dec->Init(48000, 1))
+		{
+			UE_LOG(LogTemp, Warning, TEXT("WebRTC Connector: Opus decoder init failed for MID %s"), *Mid);
+		}
+		AudioDecoders.Add(Mid, MoveTemp(Dec));
+	}
+
+	// Receive frames (Opus payloads) and decode
+	Track->onFrame([this, Mid](rtc::binary Data, rtc::FrameInfo Info)
+	{
+		TUniquePtr<O3DS::FOpusDecoder>* DecPtr = AudioDecoders.Find(Mid);
+		if (!DecPtr || !DecPtr->IsValid())
+		{
+			return;
+		}
+
+		// Decode Opus -> PCM16
+		const uint8* PacketData = reinterpret_cast<const uint8*>(Data.data());
+		const int32 PacketBytes = (int32)Data.size();
+		TArray<uint8> Pcm16;
+		int32 OutFrames = 0;
+		if (!(*DecPtr)->DecodeToPcm16(PacketData, PacketBytes, Pcm16, OutFrames))
+		{
+			return;
+		}
+
+		const int32 Channels = (*DecPtr)->GetNumChannels();
+		const int32 SampleRate = (*DecPtr)->GetSampleRate();
+		const int32 NumSamples = OutFrames * Channels;
+		// Convert PCM16 -> float
+		TArray<float> Floats;
+		Floats.SetNumUninitialized(NumSamples);
+		const int16* Src = reinterpret_cast<const int16*>(Pcm16.GetData());
+		for (int32 i = 0; i < NumSamples; ++i)
+		{
+			Floats[i] = FMath::Clamp((float)Src[i] / 32768.0f, -1.0f, 1.0f);
+		}
+
+		// Queue for game thread callback
+		FIncomingAudio Item;
+		Item.StreamLabel = TEXT("webrtc:audio"); // TODO: recover from msid/announce
+		Item.SubjectName = TEXT("");
+		Item.NumFrames = OutFrames;
+		Item.NumChannels = Channels;
+		Item.SampleRate = SampleRate;
+		Item.Samples = MoveTemp(Floats);
+		IncomingAudioQueue.Enqueue(MoveTemp(Item));
+	});
+#endif
 }

--- a/plugins/unreal/Open3DStream/Source/Open3DStream/Private/LibDataChannelConnector.h
+++ b/plugins/unreal/Open3DStream/Source/Open3DStream/Private/LibDataChannelConnector.h
@@ -53,7 +53,7 @@ public:
 	// Audio support (placeholder for future implementation)
 	virtual bool EnableAudioSend(const FAudioSendConfig& Config) override;
 	virtual bool PushPcm(const FString& StreamLabel, const float* Interleaved, int32 NumFrames, 
-	                     int32 NumChannels, int32 SampleRate, double TimestampSec) override;
+						 int32 NumChannels, int32 SampleRate, double TimestampSec) override;
 	virtual FOnRemoteAudio& OnRemoteAudio() override { return RemoteAudioCallback; }
 
 	// Additional helpers (for backward compatibility)
@@ -100,6 +100,43 @@ private:
 	// Message queue (thread-safe for libdatachannel callbacks)
 	TQueue<TArray<uint8>, EQueueMode::Mpsc> ReceivedDataQueue;
 
+	// ========== Audio Track State ==========
+	struct FAudioSendState
+	{
+		// Identifiers
+		FString StreamLabel;    // routing label (e.g., o3ds:mix)
+		FString SubjectName;    // optional
+		int32 SampleRate = 48000;
+		int32 NumChannels = 1;
+		int32 BitrateKbps = 64;
+
+		// WebRTC/libdatachannel objects
+		std::shared_ptr<rtc::Track> Track; // media track for this audio stream
+		std::shared_ptr<rtc::RtpPacketizationConfig> RtpConfig;
+		std::shared_ptr<rtc::OpusRtpPacketizer> Packetizer;
+
+		// Opus encoder (optional build)
+		TUniquePtr<class O3DS::FOpusEncoder> OpusEnc;
+	};
+
+	// Map by StreamLabel -> send state
+	TMap<FString, FAudioSendState> AudioSenders;
+
+	// Incoming audio frame queued for game thread dispatch
+	struct FIncomingAudio
+	{
+		FString StreamLabel;
+		FString SubjectName;
+		TArray<float> Samples; // interleaved [-1,1]
+		int32 NumFrames = 0;
+		int32 NumChannels = 1;
+		int32 SampleRate = 48000;
+	};
+	TQueue<FIncomingAudio, EQueueMode::Mpsc> IncomingAudioQueue;
+
+	// Per-track Opus decoders by MID (or other key)
+	TMap<FString, TUniquePtr<class O3DS::FOpusDecoder>> AudioDecoders;
+
 	// Pending ICE candidates
 	TArray<TTuple<FString, FString, int32>> PendingRemoteCandidates;
 
@@ -114,6 +151,7 @@ private:
 	void OnDataChannelClosed();
 	void OnIceCandidate(const rtc::Candidate& Candidate);
 	void OnLocalDescription(const rtc::Description& Description);
+	void OnIncomingTrack(std::shared_ptr<rtc::Track> Track);
 
 	// Signaling callbacks
 	void OnSignalingConnected();

--- a/plugins/unreal/Open3DStream/Source/Open3DStream/Private/O3DSOpusCodec.cpp
+++ b/plugins/unreal/Open3DStream/Source/Open3DStream/Private/O3DSOpusCodec.cpp
@@ -2,7 +2,7 @@
 
 #include "O3DSOpusCodec.h"
 
-#if defined(O3DS_WITH_OPUS)
+#if O3DS_WITH_OPUS
     #include <opus/opus.h>
 #endif
 
@@ -14,7 +14,7 @@ namespace O3DS
 
     bool FOpusEncoder::Init(int32 InSampleRate, int32 InNumChannels, int32 BitrateKbps, bool bUseDtx)
     {
-#if defined(O3DS_WITH_OPUS)
+#if O3DS_WITH_OPUS
         Reset();
         int Err = 0;
         OpusEncoder* E = opus_encoder_create(InSampleRate, InNumChannels, OPUS_APPLICATION_AUDIO, &Err);
@@ -40,7 +40,7 @@ namespace O3DS
 
     void FOpusEncoder::Reset()
     {
-#if defined(O3DS_WITH_OPUS)
+#if O3DS_WITH_OPUS
         if (Enc)
         {
             opus_encoder_destroy((OpusEncoder*)Enc);
@@ -53,7 +53,7 @@ namespace O3DS
     bool FOpusEncoder::Encode(const float* Interleaved, int32 NumFrames, int32 NumChannels, int32 InSampleRate,
                                TArray<uint8>& OutPacket)
     {
-#if defined(O3DS_WITH_OPUS)
+#if O3DS_WITH_OPUS
         if (!Enc || NumChannels != Channels || InSampleRate != SampleRate || !Interleaved || NumFrames <= 0)
         {
             return false;
@@ -80,7 +80,7 @@ namespace O3DS
 
     bool FOpusDecoder::Init(int32 InSampleRate, int32 InNumChannels)
     {
-#if defined(O3DS_WITH_OPUS)
+#if O3DS_WITH_OPUS
         Reset();
         int Err = 0;
         OpusDecoder* D = opus_decoder_create(InSampleRate, InNumChannels, &Err);
@@ -99,7 +99,7 @@ namespace O3DS
 
     void FOpusDecoder::Reset()
     {
-#if defined(O3DS_WITH_OPUS)
+#if O3DS_WITH_OPUS
         if (Dec)
         {
             opus_decoder_destroy((OpusDecoder*)Dec);
@@ -112,7 +112,7 @@ namespace O3DS
     bool FOpusDecoder::DecodeToPcm16(const uint8* PacketData, int32 PacketBytes,
                                       TArray<uint8>& OutPcm16, int32& OutNumFrames)
     {
-#if defined(O3DS_WITH_OPUS)
+#if O3DS_WITH_OPUS
         if (!Dec || !PacketData || PacketBytes <= 0)
         {
             return false;

--- a/plugins/unreal/Open3DStream/Source/Open3DStream/Private/O3DSOpusCodec.cpp
+++ b/plugins/unreal/Open3DStream/Source/Open3DStream/Private/O3DSOpusCodec.cpp
@@ -1,0 +1,141 @@
+// Copyright (c) Open3DStream Contributors
+
+#include "O3DSOpusCodec.h"
+
+#if defined(O3DS_WITH_OPUS)
+    #include <opus/opus.h>
+#endif
+
+namespace O3DS
+{
+    // ======================= Encoder =======================
+    FOpusEncoder::FOpusEncoder() = default;
+    FOpusEncoder::~FOpusEncoder() { Reset(); }
+
+    bool FOpusEncoder::Init(int32 InSampleRate, int32 InNumChannels, int32 BitrateKbps, bool bUseDtx)
+    {
+#if defined(O3DS_WITH_OPUS)
+        Reset();
+        int Err = 0;
+        OpusEncoder* E = opus_encoder_create(InSampleRate, InNumChannels, OPUS_APPLICATION_AUDIO, &Err);
+        if (!E || Err != OPUS_OK)
+        {
+            return false;
+        }
+        // Configure bitrate and DTX
+        opus_encoder_ctl(E, OPUS_SET_BITRATE(BitrateKbps * 1000));
+        opus_encoder_ctl(E, OPUS_SET_VBR(1));
+        opus_encoder_ctl(E, OPUS_SET_DTX(bUseDtx ? 1 : 0));
+
+        Enc = (void*)E;
+        SampleRate = InSampleRate;
+        Channels = InNumChannels;
+        Bitrate = BitrateKbps * 1000;
+        bDtx = bUseDtx;
+        return true;
+#else
+        (void)InSampleRate; (void)InNumChannels; (void)BitrateKbps; (void)bUseDtx; return false;
+#endif
+    }
+
+    void FOpusEncoder::Reset()
+    {
+#if defined(O3DS_WITH_OPUS)
+        if (Enc)
+        {
+            opus_encoder_destroy((OpusEncoder*)Enc);
+            Enc = nullptr;
+        }
+#endif
+        SampleRate = 0; Channels = 0; Bitrate = 0; bDtx = true;
+    }
+
+    bool FOpusEncoder::Encode(const float* Interleaved, int32 NumFrames, int32 NumChannels, int32 InSampleRate,
+                               TArray<uint8>& OutPacket)
+    {
+#if defined(O3DS_WITH_OPUS)
+        if (!Enc || NumChannels != Channels || InSampleRate != SampleRate || !Interleaved || NumFrames <= 0)
+        {
+            return false;
+        }
+        // Opus packet worst-case size is ~1275 bytes per frame, but allocate conservatively for 60ms stereo
+        constexpr int32 MaxPacketBytes = 4096;
+        OutPacket.SetNumUninitialized(MaxPacketBytes);
+        int Bytes = opus_encode_float((OpusEncoder*)Enc, Interleaved, NumFrames, OutPacket.GetData(), MaxPacketBytes);
+        if (Bytes < 0)
+        {
+            OutPacket.Reset();
+            return false;
+        }
+        OutPacket.SetNum(Bytes, /*bAllowShrinking*/true);
+        return true;
+#else
+        (void)Interleaved; (void)NumFrames; (void)NumChannels; (void)InSampleRate; (void)OutPacket; return false;
+#endif
+    }
+
+    // ======================= Decoder =======================
+    FOpusDecoder::FOpusDecoder() = default;
+    FOpusDecoder::~FOpusDecoder() { Reset(); }
+
+    bool FOpusDecoder::Init(int32 InSampleRate, int32 InNumChannels)
+    {
+#if defined(O3DS_WITH_OPUS)
+        Reset();
+        int Err = 0;
+        OpusDecoder* D = opus_decoder_create(InSampleRate, InNumChannels, &Err);
+        if (!D || Err != OPUS_OK)
+        {
+            return false;
+        }
+        Dec = (void*)D;
+        SampleRate = InSampleRate;
+        Channels = InNumChannels;
+        return true;
+#else
+        (void)InSampleRate; (void)InNumChannels; return false;
+#endif
+    }
+
+    void FOpusDecoder::Reset()
+    {
+#if defined(O3DS_WITH_OPUS)
+        if (Dec)
+        {
+            opus_decoder_destroy((OpusDecoder*)Dec);
+            Dec = nullptr;
+        }
+#endif
+        SampleRate = 0; Channels = 0;
+    }
+
+    bool FOpusDecoder::DecodeToPcm16(const uint8* PacketData, int32 PacketBytes,
+                                      TArray<uint8>& OutPcm16, int32& OutNumFrames)
+    {
+#if defined(O3DS_WITH_OPUS)
+        if (!Dec || !PacketData || PacketBytes <= 0)
+        {
+            return false;
+        }
+        // Opus allows up to 120 ms frames. Allocate a safe buffer: 120ms @ 48k = 5760 frames.
+        const int32 MaxFrames = FMath::Max(120 * SampleRate / 1000, 960); // at least 20ms
+        const int32 MaxSamples = MaxFrames * Channels;
+        OutPcm16.SetNumUninitialized(MaxSamples * sizeof(int16));
+        int16* Pcm = reinterpret_cast<int16*>(OutPcm16.GetData());
+
+        const int DecodedFrames = opus_decode((OpusDecoder*)Dec, PacketData, PacketBytes, Pcm, MaxFrames, 0);
+        if (DecodedFrames < 0)
+        {
+            OutPcm16.Reset();
+            OutNumFrames = 0;
+            return false;
+        }
+        const int32 BytesOut = DecodedFrames * Channels * (int32)sizeof(int16);
+        OutPcm16.SetNum(BytesOut, /*bAllowShrinking*/true);
+        OutNumFrames = DecodedFrames;
+        return true;
+#else
+        (void)PacketData; (void)PacketBytes; (void)OutPcm16; (void)OutNumFrames; return false;
+#endif
+    }
+}

--- a/plugins/unreal/Open3DStream/Source/Open3DStream/Private/UOpen3DServer.cpp
+++ b/plugins/unreal/Open3DStream/Source/Open3DStream/Private/UOpen3DServer.cpp
@@ -46,6 +46,9 @@ O3DSServer::O3DSServer()
 {
 	// Initialize mGoodTime to current time to avoid immediate "No Data" warning
 	mGoodTime = FPlatformTime::Seconds();
+	
+    // Lazy-create Opus decoder on first use; keep null until an Opus frame arrives
+    OpusDec.Reset();
 }
 
 O3DSServer::~O3DSServer()
@@ -336,6 +339,12 @@ void O3DSServer::stop()
 	mTcpAnnouncedConnected = false;
 
 	// Allow next session to dump first packet again
+	    // Release Opus decoder
+	    if (OpusDec)
+	    {
+	        OpusDec->Reset();
+	        OpusDec.Reset();
+	    }
 	GDumpedFirstNonTcpPacket = false;
 }
 
@@ -417,6 +426,31 @@ void O3DSServer::inData(const uint8 *msg, size_t len)
 				if (Hdr.GetCodec() == O3DS::EUnifiedCodec::PCM16 && R > 0)
 				{
 					FO3DSAudioBus::PublishPcm16(Meta, P, R);
+					return; // handled
+				}
+
+				if (Hdr.GetCodec() == O3DS::EUnifiedCodec::Opus && R > 0)
+				{
+					// Lazy init decoder
+					if (!OpusDec)
+					{
+						OpusDec = MakeUnique<O3DS::FOpusDecoder>();
+						if (!OpusDec->Init(Meta.SampleRate, Meta.NumChannels))
+						{
+							UE_LOG(LogTemp, Warning, TEXT("O3DS: Opus decoder init failed (sr=%d ch=%d)"), Meta.SampleRate, Meta.NumChannels);
+							return;
+						}
+					}
+					TArray<uint8> Pcm16;
+					int32 Frames = 0;
+					if (OpusDec->DecodeToPcm16(P, R, Pcm16, Frames) && Pcm16.Num() > 0)
+					{
+						FO3DSAudioBus::PublishPcm16(Meta, Pcm16.GetData(), Pcm16.Num());
+					}
+					else
+					{
+						UE_LOG(LogTemp, Verbose, TEXT("O3DS: Opus decode failed (%d bytes)"), R);
+					}
 					return; // handled
 				}
 				// Unknown/unsupported audio codec: drop for now

--- a/plugins/unreal/Open3DStream/Source/Open3DStream/Public/O3DSOpusCodec.h
+++ b/plugins/unreal/Open3DStream/Source/Open3DStream/Public/O3DSOpusCodec.h
@@ -1,0 +1,66 @@
+// Copyright (c) Open3DStream Contributors
+
+#pragma once
+
+#include "CoreMinimal.h"
+
+/**
+ * Thin RAII wrappers around libopus encoder/decoder.
+ *
+ * Usage:
+ *  - Initialize with desired sample rate (8k..48k) and channels (1 or 2)
+ *  - Encode: interleaved float PCM [-1,1] -> Opus packet bytes
+ *  - Decode: Opus packet bytes -> PCM16 interleaved bytes
+ *
+ * Guarded by O3DS_WITH_OPUS. When not available, methods return false.
+ */
+namespace O3DS
+{
+    class OPEN3DSTREAM_API FOpusEncoder
+    {
+    public:
+        FOpusEncoder();
+        ~FOpusEncoder();
+
+        bool Init(int32 SampleRate, int32 NumChannels, int32 BitrateKbps = 64, bool bUseDtx = true);
+        void Reset();
+
+        // Encode interleaved float PCM to a single Opus packet.
+        // NumFrames is per-channel samples (e.g., 480 for 10 ms @ 48 kHz)
+        bool Encode(const float* Interleaved, int32 NumFrames, int32 NumChannels, int32 SampleRate,
+                    TArray<uint8>& OutPacket);
+
+        int32 GetSampleRate() const { return SampleRate; }
+        int32 GetNumChannels() const { return Channels; }
+
+    private:
+        void* Enc = nullptr; // OpusEncoder*
+        int32 SampleRate = 0;
+        int32 Channels = 0;
+        int32 Bitrate = 0; // bps
+        bool bDtx = true;
+    };
+
+    class OPEN3DSTREAM_API FOpusDecoder
+    {
+    public:
+        FOpusDecoder();
+        ~FOpusDecoder();
+
+        bool Init(int32 SampleRate, int32 NumChannels);
+        void Reset();
+
+        // Decode Opus packet to interleaved PCM16 bytes.
+        // Returns true and fills OutPcm16 on success.
+        bool DecodeToPcm16(const uint8* PacketData, int32 PacketBytes,
+                           TArray<uint8>& OutPcm16, int32& OutNumFrames);
+
+        int32 GetSampleRate() const { return SampleRate; }
+        int32 GetNumChannels() const { return Channels; }
+
+    private:
+        void* Dec = nullptr; // OpusDecoder*
+        int32 SampleRate = 0;
+        int32 Channels = 0;
+    };
+}

--- a/plugins/unreal/Open3DStream/Source/Open3DStream/Public/Open3DWebRTCDataChannel.h
+++ b/plugins/unreal/Open3DStream/Source/Open3DStream/Public/Open3DWebRTCDataChannel.h
@@ -4,6 +4,7 @@
 
 #include "CoreMinimal.h"
 #include <functional>
+#include "IWebRTCConnector.h" // For audio track config and delegate
 
 // Forward declarations
 enum class EO3DSWebRtcBackendReceiver : uint8;
@@ -39,6 +40,19 @@ public:
 
     // Pump internal queues (call from game thread each tick).
     void Tick();
+
+    // ========== Audio (Media Tracks) ==========
+    // Create and configure a media audio track for sending Opus via the backend connector.
+    // Returns true if the track is ready to accept PushPcm calls.
+    bool EnableAudioSend(const IWebRTCConnector::FAudioSendConfig& Config);
+
+    // Push interleaved float PCM to the named stream label (configured via EnableAudioSend).
+    // Call in 10–20 ms chunks at the configured sample rate.
+    bool PushPcm(const FString& StreamLabel, const float* Interleaved, int32 NumFrames,
+                 int32 NumChannels, int32 SampleRate, double TimestampSec);
+
+    // Access the remote audio callback delegate (called on game thread after Tick).
+    IWebRTCConnector::FOnRemoteAudio& OnRemoteAudio();
 
 private:
     class FImpl;

--- a/plugins/unreal/Open3DStream/Source/Open3DStream/Public/UOpen3DServer.h
+++ b/plugins/unreal/Open3DStream/Source/Open3DStream/Public/UOpen3DServer.h
@@ -6,6 +6,8 @@
 #include "o3ds/base_connector.h"
 #include "o3ds/udp_fragment.h"
 #include "Sockets.h"
+#include "O3DSUnifiedMessage.h"
+#include "O3DSOpusCodec.h"
 
 // Forward declarations
 class IWebRTCConnector;
@@ -65,5 +67,8 @@ public:
 	double  mLastTcpConnectAttempt = 0.0;
 	int32   mTcpBackoffAttempt = 0;
 	bool    mTcpAnnouncedConnected = false; // to gate status logs
+
+    // Optional Opus decoder for unified audio frames
+    TUniquePtr<O3DS::FOpusDecoder> OpusDec;
 };
 


### PR DESCRIPTION
This PR implements the first slice of Issue #94: Refactor WebRTC transport — adding Opus encoding/decoding integration for audio over the existing DataChannel path using the O3DA (unified) header.\n\nWhat’s in\n- O3DSOpusCodec: small RAII wrappers around libopus (encoder/decoder), guarded by O3DS_WITH_OPUS.\n- Receiver (UOpen3DServer): parses EUnifiedCodec::Opus frames from the unified header, decodes to PCM16, and publishes via FO3DSAudioBus for in-world playback (e.g., UO3DSRemoteAudioComponent).\n- Sender (Open3DBroadcast debug tone): adds CVar o3ds.Broadcast.WebRTC.DebugToneCodec (0=PCM16, 1=Opus). When set to 1 and O3DS_WITH_OPUS is enabled, debug tone frames are Opus-encoded and sent using Codec=Opus.\n- Build: Open3DStream.Build.cs detects ThirdParty/opus or falls back to system opus (Linux/Mac), and defines O3DS_WITH_OPUS accordingly. No build break if Opus is unavailable.\n\nNotes\n- LiveKit native media tracks and subject-aware audio routing will land in a follow-up PR per the plan (this PR only covers DataChannel-based audio with the unified header).\n- Defaults assume 48 kHz mono in this slice; channels/sample-rate signaling can be extended inside the tiny payload metadata later without changing the wire header.\n\nTesting\n- Enable the debug tone: o3ds.Broadcast.WebRTC.DebugToneEnable=1\n- Select codec: o3ds.Broadcast.WebRTC.DebugToneCodec=1 (Opus) or 0 (PCM16)\n- Receiver: add a UO3DSRemoteAudioComponent in the scene (optional filters available).\n\nDocs/Changelog\n- Touched code is self-documented. If desired, I can add a short docs/M3.4.1a_Docs entry in a follow-up.\n\nResolves part of #94.