### PR TITLE
Add tx_seq and tx_audio_time to SubjectList schema

### DIFF
--- a/src/o3ds.fbs
+++ b/src/o3ds.fbs
@@ -97,6 +97,8 @@ table SubjectList {
    subjects:[Subject];
    updates:[SubjectUpdate];
    time:double;
+   tx_seq:ulong = 0;           // Monotonic sequence number from broadcaster
+   tx_audio_time:double = 0.0; // Audio clock timestamp (seconds) when frame captured
 }
 
 

--- a/src/o3ds/model.cpp
+++ b/src/o3ds/model.cpp
@@ -470,11 +470,11 @@ flatbuffers::Offset<flatbuffers::Vector<const O3DS::Data::CurveUpdate *>> Subjec
 		flatbuffers::Offset<O3DS::Data::Subject> s = this->Serialize(builder);
 		subjects.push_back(s);
 
-		auto ovSubjects = builder.CreateVector(subjects);
+\tauto ovSubjects = builder.CreateVector(subjects);
 
-		auto root = CreateSubjectList(builder, ovSubjects, 0, timestamp);
+\tauto root = CreateSubjectList(builder, ovSubjects, 0, timestamp, mTxSeq, mTxAudioTime);
 
-		builder.Finish(root);
+\tbuilder.Finish(root);
 
 		finalize(builder, outbuf, 1);
 
@@ -493,11 +493,11 @@ flatbuffers::Offset<flatbuffers::Vector<const O3DS::Data::CurveUpdate *>> Subjec
 		std::vector<flatbuffers::Offset<O3DS::Data::SubjectUpdate>> outSubjectUpdates;
 		outSubjectUpdates.push_back(this->SerializeUpdate(builder, count, deltaThreshold));
 
-		auto ovSubjectUpdates = builder.CreateVector(outSubjectUpdates);
+\tauto ovSubjectUpdates = builder.CreateVector(outSubjectUpdates);
 
-		auto root = CreateSubjectList(builder, 0, ovSubjectUpdates, timestamp);
+\tauto root = CreateSubjectList(builder, 0, ovSubjectUpdates, timestamp, mTxSeq, mTxAudioTime);
 
-		builder.Finish(root);
+\tbuilder.Finish(root);
 
 		finalize(builder, outbuf, 1);
 
@@ -600,11 +600,13 @@ flatbuffers::Offset<flatbuffers::Vector<const O3DS::Data::CurveUpdate *>> Subjec
 			return false;
 		}
 
-		auto root = GetSubjectList(data+8);
+\tauto root = GetSubjectList(data+8);
 
-		this->mTime = root->time();
+\tthis->mTime = root->time();
+\tthis->mTxSeq = root->tx_seq();
+\tthis->mTxAudioTime = root->tx_audio_time();
 
-		auto subjects_data = root->subjects();
+\tauto subjects_data = root->subjects();
 		auto updates_data = root->updates();
 
 		auto ovSubjects = root->subjects();

--- a/src/o3ds/model.h
+++ b/src/o3ds/model.h
@@ -213,11 +213,15 @@ namespace O3DS
 		SubjectList()
 			: mTime(0.0)
 			, mDeltaThreshold(std::numeric_limits<double>::min())
+			, mTxSeq(0)
+			, mTxAudioTime(0.0)
 		{}
 
 		SubjectList(const SubjectList &other)
 			: mTime(0.0)
 			, mDeltaThreshold(std::numeric_limits<double>::min())
+			, mTxSeq(0)
+			, mTxAudioTime(0.0)
 		{}
 
 		virtual ~SubjectList()
@@ -262,6 +266,8 @@ namespace O3DS
 
 		double mTime;
 		double mDeltaThreshold;
+		uint64_t mTxSeq;          // Monotonic sequence number
+		double mTxAudioTime;      // Audio clock timestamp
 		std::string mError;
 
 		//! Encode all of the items in the subject list as binary data

--- a/src/o3ds_generated.h
+++ b/src/o3ds_generated.h
@@ -832,7 +832,9 @@ struct SubjectList FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_SUBJECTS = 4,
     VT_UPDATES = 6,
