### PR TITLE
o3ds: Swallow announce; log remote SDP audio direction (TrackOpen=0 debug)

### DIFF
--- a/plugins/unreal/Open3DStream/Source/Open3DStream/Private/WebRTCConnector.cpp
+++ b/plugins/unreal/Open3DStream/Source/Open3DStream/Private/WebRTCConnector.cpp
@@ -641,6 +641,19 @@ void FWebRTCConnector::OnLocalDescription(const rtc::Description& Description)
 				{
 					UE_LOG(LogTemp, Verbose, TEXT("WebRTC Connector: Local SDP includes Opus PT=111"));
 				}
+				// Also log local audio direction flags to help debug TrackOpen=0
+				int32 AudioStart = SDP.Find(TEXT("m=audio"), ESearchCase::IgnoreCase, ESearchDir::FromStart);
+				if (AudioStart != INDEX_NONE)
+				{
+					int32 NextM = SDP.Find(TEXT("\nm="), ESearchCase::IgnoreCase, ESearchDir::FromStart, AudioStart + 1);
+					const FString Section = (NextM == INDEX_NONE) ? SDP.Mid(AudioStart) : SDP.Mid(AudioStart, NextM - AudioStart);
+					const bool bRecvOnly = Section.Contains(TEXT("a=recvonly"));
+					const bool bSendOnly = Section.Contains(TEXT("a=sendonly"));
+					const bool bSendRecv = Section.Contains(TEXT("a=sendrecv"));
+					const bool bInactive = Section.Contains(TEXT("a=inactive"));
+					UE_LOG(LogTemp, Verbose, TEXT("Local SDP audio dir: recvonly=%d sendonly=%d sendrecv=%d inactive=%d"),
+						bRecvOnly?1:0, bSendOnly?1:0, bSendRecv?1:0, bInactive?1:0);
+				}
 			}
 		}
 
@@ -712,6 +725,23 @@ void FWebRTCConnector::OnOfferReceived(const FString& SDP)
 		if (!bRemoteSDPHasAudio)
 		{
 			UE_LOG(LogTemp, Verbose, TEXT("WebRTC Connector: Remote offer has no m=audio"));
+		}
+		else
+		{
+			// Log remote offer audio direction and Opus presence
+			int32 AudioStart = SDP.Find(TEXT("m=audio"), ESearchCase::IgnoreCase, ESearchDir::FromStart);
+			if (AudioStart != INDEX_NONE)
+			{
+				int32 NextM = SDP.Find(TEXT("\nm="), ESearchCase::IgnoreCase, ESearchDir::FromStart, AudioStart + 1);
+				const FString Section = (NextM == INDEX_NONE) ? SDP.Mid(AudioStart) : SDP.Mid(AudioStart, NextM - AudioStart);
+				const bool bRecvOnly = Section.Contains(TEXT("a=recvonly"));
+				const bool bSendOnly = Section.Contains(TEXT("a=sendonly"));
+				const bool bSendRecv = Section.Contains(TEXT("a=sendrecv"));
+				const bool bInactive = Section.Contains(TEXT("a=inactive"));
+				const bool bOpus111 = Section.Contains(TEXT("a=rtpmap:111 opus"), ESearchCase::IgnoreCase);
+				UE_LOG(LogTemp, Verbose, TEXT("Remote OFFER audio dir: recvonly=%d sendonly=%d sendrecv=%d inactive=%d opus111=%d"),
+					bRecvOnly?1:0, bSendOnly?1:0, bSendRecv?1:0, bInactive?1:0, bOpus111?1:0);
+			}
 		}
 		
 		// Server must create answer in response to offer
@@ -965,19 +995,6 @@ bool FWebRTCConnector::ParseWebRtcUrl(const FString& Url, FString& OutHost, uint
 			return false;
 		}
 		OutPort = (uint16)P;
