### PR TITLE
o3ds: start #117 — WebRTC audio path refactor

### DIFF
--- a/plugins/unreal/Open3DStream/Source/Open3DStream/Private/Tests/O3DSWebRTCTests.cpp
+++ b/plugins/unreal/Open3DStream/Source/Open3DStream/Private/Tests/O3DSWebRTCTests.cpp
@@ -476,6 +476,68 @@ bool FO3DSWebRTC_AudioPerFrame_Localhost::RunTest(const FString& Params)
     return (bool)bGotAudio;
 }
 
+// Verifies that calling EnableAudioSend after Start is rejected by the connector
+// and that the adapter propagates the failure (Issue #118).
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FO3DSWebRTC_EnableAudioSend_RejectionPropagates,
+    "Open3DStream.WebRTC.Audio.EnableAudioSend_RejectionPropagates",
+    EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FO3DSWebRTC_EnableAudioSend_RejectionPropagates::RunTest(const FString& Params)
+{
+    FString Url; bool bFallback = false;
+    GetSignalingUrl(Url, bFallback);
+
+    TSharedPtr<IWebRTCConnector> Server = CreateWebRTCConnector(EO3DSWebRtcBackendReceiver::LibDataChannel);
+    TSharedPtr<IWebRTCConnector> Client = CreateWebRTCConnector(EO3DSWebRtcBackendReceiver::LibDataChannel);
+    if (!Server || !Client)
+    {
+        AddError(TEXT("Failed to create WebRTC connectors"));
+        return false;
+    }
+
+    const bool bServerOk = Server->Start(Url, /*bIsServer*/true);
+    const bool bClientOk = Client->Start(Url, /*bIsServer*/false);
+    TestTrue(TEXT("Server start() returned true"), bServerOk);
+    TestTrue(TEXT("Client start() returned true"), bClientOk);
+
+    // Wait until connected (or timeout)
+    TArray<TSharedPtr<IWebRTCConnector>> All{Server, Client};
+    PumpUntil(10.0, All, [&]()
+    {
+        return Server->IsConnected() && Client->IsConnected();
+    });
+
+    if (!Server->IsConnected() || !Client->IsConnected())
+    {
+        const FString ErrS = Server->GetLastError();
+        const FString ErrC = Client->GetLastError();
+        AddError(FString::Printf(TEXT("Timed out waiting for WebRTC connection (EnableAudioSend rejection test). Url=%s ServerErr='%s' ClientErr='%s'"), *Url, *ErrS, *ErrC));
+        Server->Stop();
+        Client->Stop();
+        return false;
+    }
+
+    // Now call EnableAudioSend AFTER Start, which must be rejected by inner connector.
+    IWebRTCConnector::FAudioSendConfig Cfg;
+    Cfg.bEnable = true;
+    Cfg.SampleRate = 48000;
+    Cfg.NumChannels = 1;
+    Cfg.BitrateKbps = 32;
+    Cfg.StreamLabel = TEXT("o3ds:test:late");
+    Cfg.SubjectName = TEXT("LateEnableSubject");
+    Cfg.SourceType = TEXT("test");
+
+    const bool bEnabled = Client->EnableAudioSend(Cfg);
+    TestFalse(TEXT("EnableAudioSend after Start should be rejected and return false (propagated by adapter)"), bEnabled);
+
+    // Optional: a quick push should also not be accepted as configured (may buffer or fail). We only assert
+    // the explicit contract here: the call returns false.
+
+    Server->Stop();
+    Client->Stop();
+    return true;
+}
+
 // In-process sanity checks: prove libdatachannel connects without any signaling server.
 IMPLEMENT_SIMPLE_AUTOMATION_TEST(FO3DSWebRTC_InProc_DataChannel,
     "Open3DStream.WebRTC.InProc.DataChannel",

--- a/plugins/unreal/Open3DStream/Source/Open3DStream/Private/WebRTCConnectorFactory.cpp
+++ b/plugins/unreal/Open3DStream/Source/Open3DStream/Private/WebRTCConnectorFactory.cpp
@@ -6,6 +6,8 @@
 #include "Dom/JsonObject.h"
 #include "Serialization/JsonWriter.h"
 #include "Serialization/JsonSerializer.h"
+// Audio logging category
+#include "O3DSLog.h"
 
 namespace
 {
@@ -50,12 +52,21 @@ namespace
 			if (!EnabledStreams.Contains(Cfg.StreamLabel))
 			{
 				FWebRTCConnector::FAudioConfig A; A.SampleRate = Cfg.SampleRate; A.NumChannels = Cfg.NumChannels; A.BitrateKbps = Cfg.BitrateKbps; A.FrameSizeMs =20; A.StreamLabel = Cfg.StreamLabel;
-				UE_LOG(LogTemp, Verbose, TEXT("FLibDataChannelAdapter: EnableAudioSend stream=%s sr=%d ch=%d br=%d"), *A.StreamLabel, A.SampleRate, A.NumChannels, A.BitrateKbps);
-				Inner->EnableAudioSend(A);
-				EnabledStreams.Add(Cfg.StreamLabel);
-				EmitAnnounceIfNeeded(Cfg);
-				UE_LOG(LogTemp, Verbose, TEXT("FLibDataChannelAdapter: Announce emitted for stream=%s"), *Cfg.StreamLabel);
+				UE_LOG(O3DSWebRTCAudioLog, Verbose, TEXT("[ADAPTER] EnableAudioSend request stream=%s sr=%d ch=%d br=%d"), *A.StreamLabel, A.SampleRate, A.NumChannels, A.BitrateKbps);
+				const bool bSuccess = Inner->EnableAudioSend(A);
+				if (bSuccess)
+				{
+					EnabledStreams.Add(Cfg.StreamLabel);
+					EmitAnnounceIfNeeded(Cfg);
+					UE_LOG(O3DSWebRTCAudioLog, Log, TEXT("[ADAPTER] EnableAudioSend(%s) -> SUCCESS"), *Cfg.StreamLabel);
+				}
+				else
+				{
+					UE_LOG(O3DSWebRTCAudioLog, Warning, TEXT("[ADAPTER] EnableAudioSend(%s) -> FAILED: %s"), *Cfg.StreamLabel, *Inner->GetLastError());
+				}
+				return bSuccess;
 			}
+			// Already configured with this label; treat as success (idempotent)
 			return true;
 #else
 			return false;


### PR DESCRIPTION
Resolves #117.

Bootstrap PR to kick off Unreal Windows quickbuild for the WebRTC audio path refactor.

How to steer:
- Use /stop or /steer comments per AGENTS.md to direct next steps.

References:
- Issue: https://github.com/lifelike-and-believable/Open3DStream/issues/117
- Repo agent rules: .github/copilot-instructions.md