-    VT_TIME = 8
+    VT_TIME = 8,
+    VT_TX_SEQ = 10,
+    VT_TX_AUDIO_TIME = 12
   };
   const flatbuffers::Vector<flatbuffers::Offset<O3DS::Data::Subject>> *subjects() const {
     return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<O3DS::Data::Subject>> *>(VT_SUBJECTS);
@@ -843,6 +845,12 @@ struct SubjectList FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   double time() const {
     return GetField<double>(VT_TIME, 0.0);
   }
+  uint64_t tx_seq() const {
+    return GetField<uint64_t>(VT_TX_SEQ, 0);
+  }
+  double tx_audio_time() const {
+    return GetField<double>(VT_TX_AUDIO_TIME, 0.0);
+  }
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
            VerifyOffset(verifier, VT_SUBJECTS) &&
@@ -852,6 +860,8 @@ struct SubjectList FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
            verifier.VerifyVector(updates()) &&
            verifier.VerifyVectorOfTables(updates()) &&
            VerifyField<double>(verifier, VT_TIME, 8) &&
+           VerifyField<uint64_t>(verifier, VT_TX_SEQ, 8) &&
+           VerifyField<double>(verifier, VT_TX_AUDIO_TIME, 8) &&
            verifier.EndTable();
   }
 };
@@ -869,6 +879,12 @@ struct SubjectListBuilder {
   void add_time(double time) {
     fbb_.AddElement<double>(SubjectList::VT_TIME, time, 0.0);
   }
+  void add_tx_seq(uint64_t tx_seq) {
+    fbb_.AddElement<uint64_t>(SubjectList::VT_TX_SEQ, tx_seq, 0);
+  }
+  void add_tx_audio_time(double tx_audio_time) {
+    fbb_.AddElement<double>(SubjectList::VT_TX_AUDIO_TIME, tx_audio_time, 0.0);
+  }
   explicit SubjectListBuilder(flatbuffers::FlatBufferBuilder &_fbb)
         : fbb_(_fbb) {
     start_ = fbb_.StartTable();
@@ -884,8 +900,12 @@ inline flatbuffers::Offset<SubjectList> CreateSubjectList(
     flatbuffers::FlatBufferBuilder &_fbb,
     flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<O3DS::Data::Subject>>> subjects = 0,
     flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<O3DS::Data::SubjectUpdate>>> updates = 0,
-    double time = 0.0) {
+    double time = 0.0,
+    uint64_t tx_seq = 0,
+    double tx_audio_time = 0.0) {
   SubjectListBuilder builder_(_fbb);
+  builder_.add_tx_audio_time(tx_audio_time);
+  builder_.add_tx_seq(tx_seq);
   builder_.add_time(time);
   builder_.add_updates(updates);
   builder_.add_subjects(subjects);
@@ -896,14 +916,18 @@ inline flatbuffers::Offset<SubjectList> CreateSubjectListDirect(
     flatbuffers::FlatBufferBuilder &_fbb,
     const std::vector<flatbuffers::Offset<O3DS::Data::Subject>> *subjects = nullptr,
     const std::vector<flatbuffers::Offset<O3DS::Data::SubjectUpdate>> *updates = nullptr,
-    double time = 0.0) {
+    double time = 0.0,
+    uint64_t tx_seq = 0,
+    double tx_audio_time = 0.0) {
   auto subjects__ = subjects ? _fbb.CreateVector<flatbuffers::Offset<O3DS::Data::Subject>>(*subjects) : 0;
   auto updates__ = updates ? _fbb.CreateVector<flatbuffers::Offset<O3DS::Data::SubjectUpdate>>(*updates) : 0;
   return O3DS::Data::CreateSubjectList(
       _fbb,
       subjects__,
       updates__,
-      time);
+      time,
+      tx_seq,
+      tx_audio_time);
 }
 
 struct Curve FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {


### PR DESCRIPTION
Extended the FlatBuffers schema (o3ds.fbs) to include tx_seq (monotonic sequence number) and tx_audio_time (audio clock timestamp) fields in SubjectList. Updated model.cpp to serialize and parse these new fields, ensuring that sequence and audio timing information is preserved in the data stream.