### PR TITLE
o3ds: resilient WebRTC reconnect + receiver audio fixes

### DIFF
--- a/plugins/unreal/Open3DStream/Source/Open3DShared/Private/LibDataChannelConnector.cpp
+++ b/plugins/unreal/Open3DStream/Source/Open3DShared/Private/LibDataChannelConnector.cpp
@@ -42,6 +42,11 @@ bool FLibDataChannelConnector::Start(const FO3DSWebRtcConfig& InConfig)
     bAudioOpen.store(false);
     bRemoteDescriptionSet = false;
     PendingCandidates.Reset();
+    bSignalingConnected.store(false);
+    // Stop any existing offer retry pump
+    bOfferRetryPump.store(false);
+    if (OfferRetryThread.joinable()) { OfferRetryThread.join(); }
+    OfferRetryAttempt = 0;
     // Stop audio pump thread if running
     bAudioPump.store(false);
     if (AudioThread.joinable()) { AudioThread.join(); }
@@ -68,7 +73,8 @@ bool FLibDataChannelConnector::Start(const FO3DSWebRtcConfig& InConfig)
         });
     }
 
-    // Open signaling and proceed
+    // Start signaling reconnect pump and initiate first connect
+    StartSignalingReconnectPump();
     OpenWebSocket();
     return true;
 }
