### PR TITLE
o3ds: WebRTC audio reoffer + announce source; swallow control JSON

### DIFF
--- a/plugins/unreal/Open3DStream/Source/Open3DStream/Private/WebRTCConnector.cpp
+++ b/plugins/unreal/Open3DStream/Source/Open3DStream/Private/WebRTCConnector.cpp
@@ -1489,6 +1489,12 @@ void FWebRTCConnector::EnableAudioSend(const FAudioConfig& InConfig)
 				AudioRt.bTrackReady = false;
 				UE_LOG(LogTemp, Log, TEXT("WebRTC Connector: Audio track closed"));
 			});
+					// Initialize a small reoffer timer to ensure track opens after enabling
+					{
+						const double Now = FPlatformTime::Seconds();
+						AudioOpenReofferBackoffSeconds = 1.0;
+						NextAudioOpenReofferTimeSeconds = Now + AudioOpenReofferBackoffSeconds;
+					}
 		}
 	}
 #else
@@ -1592,6 +1598,18 @@ bool FWebRTCConnector::PushAudioPCM16(const int16* Samples, int32 NumSamples)
 	{
 		AudioRt.bTrackReady = false;
 		AudioRt.NextSendRetryTimeSeconds = Now + 0.25;
+		// Proactively trigger a re-offer (client) to help finalize track opening, with backoff
+		if (!bIsServer)
+		{
+			const double Now2 = FPlatformTime::Seconds();
+			if (Now2 >= NextAudioOpenReofferTimeSeconds)
+			{
+				MaybeCreateOffer(TEXT("audio-not-open"));
+				AudioOpenReofferBackoffSeconds = FMath::Min(8.0, AudioOpenReofferBackoffSeconds * 2.0);
+				const double Jitter = (double)FMath::FRandRange(0.0f, (float)(0.25 * AudioOpenReofferBackoffSeconds));
+				NextAudioOpenReofferTimeSeconds = Now2 + AudioOpenReofferBackoffSeconds + Jitter;
+			}
+		}
 		if (CVarO3DSWebRTCVerbose->GetInt() != 0)
 		{
 			UE_LOG(LogTemp, Verbose, TEXT("WebRTC Connector: PushAudioPCM16 deferred (track not open)"));

--- a/plugins/unreal/Open3DStream/Source/Open3DStream/Private/WebRTCConnector.h
+++ b/plugins/unreal/Open3DStream/Source/Open3DStream/Private/WebRTCConnector.h
@@ -245,6 +245,10 @@ private:
 	double ReconnectBackoffSeconds =0.0;
 	int32 LastPeerState;
 
+	// Audio-track not-open reoffer helper (client only)
+	double NextAudioOpenReofferTimeSeconds = 0.0;
+	double AudioOpenReofferBackoffSeconds = 1.0; // grow up to a small cap
+
 	// Negotiated channel support
 	bool bNegotiatedChannelEnabled = false;
 	int32 NegotiatedChannelId =42;

--- a/plugins/unreal/Open3DStream/Source/Open3DStream/Private/WebRTCConnectorFactory.cpp
+++ b/plugins/unreal/Open3DStream/Source/Open3DStream/Private/WebRTCConnectorFactory.cpp
@@ -132,7 +132,8 @@ namespace
 
 		void HandleIncomingData(const uint8* Data, int32 Size)
 		{
-			// Try parse as JSON announce; ignore on failure
+			// Try parse as JSON announce; if recognized, consume it here and do NOT forward to user callback,
+			// to avoid spurious parse errors in consumers expecting O3DS flatbuffers.
 			FString JsonStr;
 			FUTF8ToTCHAR Conv(reinterpret_cast<const ANSICHAR*>(Data), Size);
 			JsonStr = FString(Conv.Length(), Conv.Get());
@@ -157,8 +158,11 @@ namespace
 							Inner->SetRxAudioRouting(Stream, Subject);
 						}
 					}
+					// Announce handled; swallow this message
+					return;
 				}
 			}
+			// Not a recognized control message; let user-level handler see it
 		}
 
 	private:


### PR DESCRIPTION
This PR completes the remaining pieces for Issue #94 WebRTC audio negotiation and validation.\n\nChanges\n- Client-side reoffer when audio track remains not open, with exponential backoff (prevents TrackOpen=0 stall)\n- o3ds.audio.announce JSON now includes "source" ("mix"|"mic") alongside stream label and subject\n- Adapter swallows o3ds.audio.announce on RX to avoid flatbuffer parse errors (previous ~191B parse failures)\n- Debug tone continues to exercise the audio-track path only\n\nExpected outcomes\n- TrackOpen flips to 1 after initial negotiation or brief reoffer cycle; SentPackets > 0; audible on receiver via FO3DSAudioBus/UO3DSRemoteAudioComponent\n- No more "Data Error" on 191-byte control messages\n\nValidation notes\n- Check logs for MaybeCreateOffer("audio-not-open") followed by "Audio track opened"\n- Confirm announce shows source="mix" when CaptureMode=Mix and stream label "o3ds:mix"\n\nFollow-ups\n- If a peer still refuses to open, we’ll dump/inspect SDP directions and expand logging around onTrack/onOpen/closed.\n