### PR TITLE
Open3DStream: UE receiver audio polish — SceneComponent, Submix/Efx/Concurrency, AutoActivate; reconnect; docs updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,18 @@ docker run --rm open3dstream-repeater:local tcp://0.0.0.0:7000 tcp://0.0.0.0:700
    - **Protocol**: TCP Client, UDP Server, WebRTC Client, etc.
 4. Click **Create**
 
+#### Unreal Receiver Audio (WebRTC)
+
+To hear audio from a WebRTC sender, add `O3DSRemoteAudioComponent` to an actor in your level:
+
+- The component is a `USceneComponent` (attach to a parent component or socket as needed)
+- It always creates and manages an internal `UAudioComponent` + procedural `USoundWave`
+- Mirrored AudioComponent-style settings are available:
+   - Volume/Pitch at the top; Attenuation (with override gating); Submix Sends; Source Effect Chain; Concurrency; AutoActivate
+- Client-first and reconnect flows are supported (signaling restarts, re-offer on DataChannel close)
+
+See `plugins/unreal/Open3DStream/docs/WEBRTC_TESTING_GUIDE.md` for step-by-step setup and troubleshooting.
+
 ## Recent Updates
 
 ### Module layout update (UE 5.6)
@@ -127,6 +139,13 @@ These changes preserve prior behavior while making responsibilities clearer and 
 Added support for animation curves to enable morph target-based facial animation:
 
 ### WebRTC Status (October 2025)
+### Receiver Audio Polish & Reconnect (November 2025)
+
+- `O3DSRemoteAudioComponent` is now a `USceneComponent` with attachment options (parent/socket)
+- Always-owned internal `UAudioComponent` + procedural `USoundWave`
+- Mirrored AudioComponent features: Submix Sends, Source Effects Chain, Concurrency, AutoActivate (default true)
+- Editor experience: categories/tooltips aligned with `UAudioComponent` layout; Volume/Pitch surfaced at the top
+- Reconnect/resilience: client-first offer retry, signaling reconnect, re-offer on DataChannel close; receiver resets PC on new offers
 
 libdatachannel is integrated with OpenSSL and enabled by default across the codebase:
 

--- a/plugins/unreal/Open3DStream/Source/Open3DStream/Private/O3DSRemoteAudioComponent.cpp
+++ b/plugins/unreal/Open3DStream/Source/Open3DStream/Private/O3DSRemoteAudioComponent.cpp
@@ -29,6 +29,29 @@ UO3DSRemoteAudioComponent::UO3DSRemoteAudioComponent()
 	PrimaryComponentTick.bCanEverTick = false;
 }
 