@@ -77,6 +83,14 @@ void FLibDataChannelConnector::Stop()
 {
     // Stop signaling and media cleanly; idempotent
     bStarted.store(false);
+
+    // Stop client offer retry pump
+    bOfferRetryPump.store(false);
+    if (OfferRetryThread.joinable()) { OfferRetryThread.join(); }
+
+    // Stop signaling reconnect pump
+    bSignalingReconnectPump.store(false);
+    if (SignalingReconnectThread.joinable()) { SignalingReconnectThread.join(); }
 
     // Stop audio pump
     bAudioPump.store(false);
@@ -218,12 +232,13 @@ void FLibDataChannelConnector::OpenWebSocket()
         FString Query;
         if (Url.Split(TEXT("?"), &Base, &Query))
         {
-            // Remove any room=... from the query
+            // Remove any room=... and role=... from the query (server ID should be clean room name)
             TArray<FString> Parts; Query.ParseIntoArray(Parts, TEXT("&"), true);
             TArray<FString> Kept;
             for (const FString& P : Parts)
             {
-                if (!P.StartsWith(TEXT("room="), ESearchCase::IgnoreCase))
+                if (!P.StartsWith(TEXT("room="), ESearchCase::IgnoreCase) &&
+                    !P.StartsWith(TEXT("role="), ESearchCase::IgnoreCase))
                 {
                     Kept.Add(P);
                 }
@@ -254,6 +269,7 @@ void FLibDataChannelConnector::OpenWebSocket()
         }
     }
 
+    if (WS.IsValid()) { WS.Reset(); }
     WS = WSM.CreateWebSocket(Url);
 
     {
@@ -261,6 +277,7 @@ void FLibDataChannelConnector::OpenWebSocket()
         WS->OnConnected().AddLambda([this, Url, Weak]()
     {
         UE_LOG(LogTemp, Log, TEXT("[LibDC] WebSocket connected (%s)"), *Url);
+        bSignalingConnected.store(true);
         AsyncTask(ENamedThreads::GameThread, [Weak]()
         {
             if (TSharedPtr<IWebRTCConnector> P = Weak.Pin())
@@ -275,12 +292,14 @@ void FLibDataChannelConnector::OpenWebSocket()
         if (Config.Role == EO3DSWebRtcRole::Client)
         {
             CreateClientMediaAndDC();
+            StartClientOfferRetryPump();
         }
     });
 
     WS->OnConnectionError().AddLambda([this, Url, Weak](const FString& Err)
     {
         UE_LOG(LogTemp, Error, TEXT("[LibDC] WebSocket error: %s (url=%s)"), *Err, *Url);
+        bSignalingConnected.store(false);
         const FString Msg = FString::Printf(TEXT("SignalingError: %s"), *Err);
         AsyncTask(ENamedThreads::GameThread, [Weak, Msg]()
         {
@@ -294,6 +313,12 @@ void FLibDataChannelConnector::OpenWebSocket()
     WS->OnClosed().AddLambda([this, Weak](int32 /*Status*/, const FString& Reason, bool /*bClean*/)
     {
         UE_LOG(LogTemp, Warning, TEXT("[LibDC] WebSocket closed: %s"), *Reason);
+        // Reset peer/media so we can accept a fresh session on reconnect
+        ResetPeerConnection();
+        // Stop client offer retry pump while disconnected
+        bOfferRetryPump.store(false);
+        if (OfferRetryThread.joinable()) { OfferRetryThread.join(); }
+        bSignalingConnected.store(false);
         AsyncTask(ENamedThreads::GameThread, [Weak]()
         {
             if (TSharedPtr<IWebRTCConnector> P = Weak.Pin())
@@ -446,6 +471,147 @@ void FLibDataChannelConnector::SetupPeerConnection(const rtc::Configuration& Cfg
             AttachRecvAudioCallbacks(RecvAudioTrack);
         });
     }
+}
+
+void FLibDataChannelConnector::ResetPeerConnection()
+{
+    // Stop audio pump
+    bAudioPump.store(false);
+    if (AudioThread.joinable()) { AudioThread.join(); }
+
+    // Clear media/data callbacks to break cycles before reset
+    if (DC) {
+        try { DC->onOpen(nullptr); DC->onClosed(nullptr); DC->onMessage(nullptr); } catch (...) {}
+    }
+    if (SendAudioTrack) {
+        try { SendAudioTrack->onOpen(nullptr); SendAudioTrack->onClosed(nullptr); SendAudioTrack->onMessage(nullptr); } catch (...) {}
+    }
+    if (RecvAudioTrack) {
+        try { RecvAudioTrack->onOpen(nullptr); RecvAudioTrack->onClosed(nullptr); RecvAudioTrack->onMessage(nullptr); } catch (...) {}
+    }
+
+#if O3DS_WITH_OPUS
+    if (OpusEnc) { opus_encoder_destroy(OpusEnc); OpusEnc = nullptr; }
+    OpusAccumPcm.Reset();
+#endif
+
+    bOpen.store(false);
+    bAudioOpen.store(false);
+    bRemoteDescriptionSet = false;
+    PendingCandidates.Reset();
+
+    DC.reset();
+    SendAudioTrack.reset();
+    RecvAudioTrack.reset();
+    PC.reset();
+}
+
+void FLibDataChannelConnector::StartSignalingReconnectPump()
+{
+    // Ensure single pump
+    bSignalingReconnectPump.store(false);
+    if (SignalingReconnectThread.joinable()) { SignalingReconnectThread.join(); }
+    SignalingReconnectAttempt = 0;
+    bSignalingReconnectPump.store(true);
+    SignalingReconnectThread = std::thread([this]()
+    {
+        while (bSignalingReconnectPump.load())
+        {
+            if (!bStarted.load()) break;
+            if (!bSignalingConnected.load())
+            {
+                // Backoff before attempting reconnection to avoid hammering
+                ++SignalingReconnectAttempt;
+                int delay = FMath::Min(1 << FMath::Min(SignalingReconnectAttempt, 4), 16); // 1,2,4,8,16 cap
+                UE_LOG(LogTemp, Log, TEXT("[LibDC] Signaling reconnect attempt %d in %ds"), SignalingReconnectAttempt, delay);
+                for (int i = 0; i < delay && bSignalingReconnectPump.load() && !bSignalingConnected.load() && bStarted.load(); ++i)
+                {
+                    std::this_thread::sleep_for(std::chrono::seconds(1));
+                }
+                if (!bSignalingReconnectPump.load() || bSignalingConnected.load() || !bStarted.load()) continue;
+                // Ask game thread to open a new WebSocket
+                AsyncTask(ENamedThreads::GameThread, [this]()
+                {
+                    if (bStarted.load())
+                    {
+                        OpenWebSocket();
+                    }
+                });
+                // After scheduling, wait a bit for connection callbacks to fire
+                std::this_thread::sleep_for(std::chrono::seconds(2));
+                continue;
+            }
+            else
+            {
+                // Connected; reset attempt counter and sleep a little
+                SignalingReconnectAttempt = 0;
+                std::this_thread::sleep_for(std::chrono::seconds(2));
+            }
+        }
+        bSignalingReconnectPump.store(false);
+    });
+}
+
+void FLibDataChannelConnector::StopSignalingReconnectPump()
+{
+    bSignalingReconnectPump.store(false);
+    if (SignalingReconnectThread.joinable()) { SignalingReconnectThread.join(); }
+}
+
+void FLibDataChannelConnector::StartClientOfferRetryPump()
+{
+    if (Config.Role != EO3DSWebRtcRole::Client) return;
+    // Ensure any prior pump is stopped
+    bOfferRetryPump.store(false);
+    if (OfferRetryThread.joinable()) { OfferRetryThread.join(); }
+    OfferRetryAttempt = 0;
+    bOfferRetryPump.store(true);
+    OfferRetryThread = std::thread([this]()
+    {
+        // Retry with modest backoff until an answer is set or stopped
+        while (bOfferRetryPump.load())
+        {
+            // Wait a bit before checking for an answer
+            std::this_thread::sleep_for(std::chrono::seconds(3));
+            if (!bOfferRetryPump.load()) break;
+
+            // If answer arrived, stop
+            if (bRemoteDescriptionSet) break;
+
+            // Only retry when signaling is present and connector running
+            if (!bStarted.load() || !WS.IsValid()) continue;
+
+            ++OfferRetryAttempt;
+            UE_LOG(LogTemp, Log, TEXT("[LibDC] Client re-offering (no answer yet), attempt %d"), OfferRetryAttempt);
+            ForceClientReoffer();
+
+            // Backoff: 3s, 5s, 7s, up to 11s
+            int backoff = 3 + FMath::Min(OfferRetryAttempt * 2, 8);
+            for (int i = 0; i < backoff && bOfferRetryPump.load(); ++i)
+            {
+                std::this_thread::sleep_for(std::chrono::seconds(1));
+                if (bRemoteDescriptionSet) break;
+            }
+            if (bRemoteDescriptionSet) break;
+        }
+        bOfferRetryPump.store(false);
+    });
+}
+
+void FLibDataChannelConnector::StopClientOfferRetryPump()
+{
+    bOfferRetryPump.store(false);
+    if (OfferRetryThread.joinable()) { OfferRetryThread.join(); }
+}
+
+void FLibDataChannelConnector::ForceClientReoffer()
+{
+    if (Config.Role != EO3DSWebRtcRole::Client) return;
+    // Recreate PC and media; this triggers a fresh offer via onLocalDescription
+    ResetPeerConnection();
+    rtc::Configuration Cfg;
+    SetupPeerConnection(Cfg);
+    CreateClientMediaAndDC();
 }
 
 void FLibDataChannelConnector::CreateClientMediaAndDC()
@@ -694,6 +860,13 @@ void FLibDataChannelConnector::CreateClientMediaAndDC()
                 P->OnState().Broadcast(TEXT("DataChannelClosed"), false);
             }
         });
+        // If signaling is still connected but DC closed, attempt a client re-offer
+        if (Config.Role == EO3DSWebRtcRole::Client && bStarted.load() && bSignalingConnected.load())
+        {
+            UE_LOG(LogTemp, Log, TEXT("[LibDC] DataChannel closed while signaling connected; forcing client re-offer"));
+            ForceClientReoffer();
+            StartClientOfferRetryPump();
+        }
     });
     DC->onMessage([this, Weak](auto M)
     {
@@ -790,6 +963,10 @@ void FLibDataChannelConnector::SendJson(const TSharedPtr<FJsonObject>& Obj)
 
 void FLibDataChannelConnector::HandleIncomingJson(const FString& JsonStr)
 {
+    if (!bStarted.load())
+    {
+        return; // ignore stray signaling after Stop()
+    }
     TSharedPtr<FJsonObject> Obj;
     TSharedRef<TJsonReader<>> R = TJsonReaderFactory<>::Create(JsonStr);
     if (!FJsonSerializer::Deserialize(R, Obj) || !Obj.IsValid()) return;
@@ -811,6 +988,7 @@ void FLibDataChannelConnector::HandleIncomingJson(const FString& JsonStr)
             {
                 PC->setRemoteDescription(rtc::Description(ToStd(Sdp), "answer"));
                 bRemoteDescriptionSet = true;
+                StopClientOfferRetryPump();
                 for (const FQueuedCand& C : PendingCandidates)
                 {
                     try { PC->addRemoteCandidate(rtc::Candidate(C.Cand, C.Mid)); } catch (...) {}
@@ -842,20 +1020,24 @@ void FLibDataChannelConnector::HandleIncomingJson(const FString& JsonStr)
         if (Type == TEXT("offer"))
         {
             RemotePeerId = Obj->GetStringField(TEXT("id"));
-            if (!PC)
+            // Always recreate a fresh PeerConnection for a new offer to avoid invalid states after disconnects
+            ResetPeerConnection();
             {
                 rtc::Configuration Cfg;
                 SetupPeerConnection(Cfg);
             }
             const FString Sdp = Obj->GetStringField(TEXT("description"));
-            PC->setRemoteDescription(rtc::Description(ToStd(Sdp), "offer"));
-            bRemoteDescriptionSet = true;
-            for (const FQueuedCand& C : PendingCandidates)
+            if (PC)
             {
-                try { PC->addRemoteCandidate(rtc::Candidate(C.Cand, C.Mid)); } catch (...) {}
+                try { PC->setRemoteDescription(rtc::Description(ToStd(Sdp), "offer")); } catch (...) { return; }
+                bRemoteDescriptionSet = true;
+                for (const FQueuedCand& C : PendingCandidates)
+                {
+                    try { PC->addRemoteCandidate(rtc::Candidate(C.Cand, C.Mid)); } catch (...) {}
+                }
+                PendingCandidates.Reset();
+                try { PC->createAnswer(); } catch (...) { /* swallow and wait for next offer */ }
             }
-            PendingCandidates.Reset();
-            PC->createAnswer();
         }
         else if (Type == TEXT("candidate"))
         {

--- a/plugins/unreal/Open3DStream/Source/Open3DShared/Private/LibDataChannelConnector.h
+++ b/plugins/unreal/Open3DStream/Source/Open3DShared/Private/LibDataChannelConnector.h
@@ -48,6 +48,17 @@ private:
     void SetupPeerConnection(const rtc::Configuration& Cfg);
     void CreateClientMediaAndDC();
     void AttachRecvAudioCallbacks(const std::shared_ptr<rtc::Track>& Track);
+    // Reset only the peer/media objects (keep signaling socket). Call on game thread before re-offer handling.
+    void ResetPeerConnection();
+
+    // Client role: retry offer if no answer arrives (handles client-starts-before-server)
+    void StartClientOfferRetryPump();
+    void StopClientOfferRetryPump();
+    void ForceClientReoffer();
+
+    // Signaling reconnect (handles server restarts after initial connect)
+    void StartSignalingReconnectPump();
+    void StopSignalingReconnectPump();
 
     void SendJson(const TSharedPtr<class FJsonObject>& Obj);
     void HandleIncomingJson(const FString& JsonStr);
@@ -95,4 +106,15 @@ private:
      struct FQueuedCand { std::string Cand; std::string Mid; };
      bool bRemoteDescriptionSet = false;
      TArray<FQueuedCand> PendingCandidates; // accessed on game thread only
+
+    // Client-side re-offer
+    std::atomic<bool> bOfferRetryPump{false};
+    std::thread OfferRetryThread;
+    int OfferRetryAttempt = 0;
+
+    // Signaling reconnect state
+    std::atomic<bool> bSignalingReconnectPump{false};
+    std::thread SignalingReconnectThread;
+    int SignalingReconnectAttempt = 0;
+    std::atomic<bool> bSignalingConnected{false};
 };

--- a/plugins/unreal/Open3DStream/Source/Open3DStream/Private/O3DSAudioDebugCommands.cpp
+++ b/plugins/unreal/Open3DStream/Source/Open3DStream/Private/O3DSAudioDebugCommands.cpp
@@ -1,0 +1,57 @@
+// Copyright (c) Open3DStream Contributors
+
+#include "CoreMinimal.h"
+#include "HAL/IConsoleManager.h"
+#include "O3DSAudioBus.h"
+#include "O3DSUnifiedMessage.h"
+#include "Async/Async.h"
+
+// Console: o3ds.AudioBus.TestTone [Seconds] [FrequencyHz] [Gain]
+// Publishes a simple sine wave via FO3DSAudioBus with a Mix-mode stream label so
+// UO3DSRemoteAudioComponent (Mix) will accept it. Useful to isolate AudioBus->Playback.
+static void O3DSTestTone_Exec(const TArray<FString>& Args)
+{
+    const int32 SampleRate = 48000;
+    int32 Seconds = 2;
+    float Freq = 440.0f;
+    float Gain = 0.5f; // 50% to avoid clipping
+
+    if (Args.Num() > 0) { Seconds = FMath::Clamp(FCString::Atoi(*Args[0]), 1, 10); }
+    if (Args.Num() > 1) { Freq = FMath::Clamp(FCString::Atof(*Args[1]), 50.0f, 4000.0f); }
+    if (Args.Num() > 2) { Gain = FMath::Clamp(FCString::Atof(*Args[2]), 0.0f, 2.0f); }
+
+    const int32 TotalFrames = Seconds * SampleRate;
+    const int32 Channels = 1;
+    TArray<int16> PCM16;
+    PCM16.AddUninitialized(TotalFrames * Channels);
+
+    const double TwoPi = 2.0 * PI;
+    for (int32 n = 0; n < TotalFrames; ++n)
+    {
+        const double t = static_cast<double>(n) / static_cast<double>(SampleRate);
+        const double s = FMath::Sin(TwoPi * Freq * t) * Gain;
+        const int16 v = static_cast<int16>(FMath::Clamp(s, -1.0, 1.0) * 32767.0);
+        PCM16[n] = v;
+    }
+
+    AsyncTask(ENamedThreads::GameThread, [PCM16 = MoveTemp(PCM16), Channels, SampleRate]()
+    {
+        O3DS::FAudioFrameMeta Meta;
+        Meta.StreamLabel = TEXT("o3ds:mix:test");
+        Meta.SubjectName = TEXT("TestTone");
+        Meta.NumChannels = Channels;
+        Meta.SampleRate = SampleRate;
+        Meta.TimestampSec = 0.0;
+
+        const uint8* Bytes = reinterpret_cast<const uint8*>(PCM16.GetData());
+        const int32 NumBytes = PCM16.Num() * sizeof(int16);
+        FO3DSAudioBus::PublishPcm16(Meta, Bytes, NumBytes);
+
+        UE_LOG(LogTemp, Log, TEXT("O3DS AudioBus: Published TestTone %d frames @ %d Hz"), PCM16.Num() / Channels, SampleRate);
+    });
+}
+
+static FAutoConsoleCommand O3DSCmd_TestTone(
+    TEXT("o3ds.AudioBus.TestTone"),
+    TEXT("Publish a sine test tone onto O3DS AudioBus. Usage: o3ds.AudioBus.TestTone [Seconds=2] [FreqHz=440] [Gain=0.5]"),
+    FConsoleCommandWithArgsDelegate::CreateStatic(&O3DSTestTone_Exec));

--- a/plugins/unreal/Open3DStream/Source/Open3DStream/Private/O3DSRemoteAudioComponent.cpp
+++ b/plugins/unreal/Open3DStream/Source/Open3DStream/Private/O3DSRemoteAudioComponent.cpp
@@ -6,6 +6,7 @@
 #include "Components/AudioComponent.h"
 #include "O3DSAudioBus.h"
 #include "O3DSUnifiedMessage.h"
+#include "O3DSStreamLogs.h"
 // Needed for AActor definition used by GetOwner() and attachment calls
 #include "GameFramework/Actor.h"
 
@@ -38,15 +39,40 @@ void UO3DSRemoteAudioComponent::BeginPlay()
 				{
 					AudioComp->AttachToComponent(GetOwner()->GetRootComponent(), FAttachmentTransformRules::KeepRelativeTransform);
 				}
+				// Ensure 2D playback so it's audible regardless of listener position
+				AudioComp->bAllowSpatialization = false;
+				AudioComp->bIsUISound = true;
+				// Apply initial gain
+				AudioComp->SetVolumeMultiplier(FMath::Max(0.0f, Gain));
 			}
+		}
+		else
+		{
+			// If an existing component was found, make sure settings are friendly for remote 2D playback
+			AudioComp->bAllowSpatialization = false;
+			AudioComp->bIsUISound = true;
+			AudioComp->SetVolumeMultiplier(FMath::Max(0.0f, Gain));
 		}
 	}
 
 	// Subscribe to global audio bus published by the network receiver
 	BusDelegateHandle = FO3DSAudioBus::OnPcm16().AddUObject(this, &UO3DSRemoteAudioComponent::OnAudioPcm16);
+	// Always emit a single confirmation log so users can verify subscription without CVars
+	{
+		static bool bOnce = false;
+		if (!bOnce)
+		{
+			bOnce = true;
+			UE_LOG(LogO3DSReceiverAudio, Log, TEXT("Subscribed to FO3DSAudioBus (Gain=%.2f, AutoCreateAudioComp=%d)"), Gain, bAutoCreateAudioComponent ? 1 : 0);
+			if (!AudioComp)
+			{
+				UE_LOG(LogO3DSReceiverAudio, Warning, TEXT("No UAudioComponent present/created on owner '%s'"), *GetOwner()->GetName());
+			}
+		}
+	}
 	if (CVarO3DSRemoteAudioDebug->GetInt() !=0)
 	{
-		UE_LOG(LogTemp, Log, TEXT("O3DS RemoteAudio: Subscribed to FO3DSAudioBus"));
+		UE_LOG(LogO3DSReceiverAudio, Log, TEXT("Debug enabled"));
 	}
 }
 
@@ -77,7 +103,7 @@ bool UO3DSRemoteAudioComponent::MatchesFilter(const FString& InSubject, const FS
 	if (!StreamLabelFilter.IsEmpty() && !InStream.Contains(StreamLabelFilter)) return false;
 	if (CVarO3DSRemoteAudioDebug->GetInt() !=0)
 	{
-		UE_LOG(LogTemp, Verbose, TEXT("O3DS RemoteAudio: Filter pass subject='%s' stream='%s'"), *InSubject, *InStream);
+		UE_LOG(LogO3DSReceiverAudio, Verbose, TEXT("Filter pass subject='%s' stream='%s'"), *InSubject, *InStream);
 	}
 	return true;
 }
@@ -95,6 +121,8 @@ void UO3DSRemoteAudioComponent::EnsureSoundWave(int32 NumChannels, int32 SampleR
 			SoundWave->SetSampleRate(SampleRate);
 			SoundWave->Duration = INDEFINITELY_LOOPING_DURATION;
 			SoundWave->SoundGroup = SOUNDGROUP_Voice;
+			// Explicitly mark as procedural/streaming source
+			SoundWave->bProcedural = true;
 		}
 		CurrentChannels = NumChannels;
 		CurrentSampleRate = SampleRate;
@@ -106,9 +134,11 @@ void UO3DSRemoteAudioComponent::EnsureSoundWave(int32 NumChannels, int32 SampleR
 			{
 				AudioComp->Play();
 			}
+			// Ensure current gain is applied whenever we swap sound waves
+			AudioComp->SetVolumeMultiplier(FMath::Max(0.0f, Gain));
 			if (CVarO3DSRemoteAudioDebug->GetInt() !=0)
 			{
-				UE_LOG(LogTemp, Log, TEXT("O3DS RemoteAudio: SoundWave prepared ch=%d sr=%d; AudioComp playing=%d"),
+				UE_LOG(LogO3DSReceiverAudio, Log, TEXT("SoundWave prepared ch=%d sr=%d; AudioComp playing=%d"),
 					NumChannels, SampleRate, AudioComp->IsPlaying()?1:0);
 			}
 		}
@@ -123,7 +153,7 @@ void UO3DSRemoteAudioComponent::OnAudioFrame(const FString& StreamLabel, const F
 		{
 			static int32 DropEvery =0; if ((DropEvery++ %100) ==0)
 			{
-				UE_LOG(LogTemp, Verbose, TEXT("O3DS RemoteAudio: Dropped frame by filter subject='%s' stream='%s'"), *SubjectName, *StreamLabel);
+				UE_LOG(LogO3DSReceiverAudio, Verbose, TEXT("Dropped frame by filter subject='%s' stream='%s'"), *SubjectName, *StreamLabel);
 			}
 		}
 		return;
@@ -150,7 +180,7 @@ void UO3DSRemoteAudioComponent::OnAudioFrame(const FString& StreamLabel, const F
 	{
 		static int32 LogEvery =0; if ((LogEvery++ %50) ==0)
 		{
-			UE_LOG(LogTemp, Verbose, TEXT("O3DS RemoteAudio: Queued frames=%d ch=%d sr=%d stream='%s' subject='%s'"),
+			UE_LOG(LogO3DSReceiverAudio, Verbose, TEXT("Queued frames=%d ch=%d sr=%d stream='%s' subject='%s'"),
 				NumFrames, NumChannels, SampleRate, *StreamLabel, *SubjectName);
 		}
 	}
@@ -174,6 +204,24 @@ void UO3DSRemoteAudioComponent::OnAudioPcm16(const O3DS::FAudioFrameMeta& Meta, 
 	if (!SoundWave)
 	{
 		return;
+	}
+	// One-time confirmation log on first received frame
+	{
+		static bool bFirstFrame = false;
+		if (!bFirstFrame)
+		{
+			bFirstFrame = true;
+			UE_LOG(LogO3DSReceiverAudio, Log, TEXT("First PCM16 frame received (%d samples) stream='%s' subject='%s'"), NumSamples, *StreamLabel, *SubjectName);
+		}
+	}
+	// Keep audio component volume in sync with Gain slider
+	if (AudioComp)
+	{
+		AudioComp->SetVolumeMultiplier(FMath::Max(0.0f, Gain));
+		if (!AudioComp->IsPlaying())
+		{
+			AudioComp->Play();
+		}
 	}
 	SoundWave->QueueAudio(const_cast<uint8*>(PCM16Bytes.GetData()), PCM16Bytes.Num());
 }

--- a/plugins/unreal/Open3DStream/Source/Open3DStream/Private/Open3DStream.cpp
+++ b/plugins/unreal/Open3DStream/Source/Open3DStream/Private/Open3DStream.cpp
@@ -1,6 +1,7 @@
 // Copyright Epic Games, Inc. All Rights Reserved.
 
 #include "Open3DStream.h"
+#include "O3DSStreamLogs.h"
 #include "O3DSLoopback.h"
 #include "Modules/ModuleManager.h"
 #include "Features/IModularFeatures.h"
@@ -10,10 +11,15 @@
 
 #define LOCTEXT_NAMESPACE "FOpen3DStreamModule"
 
+// Define receiver-specific log categories
+DEFINE_LOG_CATEGORY(LogO3DSReceiver);
+DEFINE_LOG_CATEGORY(LogO3DSReceiverWebRTC);
+DEFINE_LOG_CATEGORY(LogO3DSReceiverAudio);
+
 void FOpen3DStreamModule::StartupModule()
 {
 	// This code will execute after your module is loaded into memory; the exact timing is specified in the .uplugin file per-module
-	UE_LOG(LogTemp, Display, TEXT("Open3DStream module started"));
+	UE_LOG(LogO3DSReceiver, Display, TEXT("Open3DStream module started"));
 
 	// Register loopback consumer factory so Broadcast can forward serialized frames without a hard dependency
 	FSerializedFrameConsumerRegistry::RegisterFactory([]() -> TSharedPtr<ISerializedFrameConsumer>

--- a/plugins/unreal/Open3DStream/Source/Open3DStream/Private/Open3DStreamSource.cpp
+++ b/plugins/unreal/Open3DStream/Source/Open3DStream/Private/Open3DStreamSource.cpp
@@ -12,6 +12,7 @@
 #include "UnrealModel.h"
 #include "o3ds/model.h"
 #include "WebRTC/Open3DSWebRtcReceiver.h"
+#include "O3DSStreamLogs.h"
 
 //#include "get_time.h"
 using namespace O3DS::Data;
@@ -81,7 +82,7 @@ FOpen3DStreamSource::FOpen3DStreamSource(const FOpen3DStreamSettings& Settings)
  if (!bLoggedBind)
  {
  bLoggedBind = true;
- UE_LOG(LogTemp, Log, TEXT("O3DS RX: LiveLink OnData bound in Open3DStreamSource"));
+ UE_LOG(LogO3DSReceiver, Log, TEXT("LiveLink OnData bound in Open3DStreamSource"));
  }
 }
 
@@ -138,7 +139,7 @@ void FOpen3DStreamSource::ReceiveClient(ILiveLinkClient* InClient, FGuid InSourc
 	 const FString Normalized = O3DSHelpers::NormalizeTcpUrlHostPort(U);
 	 if (!Normalized.Equals(U))
 	 {
-		 UE_LOG(LogTemp, Log, TEXT("O3DS RX: Normalized URL '%s' -> '%s'"), *U, *Normalized);
+		 UE_LOG(LogO3DSReceiver, Log, TEXT("Normalized URL '%s' -> '%s'"), *U, *Normalized);
 		 Url = FText::FromString(Normalized);
 	 }
  }
@@ -219,7 +220,7 @@ void FOpen3DStreamSource::OnPackage(const TArray<uint8>& data)
  for (int32 i =0; i < DumpN; ++i) { Hex += FString::Printf(TEXT("%02X "), data[i]); }
  static const uint8 Magic[14] = {0x00,0xFF,0x03,0xFE,'O','3','D','S','-','S','T','A','R','T'};
  const bool bTcpMagic = (data.Num() >=14) && (FMemory::Memcmp(data.GetData(), Magic,14) ==0);
- UE_LOG(LogTemp, Verbose, TEXT("O3DS Receiver: packet bytes=%d tcp_magic=%s first_%d=%s"), data.Num(), bTcpMagic?TEXT("true"):TEXT("false"), DumpN, *Hex);
+ UE_LOG(LogO3DSReceiver, Verbose, TEXT("packet bytes=%d tcp_magic=%s first_%d=%s"), data.Num(), bTcpMagic?TEXT("true"):TEXT("false"), DumpN, *Hex);
  }
 
  // Parse O3DS buffer (non-TCP transports provide raw payload without TCP magic)
@@ -228,7 +229,7 @@ void FOpen3DStreamSource::OnPackage(const TArray<uint8>& data)
  OnStatus(LOCTEXT("DataError", "Data Error"), true);
  if (CVarO3DSReceiverDebugParse->GetInt() !=0)
  {
- UE_LOG(LogTemp, Warning, TEXT("O3DS Receiver: Parse failed (bytes=%d)"), data.Num());
+ UE_LOG(LogO3DSReceiver, Warning, TEXT("Parse failed (bytes=%d)"), data.Num());
  }
  return;
  }
@@ -237,7 +238,7 @@ void FOpen3DStreamSource::OnPackage(const TArray<uint8>& data)
  {
  int32 Count =0;
  for (auto* S : mSubjects) { (void)S; ++Count; }
- UE_LOG(LogTemp, Verbose, TEXT("O3DS Receiver: Parse OK subjects=%d time=%.6f"), Count, mSubjects.mTime);
+ UE_LOG(LogO3DSReceiver, Verbose, TEXT("Parse OK subjects=%d time=%.6f"), Count, mSubjects.mTime);
  }
 
  TArray<FName> BoneNames;
@@ -360,11 +361,11 @@ void FOpen3DStreamSource::OnPackage(const TArray<uint8>& data)
  if (InitializedSubjects.Find(SubjectName) == INDEX_NONE)
  {
  InitializedSubjects.Add(SubjectName);
- UE_LOG(LogTemp, Log, TEXT("O3DS Receiver: Created subject '%s'"), *SubjectName.Name.ToString());
+ UE_LOG(LogO3DSReceiver, Log, TEXT("Created subject '%s'"), *SubjectName.Name.ToString());
  }
  else
  {
- UE_LOG(LogTemp, Log, TEXT("O3DS Receiver: Static data updated for subject '%s' (bones/curves changed)"), *SubjectName.Name.ToString());
+ UE_LOG(LogO3DSReceiver, Log, TEXT("Static data updated for subject '%s' (bones/curves changed)"), *SubjectName.Name.ToString());
  }
 
  SubjectSkeletonHash.FindOrAdd(SubjectName.Name) = NewSkelHash;

--- a/plugins/unreal/Open3DStream/Source/Open3DStream/Private/SOpen3DStreamFactory.cpp
+++ b/plugins/unreal/Open3DStream/Source/Open3DStream/Private/SOpen3DStreamFactory.cpp
@@ -1,6 +1,8 @@
 #include "SOpen3DStreamFactory.h"
 #include "Widgets/Input/SEditableTextBox.h"
 #include "Widgets/Input/SButton.h"
+#include "Widgets/Input/SCheckBox.h"
+#include "Widgets/Input/SSpinBox.h"
 #include "Widgets/Text/STextBlock.h"
 
 #include "Open3DStreamSource.h"
@@ -182,6 +184,49 @@ void SOpen3DStreamFactory::Construct(const FArguments& Args)
 				.OnTextChanged(this, &SOpen3DStreamFactory::SetLiveKitToken)
 			]
 		]
+		// WebRTC Audio Enable
+		+ SVerticalBox::Slot()
+		.Padding(5)
+		.AutoHeight()
+		[
+			SAssignNew(WebRtcAudioRow, SHorizontalBox)
+			.Visibility(this, &SOpen3DStreamFactory::GetWebRtcBackendVisibility)
+			+ SHorizontalBox::Slot()
+			.FillWidth(0.3f)
+			[
+				SNew(STextBlock).Text(LOCTEXT("EnableWebRTCAudio", "Enable WebRTC Audio")).MinDesiredWidth(200)
+			]
+			+ SHorizontalBox::Slot()
+			.FillWidth(0.7f)
+			.HAlign(HAlign_Left)
+			[
+				SNew(SCheckBox)
+				.IsChecked(this, &SOpen3DStreamFactory::GetEnableWebRTCAudioState)
+				.OnCheckStateChanged(this, &SOpen3DStreamFactory::OnEnableWebRTCAudioChanged)
+			]
+		]
+		// Audio Playout Delay
+		+ SVerticalBox::Slot()
+		.Padding(5)
+		.AutoHeight()
+		[
+			SAssignNew(AudioDelayRow, SHorizontalBox)
+			.Visibility(this, &SOpen3DStreamFactory::GetWebRtcBackendVisibility)
+			+ SHorizontalBox::Slot()
+			.FillWidth(0.3f)
+			[
+				SNew(STextBlock).Text(LOCTEXT("AudioPlayoutDelay", "Audio Playout Delay (ms)")).MinDesiredWidth(200)
+			]
+			+ SHorizontalBox::Slot()
+			.FillWidth(0.7f)
+			[
+				SNew(SSpinBox<int32>)
+				.MinValue(0)
+				.MaxValue(500)
+				.Value(this, &SOpen3DStreamFactory::GetAudioPlayoutDelay)
+				.OnValueChanged(this, &SOpen3DStreamFactory::OnAudioPlayoutDelayChanged)
+			]
+		]
 		// Key
 		//+ SVerticalBox::Slot()
 		//.Padding(5)
@@ -356,23 +401,21 @@ FReply SOpen3DStreamFactory::OnSource()
 	FString EffectiveUrl = NormalizeUrlForFamily(InputUrl, FamilyStr, ModeStr);
 	const FString ProtocolName = ComputeProtocolFor(FamilyStr, ModeStr);
 
-	// For WebRTC, compose URL with room/role consistently
+	// For WebRTC: do NOT append room to URL for LibDataChannel backend in server mode.
+	// LibDataChannelConnector will handle path construction from Config.Room.
+	// For LiveKit or other backends, query params may be needed.
+	// For now, keep URL clean and pass Room separately via Settings->WebRtcRoom.
 	if (FamilyStr.Equals(TEXT("WebRTC"), ESearchCase::IgnoreCase))
 	{
 		if (EffectiveUrl.EndsWith(TEXT("/"))) { EffectiveUrl.LeftChopInline(1); }
-		// P2P uses path /<room>; LiveKit uses ?room= param – unify on query param to avoid clashes
-		if (!EffectiveUrl.Contains(TEXT("room=")))
-		{
-			EffectiveUrl += EffectiveUrl.Contains(TEXT("?"))
-				? FString::Printf(TEXT("&room=%s"), *Room)
-				: FString::Printf(TEXT("?room=%s"), *Room);
-		}
+		// Room will be passed separately in Settings->WebRtcRoom
+		// LibDataChannelConnector handles URL construction based on Role
 	}
 
 	Settings->Url = FText::FromString(EffectiveUrl);
 	Settings->Protocol = FText::FromString(ProtocolName);
 
-	// Populate WebRTC backend and LiveKit configuration
+	// Populate WebRTC backend and LiveLink configuration
 	if (FamilyStr.Equals(TEXT("WebRTC"), ESearchCase::IgnoreCase))
 	{
 		Settings->WebRtcRoom = Room;
@@ -391,6 +434,10 @@ FReply SOpen3DStreamFactory::OnSource()
 	{
 		Settings->WebRtcBackend = EO3DSWebRtcBackendReceiver::LibDataChannel;
 	}
+
+	// Populate audio settings
+	Settings->bEnableWebRTCAudio = bEnableWebRTCAudio;
+	Settings->WebRTCAudioPlayoutDelayMs = WebRTCAudioPlayoutDelayMs;
 	
 	OnSelectedEvent.ExecuteIfBound(Settings);
 	return FReply::Handled();

--- a/plugins/unreal/Open3DStream/Source/Open3DStream/Private/WebRTC/O3DSOpusDecoder.cpp
+++ b/plugins/unreal/Open3DStream/Source/Open3DStream/Private/WebRTC/O3DSOpusDecoder.cpp
@@ -3,6 +3,7 @@
 #include "WebRTC/O3DSOpusDecoder.h"
 #include "O3DSAudioBus.h"
 #include "O3DSUnifiedMessage.h"
+#include "O3DSStreamLogs.h"
 #include "Async/Async.h"
 #include "HAL/PlatformTime.h"
 
@@ -36,7 +37,7 @@ bool FO3DSOpusDecoder::Initialize(int32 InSampleRate, int32 InNumChannels)
     // For MVP, only support 48 kHz
     if (InSampleRate != 48000)
     {
-        UE_LOG(LogTemp, Error, TEXT("O3DS Opus Decoder: unsupported sample rate %d (only 48000 supported)"), InSampleRate);
+        UE_LOG(LogO3DSReceiverAudio, Error, TEXT("unsupported sample rate %d (only 48000 supported)"), InSampleRate);
         return false;
     }
 
@@ -48,7 +49,7 @@ bool FO3DSOpusDecoder::Initialize(int32 InSampleRate, int32 InNumChannels)
     Decoder = opus_decoder_create(SampleRate, NumChannels, &Error);
     if (Error != OPUS_OK || !Decoder)
     {
-        UE_LOG(LogTemp, Error, TEXT("O3DS Opus Decoder: opus_decoder_create failed (error=%d)"), Error);
+        UE_LOG(LogO3DSReceiverAudio, Error, TEXT("opus_decoder_create failed (error=%d)"), Error);
         return false;
     }
 
@@ -57,7 +58,7 @@ bool FO3DSOpusDecoder::Initialize(int32 InSampleRate, int32 InNumChannels)
 
     if (CVarO3DSReceiverAudioLog->GetInt() != 0)
     {
-        UE_LOG(LogTemp, Log, TEXT("O3DS Opus Decoder: initialized (rate=%d, channels=%d, frame=%d samples)"),
+        UE_LOG(LogO3DSReceiverAudio, Log, TEXT("initialized (rate=%d, channels=%d, frame=%d samples)"),
             SampleRate, NumChannels, FrameSizeSamples);
     }
 
@@ -73,7 +74,7 @@ void FO3DSOpusDecoder::Shutdown()
 
         if (CVarO3DSReceiverAudioLog->GetInt() != 0)
         {
-            UE_LOG(LogTemp, Log, TEXT("O3DS Opus Decoder: shutdown"));
+            UE_LOG(LogO3DSReceiverAudio, Log, TEXT("shutdown"));
         }
     }
 }
@@ -95,7 +96,7 @@ void FO3DSOpusDecoder::DecodeRtpPacket(const TArray<uint8>& RtpBytes)
         const double Now = FPlatformTime::Seconds();
         if (Now - LastErrorLogTime > ErrorLogThrottleSec)
         {
-            UE_LOG(LogTemp, Warning, TEXT("O3DS Opus Decoder: invalid RTP packet (size=%d)"), RtpBytes.Num());
+            UE_LOG(LogO3DSReceiverAudio, Warning, TEXT("invalid RTP packet (size=%d)"), RtpBytes.Num());
             LastErrorLogTime = Now;
         }
         return;
@@ -107,7 +108,7 @@ void FO3DSOpusDecoder::DecodeRtpPacket(const TArray<uint8>& RtpBytes)
         const double Now = FPlatformTime::Seconds();
         if (Now - LastErrorLogTime > ErrorLogThrottleSec)
         {
-            UE_LOG(LogTemp, Warning, TEXT("O3DS Opus Decoder: unexpected payload type %d (expected 111)"), PayloadType);
+            UE_LOG(LogO3DSReceiverAudio, Warning, TEXT("unexpected payload type %d (expected 111)"), PayloadType);
             LastErrorLogTime = Now;
         }
         return;
@@ -128,7 +129,7 @@ void FO3DSOpusDecoder::DecodeRtpPacket(const TArray<uint8>& RtpBytes)
         const double Now = FPlatformTime::Seconds();
         if (Now - LastErrorLogTime > ErrorLogThrottleSec)
         {
-            UE_LOG(LogTemp, Warning, TEXT("O3DS Opus Decoder: opus_decode failed (error=%d)"), SamplesDecoded);
+            UE_LOG(LogO3DSReceiverAudio, Warning, TEXT("opus_decode failed (error=%d)"), SamplesDecoded);
             LastErrorLogTime = Now;
         }
         return;
@@ -136,7 +137,7 @@ void FO3DSOpusDecoder::DecodeRtpPacket(const TArray<uint8>& RtpBytes)
 
     if (CVarO3DSReceiverAudioLog->GetInt() != 0)
     {
-        UE_LOG(LogTemp, Verbose, TEXT("O3DS Opus Decoder: decoded %d samples (payload=%d bytes, ts=%u)"),
+        UE_LOG(LogO3DSReceiverAudio, Verbose, TEXT("decoded %d samples (payload=%d bytes, ts=%u)"),
             SamplesDecoded, PayloadLen, Timestamp);
     }
 
@@ -199,7 +200,8 @@ void FO3DSOpusDecoder::PublishAudio(const int16* Samples, int32 NumSamples, uint
     {
         // Build metadata for Audio Bus
         O3DS::FAudioFrameMeta Meta;
-        Meta.StreamLabel = TEXT("o3ds:webrtc:remote");
+        // Use a stream label that passes the RemoteAudio Mix-mode filter (starts with "o3ds:mix")
+        Meta.StreamLabel = TEXT("o3ds:mix:webrtc");
         Meta.SubjectName = TEXT("WebRTC");
         Meta.NumChannels = LocalChannels;
         Meta.SampleRate = LocalRate;
@@ -213,7 +215,7 @@ void FO3DSOpusDecoder::PublishAudio(const int16* Samples, int32 NumSamples, uint
 
         if (CVarO3DSReceiverAudioLog->GetInt() != 0)
         {
-            UE_LOG(LogTemp, Verbose, TEXT("O3DS Opus Decoder: published %d samples (%d bytes) to Audio Bus"),
+            UE_LOG(LogO3DSReceiverAudio, Verbose, TEXT("published %d samples (%d bytes) to Audio Bus"),
                 SamplesCopy.Num(), NumBytes);
         }
     });

--- a/plugins/unreal/Open3DStream/Source/Open3DStream/Private/WebRTC/Open3DSWebRtcReceiver.cpp
+++ b/plugins/unreal/Open3DStream/Source/Open3DStream/Private/WebRTC/Open3DSWebRtcReceiver.cpp
@@ -1,6 +1,7 @@
 // Copyright Epic Games, Inc. All Rights Reserved.
 
 #include "WebRTC/Open3DSWebRtcReceiver.h"
+#include "O3DSStreamLogs.h"
 #include "WebRTC/O3DSOpusDecoder.h"
 #include "Open3DStreamSourceSettings.h"
 #include "WebRTCConnectorFactory.h"
@@ -11,6 +12,21 @@ static TAutoConsoleVariable<int32> CVarO3DSReceiverWebRtcLog(
     TEXT("o3ds.Receiver.WebRTC.Log"),
     0,
     TEXT("Enable verbose logging for WebRTC receiver adapter (0/1)."),
+    ECVF_Default);
+static TAutoConsoleVariable<int32> CVarO3DSReceiverWebRtcLogDataContent(
+    TEXT("o3ds.Receiver.WebRTC.LogDataContent"),
+    0,
+    TEXT("When 1, log the received DataChannel payload as hex (first 64 bytes)."),
+    ECVF_Default);
+static TAutoConsoleVariable<int32> CVarO3DSReceiverWebRtcLogDataCount(
+    TEXT("o3ds.Receiver.WebRTC.LogDataCount"),
+    0,
+    TEXT("When 1, log only the number of bytes received on the DataChannel."),
+    ECVF_Default);
+static TAutoConsoleVariable<int32> CVarO3DSReceiverWebRtcLogAudioRtp(
+    TEXT("o3ds.Receiver.WebRTC.LogAudioRtp"),
+    0,
+    TEXT("When 1, log received RTP audio packet sizes."),
     ECVF_Default);
 
 FOpen3DSWebRtcReceiver::FOpen3DSWebRtcReceiver()
@@ -26,7 +42,7 @@ bool FOpen3DSWebRtcReceiver::Start(const FOpen3DStreamSettings& Settings)
 {
     if (bStarted)
     {
-        UE_LOG(LogTemp, Warning, TEXT("O3DS WebRTC Receiver: already started"));
+        UE_LOG(LogO3DSReceiverWebRTC, Warning, TEXT("already started"));
         return false;
     }
 
@@ -38,7 +54,7 @@ bool FOpen3DSWebRtcReceiver::Start(const FOpen3DStreamSettings& Settings)
     Connector = FWebRTCConnectorFactory::Create(Backend);
     if (!Connector)
     {
-        UE_LOG(LogTemp, Error, TEXT("O3DS WebRTC Receiver: failed to create connector for backend"));
+        UE_LOG(LogO3DSReceiverWebRTC, Error, TEXT("failed to create connector for backend"));
         return false;
     }
 
@@ -46,8 +62,14 @@ bool FOpen3DSWebRtcReceiver::Start(const FOpen3DStreamSettings& Settings)
     FO3DSWebRtcConfig Config;
     Config.Backend = EO3DSWebRtcBackend::LibDataChannel;
     Config.Role = EO3DSWebRtcRole::Server;
+    
+    // For server role, ensure the URL is normalized per LibDataChannelConnector expectations:
+    // The Room will be moved into the WebSocket path (e.g., ws://host:port/<Room>)
+    // and query parameters will be stripped by the connector's OpenWebSocket() logic.
+    // Just pass the base signaling URL and let the connector handle path construction.
     Config.SignalingUrl = Settings.Url.ToString();
     Config.Room = Settings.WebRtcRoom;
+    
     Config.bEnableAudio = Settings.bEnableWebRTCAudio;
     Config.SampleRate = 48000;
     Config.NumChannels = 1;
@@ -61,7 +83,7 @@ bool FOpen3DSWebRtcReceiver::Start(const FOpen3DStreamSettings& Settings)
     // Start connector
     if (!Connector->Start(Config))
     {
-        UE_LOG(LogTemp, Error, TEXT("O3DS WebRTC Receiver: failed to start connector"));
+        UE_LOG(LogO3DSReceiverWebRTC, Error, TEXT("failed to start connector"));
         return false;
     }
 
@@ -71,12 +93,14 @@ bool FOpen3DSWebRtcReceiver::Start(const FOpen3DStreamSettings& Settings)
         OpusDecoder = MakeShared<FO3DSOpusDecoder>();
         if (!OpusDecoder->Initialize(Config.SampleRate, Config.NumChannels))
         {
-            UE_LOG(LogTemp, Error, TEXT("O3DS WebRTC Receiver: failed to initialize Opus decoder"));
+            UE_LOG(LogO3DSReceiverAudio, Error, TEXT("failed to initialize Opus decoder"));
             OpusDecoder.Reset();
         }
         else
         {
             bAudioEnabled = true;
+            // Always log once so users can confirm audio decode path enabled
+            UE_LOG(LogO3DSReceiverAudio, Log, TEXT("Audio enabled (sr=%d ch=%d)"), Config.SampleRate, Config.NumChannels);
         }
     }
 
@@ -84,7 +108,7 @@ bool FOpen3DSWebRtcReceiver::Start(const FOpen3DStreamSettings& Settings)
 
     if (CVarO3DSReceiverWebRtcLog->GetInt() != 0)
     {
-        UE_LOG(LogTemp, Log, TEXT("O3DS WebRTC Receiver: started (audio=%s)"),
+        UE_LOG(LogO3DSReceiverWebRTC, Log, TEXT("started (audio=%s)"),
             bAudioEnabled ? TEXT("enabled") : TEXT("disabled"));
     }
 
@@ -115,7 +139,7 @@ void FOpen3DSWebRtcReceiver::Stop()
 
     if (CVarO3DSReceiverWebRtcLog->GetInt() != 0)
     {
-        UE_LOG(LogTemp, Log, TEXT("O3DS WebRTC Receiver: stopped"));
+        UE_LOG(LogO3DSReceiverWebRTC, Log, TEXT("stopped"));
     }
 }
 
@@ -149,7 +173,7 @@ void FOpen3DSWebRtcReceiver::OnConnectorState(const FString& State, bool bIsErro
     {
         if (CVarO3DSReceiverWebRtcLog->GetInt() != 0)
         {
-            UE_LOG(LogTemp, Log, TEXT("O3DS WebRTC Receiver: state=%s error=%d"), *State, bIsError ? 1 : 0);
+            UE_LOG(LogO3DSReceiverWebRTC, Log, TEXT("state=%s error=%d"), *State, bIsError ? 1 : 0);
         }
 
         if (OnStateCallback)
@@ -164,9 +188,31 @@ void FOpen3DSWebRtcReceiver::OnConnectorData(const TArray<uint8>& Bytes)
     // Marshal to game thread and forward to source parsing
     AsyncTask(ENamedThreads::GameThread, [this, Bytes]()
     {
-        if (CVarO3DSReceiverWebRtcLog->GetInt() != 0)
+        const bool bLogContent = (CVarO3DSReceiverWebRtcLogDataContent->GetInt() != 0);
+        const bool bLogCount = (CVarO3DSReceiverWebRtcLogDataCount->GetInt() != 0);
+        const bool bLogVerbose = (CVarO3DSReceiverWebRtcLog->GetInt() != 0);
+        
+        if (bLogContent)
         {
-            UE_LOG(LogTemp, Verbose, TEXT("O3DS WebRTC Receiver: data bytes=%d"), Bytes.Num());
+            // Show the first 64 byte values (hex) for FlatBuffer-style payloads
+            const int32 MaxShow = 64;
+            const int32 N = FMath::Min(Bytes.Num(), MaxShow);
+            TArray<FString> Hex; Hex.Reserve(N);
+            for (int32 i = 0; i < N; ++i)
+            {
+                Hex.Add(FString::Printf(TEXT("%02X"), Bytes[i]));
+            }
+            const FString Head = FString::Join(Hex, TEXT(" "));
+            const bool bTrunc = (Bytes.Num() > MaxShow);
+            UE_LOG(LogO3DSReceiverWebRTC, Log, TEXT("Data: [%s]%s (%d bytes)"), *Head, bTrunc ? TEXT(" ...") : TEXT(""), Bytes.Num());
+        }
+        else if (bLogCount)
+        {
+            UE_LOG(LogO3DSReceiverWebRTC, Verbose, TEXT("Data: %d bytes"), Bytes.Num());
+        }
+        else if (bLogVerbose)
+        {
+            UE_LOG(LogO3DSReceiverWebRTC, Verbose, TEXT("data bytes=%d"), Bytes.Num());
         }
 
         if (OnDataCallback)
@@ -178,9 +224,31 @@ void FOpen3DSWebRtcReceiver::OnConnectorData(const TArray<uint8>& Bytes)
 
 void FOpen3DSWebRtcReceiver::OnConnectorAudioRtp(const TArray<uint8>& RtpBytes)
 {
+    // Log first packet once so users can confirm audio RTP path is live
+    {
+        static bool bFirstRtpSeen = false;
+        if (!bFirstRtpSeen)
+        {
+            bFirstRtpSeen = true;
+            UE_LOG(LogO3DSReceiverAudio, Log, TEXT("First audio RTP received (%d bytes)"), RtpBytes.Num());
+        }
+    }
+    if (CVarO3DSReceiverWebRtcLogAudioRtp->GetInt() != 0)
+    {
+        UE_LOG(LogO3DSReceiverAudio, Log, TEXT("RTP: %d bytes"), RtpBytes.Num());
+    }
+    
     // Decode off the game thread (already on connector thread)
     if (OpusDecoder && OpusDecoder->IsInitialized())
     {
         OpusDecoder->DecodeRtpPacket(RtpBytes);
+    }
+    else
+    {
+        static int32 WarnEvery = 0;
+        if ((WarnEvery++ % 100) == 0)
+        {
+            UE_LOG(LogO3DSReceiverAudio, Warning, TEXT("Audio RTP received but decoder not initialized (audio disabled?)"));
+        }
     }
 }

--- a/plugins/unreal/Open3DStream/Source/Open3DStream/Public/O3DSStreamLogs.h
+++ b/plugins/unreal/Open3DStream/Source/Open3DStream/Public/O3DSStreamLogs.h
@@ -1,0 +1,15 @@
+// Copyright (c) Open3DStream Contributors
+
+#pragma once
+
+#include "CoreMinimal.h"
+
+// Receiver-specific log categories for easy filtering in Output Log
+// Usage examples:
+//   UE_LOG(LogO3DSReceiver, Log, TEXT("..."));
+//   UE_LOG(LogO3DSReceiverWebRTC, Verbose, TEXT("..."));
+//   UE_LOG(LogO3DSReceiverAudio, Warning, TEXT("..."));
+
+DECLARE_LOG_CATEGORY_EXTERN(LogO3DSReceiver, Log, All);
+DECLARE_LOG_CATEGORY_EXTERN(LogO3DSReceiverWebRTC, Log, All);
+DECLARE_LOG_CATEGORY_EXTERN(LogO3DSReceiverAudio, Log, All);

--- a/plugins/unreal/Open3DStream/Source/Open3DStream/Public/SOpen3DStreamFactory.h
+++ b/plugins/unreal/Open3DStream/Source/Open3DStream/Public/SOpen3DStreamFactory.h
@@ -58,6 +58,13 @@ class OPEN3DSTREAM_API SOpen3DStreamFactory : public SCompoundWidget
 	void SetLiveKitToken(const FText& InText) { mLiveKitToken = InText; }
 	FText GetLiveKitToken() const { return mLiveKitToken; }
 
+	// Audio settings (WebRTC)
+	void OnEnableWebRTCAudioChanged(ECheckBoxState NewState) { bEnableWebRTCAudio = (NewState == ECheckBoxState::Checked); }
+	ECheckBoxState GetEnableWebRTCAudioState() const { return bEnableWebRTCAudio ? ECheckBoxState::Checked : ECheckBoxState::Unchecked; }
+	
+	void OnAudioPlayoutDelayChanged(int32 NewValue) { WebRTCAudioPlayoutDelayMs = NewValue; }
+	int32 GetAudioPlayoutDelay() const { return WebRTCAudioPlayoutDelayMs; }
+
 	// Visibility helpers
 	EVisibility GetWebRtcBackendVisibility() const;
 	EVisibility GetLiveKitFieldsVisibility() const;
@@ -84,6 +91,10 @@ private:
 	FText mLiveKitRoom = FText::FromString(TEXT("room1"));
 	FText mLiveKitToken;
 
+	// Audio settings (WebRTC)
+	bool bEnableWebRTCAudio = false;
+	int32 WebRTCAudioPlayoutDelayMs = 0;
+
 	// Family + Mode combos
 	TArray<FComboItemType> FamilyOptions;
 	FComboItemType CurrentFamily;
@@ -103,6 +114,8 @@ private:
 	TSharedPtr<SHorizontalBox> LiveKitServerUrlRow;
 	TSharedPtr<SHorizontalBox> LiveKitRoomRow;
 	TSharedPtr<SHorizontalBox> LiveKitTokenRow;
+	TSharedPtr<SHorizontalBox> WebRtcAudioRow;
+	TSharedPtr<SHorizontalBox> AudioDelayRow;
 
 	static FText LastUrl;
 	static int LastFamilyId;


### PR DESCRIPTION
This PR improves receiver audio playback and makes WebRTC connections resilient to start-order and server restarts.\n\nReceiver side\n- UO3DSRemoteAudioComponent: force 2D (non-spatialized) playback, procedural SoundWave, auto-Play on frames, and apply Gain at AudioComponent.\n- Introduced receiver-specific UE log categories and a small debug command helper.\n\nWebRTC stability\n- Server role: ResetPeerConnection() on new offer; guard setRemoteDescription/createAnswer and apply queued candidates before answering.\n- Client role: Offer-retry pump when starting before the server is up.\n- Signaling reconnect pump to recover automatically when the signaling server/UE server restarts.\n- Client re-offer when DataChannel closes while signaling remains connected.\n\nVerification\n- Build: PASS (ProjectSandboxEditor Win64 Development).\n- Manual tests: \n  - Start client first → auto connects when server appears.\n  - Stop/play PIE multiple times → no crashes; session recovers.\n  - Restart server/LiveLink source → automatic reconnect; audio + animation resume.\n\nNotes\n- Excludes test maps/assets from this PR to keep scope focused.\n- Follow-ups: optional RMS/energy debug logging via CVar; configurable retry intervals.\n\nResolves #134