-	}
-
-	// Parse query params into map
-	if (!QueryString.IsEmpty())
-	{
-		TArray<FString> Pairs;
-		QueryString.ParseIntoArray(Pairs, TEXT("&"), true);
-		for (const FString& Pair : Pairs)
-		{
-			if (Pair.IsEmpty()) continue;
-			int32 Eq = Pair.Find(TEXT("="));
-			if (Eq != INDEX_NONE)
-			{
 				const FString Key = Pair.Left(Eq);
 				const FString Val = Pair.Mid(Eq +1);
 				OutParams.Add(Key, Val);

--- a/plugins/unreal/Open3DStream/Source/Open3DStream/Private/WebRTCConnector.cpp
+++ b/plugins/unreal/Open3DStream/Source/Open3DStream/Private/WebRTCConnector.cpp
@@ -995,8 +995,20 @@ bool FWebRTCConnector::ParseWebRtcUrl(const FString& Url, FString& OutHost, uint
 			return false;
 		}
 		OutPort = (uint16)P;
+	}
+
+	// Parse query string into OutParams (case-preserving keys)
+	if (!QueryString.IsEmpty())
+	{
+		TArray<FString> Pairs;
+		QueryString.ParseIntoArray(Pairs, TEXT("&"), true);
+		for (const FString& Pair : Pairs)
+		{
+			int32 Eq = Pair.Find(TEXT("="));
+			if (Eq != INDEX_NONE)
+			{
 				const FString Key = Pair.Left(Eq);
-				const FString Val = Pair.Mid(Eq +1);
+				const FString Val = Pair.Mid(Eq + 1);
 				OutParams.Add(Key, Val);
 			}
 			else

--- a/plugins/unreal/Open3DStream/Source/Open3DStream/Private/WebRTCConnector.cpp
+++ b/plugins/unreal/Open3DStream/Source/Open3DStream/Private/WebRTCConnector.cpp
@@ -750,6 +750,24 @@ void FWebRTCConnector::OnAnswerReceived(const FString& SDP)
 		{
 			UE_LOG(LogTemp, Warning, TEXT("WebRTC Connector: Remote SDP has no m=audio; audio track will not open"));
 		}
+		else if (bRemoteSDPHasAudio)
+		{
+			// Log audio m-line direction and Opus PT presence to troubleshoot TrackOpen=0 cases
+			int32 AudioStart = SDP.Find(TEXT("m=audio"), ESearchCase::IgnoreCase, ESearchDir::FromStart);
+			int32 NextM = INDEX_NONE;
+			if (AudioStart != INDEX_NONE)
+			{
+				NextM = SDP.Find(TEXT("\nm="), ESearchCase::IgnoreCase, ESearchDir::FromStart, AudioStart + 1);
+				const FString Section = (NextM == INDEX_NONE) ? SDP.Mid(AudioStart) : SDP.Mid(AudioStart, NextM - AudioStart);
+				const bool bRecvOnly = Section.Contains(TEXT("a=recvonly"));
+				const bool bSendOnly = Section.Contains(TEXT("a=sendonly"));
+				const bool bSendRecv = Section.Contains(TEXT("a=sendrecv"));
+				const bool bInactive = Section.Contains(TEXT("a=inactive"));
+				const bool bOpus111 = Section.Contains(TEXT("a=rtpmap:111 opus"), ESearchCase::IgnoreCase);
+				UE_LOG(LogTemp, Verbose, TEXT("Remote SDP audio dir: recvonly=%d sendonly=%d sendrecv=%d inactive=%d opus111=%d"),
+					bRecvOnly?1:0, bSendOnly?1:0, bSendRecv?1:0, bInactive?1:0, bOpus111?1:0);
+			}
+		}
 		FlushPendingRemoteCandidates();
 	}
 	catch (const std::exception& e)

--- a/plugins/unreal/Open3DStream/Source/Open3DStream/Private/WebRTCConnectorFactory.cpp
+++ b/plugins/unreal/Open3DStream/Source/Open3DStream/Private/WebRTCConnectorFactory.cpp
@@ -164,6 +164,7 @@ namespace
 						}
 					}
 					// Announce handled; swallow this message
+					UE_LOG(LogTemp, Verbose, TEXT("FLibDataChannelAdapter: Swallowed o3ds.audio.announce (tracks=%d)"), Root->GetArrayField(TEXT("tracks")).Num());
 					return true;
 				}
 			}

--- a/plugins/unreal/Open3DStream/Source/Open3DStream/Private/WebRTCConnectorFactory.cpp
+++ b/plugins/unreal/Open3DStream/Source/Open3DStream/Private/WebRTCConnectorFactory.cpp
@@ -21,7 +21,11 @@ namespace
 			// Chain a data callback to parse announce before user callback
 			Inner->SetDataReceivedCallback([this](const uint8* Data, int32 Size)
 			{
-				HandleIncomingData(Data, Size);
+				// Swallow recognized control messages (e.g., o3ds.audio.announce)
+				if (HandleIncomingData(Data, Size))
+				{
+					return; // consumed
+				}
 				// Forward to external if bound
 				if (UserDataCallback)
 				{
@@ -130,7 +134,8 @@ namespace
 			SendDataReliable(reinterpret_cast<const uint8*>(Conv.Get()), Conv.Length());
 		}
 
-		void HandleIncomingData(const uint8* Data, int32 Size)
+		// Returns true if the message was recognized and consumed (not forwarded)
+		bool HandleIncomingData(const uint8* Data, int32 Size)
 		{
 			// Try parse as JSON announce; if recognized, consume it here and do NOT forward to user callback,
 			// to avoid spurious parse errors in consumers expecting O3DS flatbuffers.
@@ -159,10 +164,11 @@ namespace
 						}
 					}
 					// Announce handled; swallow this message
-					return;
+					return true;
 				}
 			}
 			// Not a recognized control message; let user-level handler see it
+			return false;
 		}
 
 	private:


### PR DESCRIPTION
Fixes two issues observed in testing for #94:\n\n1) 191-byte parse error after enabling debug tone\n   - Cause: o3ds.audio.announce JSON was still forwarded to flatbuffer consumers\n   - Fix: Adapter now swallows recognized control JSON before invoking user callback\n\n2) TrackOpen=0 despite m=audio=1 on both SDPs\n   - Adds detailed logs for the answer’s audio m-line: direction (recvonly/sendonly/sendrecv/inactive) and Opus PT=111 presence\n   - Helps us confirm whether direction/capability prevents the local audio track from opening\n\nNo behavior change to data/audio paths besides the swallow; logs are verbose-only.\n