+void UO3DSRemoteAudioComponent::OnRegister()
+{
+	Super::OnRegister();
+
+	// Attach this SceneComponent to the specified parent (or owner's root)
+	USceneComponent* ParentToAttach = nullptr;
+	if (AActor* Owner = GetOwner())
+	{
+		if (UActorComponent* RefComp = AC_AttachParent.GetComponent(Owner))
+		{
+			ParentToAttach = Cast<USceneComponent>(RefComp);
+		}
+		if (!ParentToAttach)
+		{
+			ParentToAttach = Owner->GetRootComponent();
+		}
+	}
+	if (ParentToAttach && ParentToAttach != GetAttachParent())
+	{
+		AttachToComponent(ParentToAttach, FAttachmentTransformRules::KeepRelativeTransform, AC_AttachSocketName);
+	}
+}
+
 void UO3DSRemoteAudioComponent::BeginPlay()
 {
 	Super::BeginPlay();
@@ -38,23 +61,8 @@ void UO3DSRemoteAudioComponent::BeginPlay()
 	if (AudioComp)
 	{
 		AudioComp->RegisterComponent();
-		// Choose attachment parent: explicit reference first, then owner's root
-		USceneComponent* ParentToAttach = nullptr;
-		if (GetOwner())
-		{
-			if (UActorComponent* RefComp = AC_AttachParent.GetComponent(GetOwner()))
-			{
-				ParentToAttach = Cast<USceneComponent>(RefComp);
-			}
-			if (!ParentToAttach)
-			{
-				ParentToAttach = GetOwner()->GetRootComponent();
-			}
-		}
-		if (ParentToAttach)
-		{
-			AudioComp->AttachToComponent(ParentToAttach, FAttachmentTransformRules::KeepRelativeTransform, AC_AttachSocketName);
-		}
+		// Attach internal audio component to this SceneComponent for consistent transform inheritance
+		AudioComp->AttachToComponent(this, FAttachmentTransformRules::KeepRelativeTransform);
 		// Configure from mirrored properties (leave out Sound Source)
 		AudioComp->bAutoActivate = bAC_AutoActivate;
 		AudioComp->bAllowSpatialization = bAC_AllowSpatialization;

--- a/plugins/unreal/Open3DStream/Source/Open3DStream/Private/O3DSRemoteAudioComponent.cpp
+++ b/plugins/unreal/Open3DStream/Source/Open3DStream/Private/O3DSRemoteAudioComponent.cpp
@@ -10,6 +10,8 @@
 // Needed for AActor definition used by GetOwner() and attachment calls
 #include "GameFramework/Actor.h"
 #include "Sound/SoundAttenuation.h"
+// For scene component attachment
+#include "Components/SceneComponent.h"
 // Submix/Effects/Concurrency/Modulation support
 #include "Sound/SoundSubmix.h"
 #include "Sound/SoundSubmixSend.h"
@@ -36,9 +38,22 @@ void UO3DSRemoteAudioComponent::BeginPlay()
 	if (AudioComp)
 	{
 		AudioComp->RegisterComponent();
-		if (GetOwner() && GetOwner()->GetRootComponent())
+		// Choose attachment parent: explicit reference first, then owner's root
+		USceneComponent* ParentToAttach = nullptr;
+		if (GetOwner())
 		{
-			AudioComp->AttachToComponent(GetOwner()->GetRootComponent(), FAttachmentTransformRules::KeepRelativeTransform);
+			if (UActorComponent* RefComp = AC_AttachParent.GetComponent(GetOwner()))
+			{
+				ParentToAttach = Cast<USceneComponent>(RefComp);
+			}
+			if (!ParentToAttach)
+			{
+				ParentToAttach = GetOwner()->GetRootComponent();
+			}
+		}
+		if (ParentToAttach)
+		{
+			AudioComp->AttachToComponent(ParentToAttach, FAttachmentTransformRules::KeepRelativeTransform, AC_AttachSocketName);
 		}
 		// Configure from mirrored properties (leave out Sound Source)
 		AudioComp->bAutoActivate = bAC_AutoActivate;

--- a/plugins/unreal/Open3DStream/Source/Open3DStream/Public/O3DSRemoteAudioComponent.h
+++ b/plugins/unreal/Open3DStream/Source/Open3DStream/Public/O3DSRemoteAudioComponent.h
@@ -50,6 +50,13 @@ public:
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Open3DStream|Audio")
 	float Gain =1.0f;
 
+	// Quick access mixers at top
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Open3DStream|Audio", meta=(DisplayName="Volume Multiplier", ClampMin="0.0", ToolTip="Scales the overall output level of the audio component. 1.0 = original level."))
+	float AC_VolumeMultiplier = 1.0f;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Open3DStream|Audio", meta=(DisplayName="Pitch Multiplier", ToolTip="Scales playback pitch. 1.0 = original pitch."))
+	float AC_PitchMultiplier = 1.0f;
+
 	// AudioComponent configuration (applies to the auto-created component)
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Attenuation", meta=(DisplayName="Allow Spatialization", ToolTip="Whether to spatialize this sound when playing in 3D."))
 	bool bAC_AllowSpatialization = false;
@@ -57,19 +64,15 @@ public:
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Sound", meta=(DisplayName="Is UI Sound", ToolTip="If true, plays as a non-spatialized UI sound and may bypass reverb/occlusion."))
 	bool bAC_IsUISound = true;
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Sound", meta=(DisplayName="Volume Multiplier", ClampMin="0.0", ToolTip="Scales the overall output level of the audio component. 1.0 = original level."))
-	float AC_VolumeMultiplier = 1.0f;
-
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Sound", meta=(DisplayName="Pitch Multiplier", ToolTip="Scales playback pitch. 1.0 = original pitch."))
-	float AC_PitchMultiplier = 1.0f;
+    
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Attenuation", meta=(DisplayName="Override Attenuation", ToolTip="Enable per-instance attenuation overrides below instead of using the asset's attenuation settings."))
 	bool bAC_OverrideAttenuation = false;
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Attenuation", meta=(DisplayName="Attenuation Settings", EditCondition="!bAC_OverrideAttenuation", ToolTip="Asset-based attenuation settings to apply when not overriding."))
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Attenuation", meta=(DisplayName="Attenuation Settings", EditCondition="!bAC_OverrideAttenuation", EditConditionHides, ToolTip="Asset-based attenuation settings to apply when not overriding."))
 	TObjectPtr<USoundAttenuation> AC_AttenuationSettings = nullptr;
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Attenuation", meta=(DisplayName="Attenuation Overrides", EditCondition="bAC_OverrideAttenuation", ToolTip="Per-instance attenuation overrides used when Override Attenuation is enabled."))
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Attenuation", meta=(DisplayName="Attenuation Overrides", EditCondition="bAC_OverrideAttenuation", EditConditionHides, ToolTip="Per-instance attenuation overrides used when Override Attenuation is enabled."))
 	FSoundAttenuationSettings AC_AttenuationOverrides;
 
 	// Submix Sends

--- a/plugins/unreal/Open3DStream/Source/Open3DStream/Public/O3DSRemoteAudioComponent.h
+++ b/plugins/unreal/Open3DStream/Source/Open3DStream/Public/O3DSRemoteAudioComponent.h
@@ -3,7 +3,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
-#include "Components/ActorComponent.h"
+#include "Components/SceneComponent.h"
 #include "LiveLinkTypes.h"
 #include "Engine/EngineTypes.h" // FComponentReference
 #include "O3DSRemoteAudioComponent.generated.h"
@@ -30,7 +30,7 @@ enum class EO3DSRemoteAudioMode : uint8
 };
 
 UCLASS(ClassGroup=(Open3DStream), meta=(BlueprintSpawnableComponent))
-class OPEN3DSTREAM_API UO3DSRemoteAudioComponent : public UActorComponent
+class OPEN3DSTREAM_API UO3DSRemoteAudioComponent : public USceneComponent
 {
 	GENERATED_BODY()
 public:
@@ -113,6 +113,7 @@ public:
 protected:
 	virtual void BeginPlay() override;
 	virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
+	virtual void OnRegister() override;
 
 private:
 	void OnAudioFrame(const FString& StreamLabel, const FString& SubjectName, const float* Interleaved, int32 NumFrames, int32 NumChannels, int32 SampleRate);

--- a/plugins/unreal/Open3DStream/Source/Open3DStream/Public/O3DSRemoteAudioComponent.h
+++ b/plugins/unreal/Open3DStream/Source/Open3DStream/Public/O3DSRemoteAudioComponent.h
@@ -5,6 +5,7 @@
 #include "CoreMinimal.h"
 #include "Components/ActorComponent.h"
 #include "LiveLinkTypes.h"
+#include "Engine/EngineTypes.h" // FComponentReference
 #include "O3DSRemoteAudioComponent.generated.h"
 
 class UAudioComponent;
@@ -17,6 +18,7 @@ class USoundConcurrency;
 struct FSoundSubmixSendInfo;
 struct FSoundConcurrencySettings;
 struct FSoundModulationDestinationSettings;
+class USceneComponent;
 
 namespace O3DS { struct FAudioFrameMeta; }
 
@@ -56,6 +58,13 @@ public:
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Open3DStream|Audio", meta=(DisplayName="Pitch Multiplier", ToolTip="Scales playback pitch. 1.0 = original pitch."))
 	float AC_PitchMultiplier = 1.0f;
+
+	// Attachment for the internally-created UAudioComponent (SceneComponent)
+	UPROPERTY(EditAnywhere, Category="Open3DStream|Audio|Attachment", meta=(DisplayName="Attach Parent", ToolTip="Optional parent scene component to attach the internal UAudioComponent to. If unset, attaches to the Actor's RootComponent."))
+	FComponentReference AC_AttachParent;
+
+	UPROPERTY(EditAnywhere, Category="Open3DStream|Audio|Attachment", meta=(DisplayName="Attach Socket Name", ToolTip="Optional socket to use when attaching to the parent component."))
+	FName AC_AttachSocketName;
 
 	// AudioComponent configuration (applies to the auto-created component)
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Attenuation", meta=(DisplayName="Allow Spatialization", ToolTip="Whether to spatialize this sound when playing in 3D."))

--- a/plugins/unreal/Open3DStream/docs/WEBRTC_TESTING_GUIDE.md
+++ b/plugins/unreal/Open3DStream/docs/WEBRTC_TESTING_GUIDE.md
@@ -12,15 +12,15 @@ This guide provides step-by-step instructions for testing the WebRTC receiver an
 
 ---
 
-## Important: Startup Order
+## Connection Order and Resilience
 
-**⚠️ Critical:** Until reconnect logic is implemented, you **must start components in this order**:
+The receiver and broadcaster now include reconnect logic:
 
-1. **Signaling Server** (first)
-2. **Receiver/Server** (second - waits for client)
-3. **Broadcaster/Client** (last - initiates connection)
+- Client-first is supported. If the client starts before the receiver, it will retry offers with backoff until the receiver appears.
+- Receiver survives signaling restarts and Live Link source recreation; it resets the PeerConnection and re-offers as needed.
+- If the DataChannel closes while signaling remains connected, the client will re-offer.
 
-Starting the client before the server may result in connection timeouts or failures. If this happens, restart the client after the receiver is up.
+Recommended order (for faster connects): signaling → receiver → broadcaster. Not strictly required.
 
 ---
 
@@ -79,11 +79,26 @@ The receiver is now **waiting for a client to connect**.
 
 To hear the audio stream:
 
-1. In the receiver editor's level, add a new actor (or use existing one)
-2. Add **O3DSRemoteAudioComponent**:
-   - **Receive Mode**: `Mix` (receives all audio)
-   - **Auto Create Audio Component**: ✓ (checked)
-   - **Gain**: `1.0`
+1. In the receiver editor's level, add a new actor (or use an existing one)
+2. Add **O3DSRemoteAudioComponent** (now a SceneComponent so it can be attached):
+    - Top section:
+       - **Receive Mode**: `Mix` (receives all audio) or `Subject`
+       - **LiveLink Subject Name**: set when using `Subject`
+       - **Stream Label Filter**: optional substring filter
+       - **Gain**: `1.0` (source-side scaling before enqueue)
+       - **Volume Multiplier** / **Pitch Multiplier**: component-level mix controls
+    - Attachment:
+       - **Attach Parent**: optional parent scene component (e.g., SkeletalMeshComponent)
+       - **Attach Socket Name**: optional socket on parent
+    - Attenuation:
+       - **Allow Spatialization**: enable for 3D placement
+       - **Override Attenuation**: when enabled, **Attenuation Overrides** become editable; otherwise use **Attenuation Settings** asset
+    - Routing & processing:
+       - **Submix Sends**: route to one or more submixes
+       - **Source Effect Chain**: optional source effects chain
+       - **Concurrency Set/Overrides**: concurrency behavior
+    - Activation:
+       - **Auto Activate**: ✓ (default; auto-plays when the procedural wave is ready)
 3. (Optional) Enable audio debug logging:
    ```
    o3ds.RemoteAudio.Debug 1
@@ -154,7 +169,7 @@ O3DS Opus Decoder: published <N> samples (<N> bytes) to Audio Bus
 
 With the sender's audio enabled (microphone or game audio):
 
-1. You should **hear audio** playing in the receiver editor (if O3DSRemoteAudioComponent is added)
+1. You should **hear audio** playing in the receiver editor (with O3DSRemoteAudioComponent added)
 2. Check receiver logs for audio activity:
    ```
    [Opus Decoder] decoded 960 samples (payload=93 bytes, ts=<N>)
@@ -364,12 +379,15 @@ python signaling-server.py
 6. For `Mix` mode: play music in UE (add AudioComponent with SoundWave)
 
 **Solutions (Receiver):**
-1. Verify **O3DSRemoteAudioComponent** is added to an actor
+1. Verify **O3DSRemoteAudioComponent** is added and attached where you expect
 2. Check component settings:
-   - **Receive Mode** = `Mix` (receives all audio)
-   - **Auto Create Audio Component** = checked
-   - **Gain** > 0
-3. Enable audio debug:
+   - **Receive Mode** = `Mix` (receives all audio) or a valid **Subject**
+   - **Auto Activate** = true (or call Play() manually if false)
+   - **Gain** > 0 and **Volume Multiplier** > 0
+3. Check routing/processing:
+   - If using Submix Sends, confirm the target submix is audible
+   - If using Source Effects Chain, disable temporarily to test
+4. Enable audio debug:
    ```
    o3ds.RemoteAudio.Debug 1
    o3ds.Receiver.Audio.Log 1
@@ -489,32 +507,32 @@ o3ds.RemoteAudio.Debug 0/1            // Log audio bus events and playback
 
 ---
 
-## Known Limitations (MVP)
+## Known Limitations
 
-These are expected behaviors in the current implementation:
+These are the current limits/caveats:
 
-1. **No reconnect logic:**
-   - If connection drops, manual restart required
-   - Client must start after server (see startup order above)
-
-2. **No jitter buffer:**
+1. **No jitter buffer:**
    - Audio decoded per-packet (no reordering)
    - May cause rare artifacts on lossy/reordered networks
    - Future: add jitter buffer for production deployments
 
-3. **48 kHz audio only:**
+2. **48 kHz audio only:**
    - Non-48kHz input is dropped with verbose log
    - Future: add resampler for arbitrary sample rates
 
-4. **No persistent signaling:**
+3. **No persistent signaling:**
    - Sample signaling server doesn't queue messages
    - Clients/servers must overlap connection window
    - Future: upgrade to production signaling with persistence
 
-5. **Single room per source:**
+4. **Single room per source:**
    - One Live Link source = one room
    - Multiple sources require multiple Live Link sources
    - Future: multi-room receiver or dynamic room switching
+
+5. **Modulation destinations (UE 5.6):**
+   - Volume/Pitch modulation properties are exposed on the component but may not be wired by default on 5.6 API surface.
+   - Future: version-aware wiring when engine exposes destinations on the component or sound asset.
 
 ---
 


### PR DESCRIPTION
Summary\nThis PR completes the receiver-side audio and reconnect polish for the Unreal plugin. It converts O3DSRemoteAudioComponent into a SceneComponent, always owns an internal UAudioComponent + procedural USoundWave, mirrors key AudioComponent features, and documents the workflow. Reconnect paths (client-first, signaling restarts, re-offer on DataChannel close) are implemented and validated.\n\nKey changes\n- O3DSRemoteAudioComponent → USceneComponent with attachment options (parent/socket)\n- Internal UAudioComponent attached to this component; AutoActivate respected\n- Mirrored features: Submix Sends, Source Effects Chain, Concurrency (set + overrides), Attenuation (override gating), Volume/Pitch surfaced at top with UE-aligned categories/tooltips\n- Modulation (Volume/Pitch) properties exposed; wiring guarded for UE 5.6 API surface\n- Reconnect resiliency: client-first offer retry, signaling reconnect, re-offer on DC close; receiver resets PC on new offers/signaling close\n- Docs updated: WEBRTC_TESTING_GUIDE.md + README.md (SceneComponent usage, routing, reconnect)\n\nHow to test\n- Add O3DSRemoteAudioComponent to an actor and attach to a SceneComponent/socket as needed\n- Configure Volume/Pitch, Attenuation (override gating), Submix Sends, Source Effects Chain, Concurrency, AutoActivate\n- Validate client-first and signaling restart scenarios; audio resumes with routing/effects intact\n\nBuild/CI\n- Local: ProjectSandboxEditor Win64 Development — PASS\n- No schema changes; protocol unchanged\n\nCompatibility\n- UE 5.6; modulation wiring to be enabled in follow-up when engine API permits\n\nNotes\n- Debug CVars: o3ds.RemoteAudio.Debug, o3ds.Receiver.Audio.Log, o3ds.Receiver.WebRTC.Log\n