### PR TITLE
Add Open3DBroadcast CI workflows

### DIFF
--- a/.github/actions/build-plugin-core/action.yml
+++ b/.github/actions/build-plugin-core/action.yml
@@ -23,13 +23,17 @@ inputs:
   opus_asset_regex:
     required: false
     description: Optional override regex to pick an opus release asset for this runner OS/arch.
+  plugin_relative_path:
+    required: false
+    default: ''
+    description: Optional relative path to plugin directory when not under plugins/unreal/<plugin_name>.
 outputs:
   plugin_dir:
     description: Resolved plugin directory
-    value: ${{ steps.find.outputs.plugin_dir }}
+    value: ${{ steps.resolve.outputs.plugin_dir }}
   uplugin_path:
     description: Resolved .uplugin path
-    value: ${{ steps.find.outputs.plugin_path }}
+    value: ${{ steps.resolve.outputs.plugin_path }}
 runs:
   using: composite
   steps:
@@ -39,6 +43,33 @@ runs:
         fetch-depth: 0
         lfs: true
         submodules: recursive
+
+    - name: Resolve plugin location
+      id: resolve
+      shell: pwsh
+      run: |
+        $ErrorActionPreference = 'Stop'
+        $custom = "${{ inputs.plugin_relative_path }}"
+        if ([string]::IsNullOrWhiteSpace($custom)) {
+          $pluginDir = Join-Path $PWD "plugins/unreal/${{ inputs.plugin_name }}"
+        } else {
+          $pluginDir = Join-Path $PWD $custom
+        }
+
+        if (!(Test-Path -LiteralPath $pluginDir)) {
+          throw "Plugin directory not found: $pluginDir"
+        }
+
+        $upluginPath = Join-Path $pluginDir "${{ inputs.plugin_name }}.uplugin"
+        if (!(Test-Path -LiteralPath $upluginPath)) {
+          throw "Plugin .uplugin file not found: $upluginPath"
+        }
+
+        "PLUGIN_DIR=$pluginDir" | Out-File -FilePath $env:GITHUB_ENV -Append
+        "PLUGIN_UPLUGIN=$upluginPath" | Out-File -FilePath $env:GITHUB_ENV -Append
+
+        "plugin_dir=$pluginDir"   | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+        "plugin_path=$upluginPath" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
 
     - name: Setup MSBuild
       uses: microsoft/setup-msbuild@v2
@@ -270,13 +301,37 @@ runs:
     - name: Copy libraries and headers to plugin
       shell: pwsh
       run: |
-        $pluginLib = Join-Path "plugins/unreal" "${{ inputs.plugin_name }}/ThirdParty"
+        $ErrorActionPreference = 'Stop'
+        $pluginDir = $env:PLUGIN_DIR
+        if ([string]::IsNullOrWhiteSpace($pluginDir)) {
+          throw "PLUGIN_DIR environment variable not set. Ensure the resolve step executed successfully."
+        }
+
+        $pluginLib = Join-Path $pluginDir "ThirdParty"
+        $pluginLibWin64 = Join-Path $pluginLib "Lib/Win64"
+        New-Item -ItemType Directory -Force -Path $pluginLib | Out-Null
+        New-Item -ItemType Directory -Force -Path $pluginLibWin64 | Out-Null
+
+        $moduleLibTargets = @()
+        $sourceDir = Join-Path $pluginDir "Source"
+        if (Test-Path $sourceDir) {
+          Get-ChildItem -Path $sourceDir -Directory | ForEach-Object {
+            $moduleLibDir = Join-Path $_.FullName "ThirdParty/Lib/Win64"
+            New-Item -ItemType Directory -Force -Path $moduleLibDir | Out-Null
+            $moduleLibTargets += $moduleLibDir
+          }
+        }
+
         New-Item -ItemType Directory -Force -Path (Join-Path $pluginLib "include") | Out-Null
 
         # Copy o3ds to new structure (prebuilt lib location)
         New-Item -ItemType Directory -Force -Path (Join-Path $pluginLib "o3ds/include/o3ds") | Out-Null
         New-Item -ItemType Directory -Force -Path (Join-Path $pluginLib "o3ds/lib/Win64/Release") | Out-Null
         Copy-Item "vsbuild/src/${{ inputs.build_type }}/open3dstreamstatic.lib" (Join-Path $pluginLib "o3ds/lib/Win64/Release/o3ds.lib") -Force
+        Copy-Item "vsbuild/src/${{ inputs.build_type }}/open3dstreamstatic.lib" (Join-Path $pluginLibWin64 "open3dstreamstatic.lib") -Force
+        foreach ($target in $moduleLibTargets) {
+          Copy-Item "vsbuild/src/${{ inputs.build_type }}/open3dstreamstatic.lib" (Join-Path $target "open3dstreamstatic.lib") -Force
+        }
         Copy-Item "src/o3ds/*.h" (Join-Path $pluginLib "o3ds/include/o3ds") -Force
         Copy-Item "src/o3ds_generated.h" (Join-Path $pluginLib "o3ds/include") -Force
 
@@ -288,6 +343,12 @@ runs:
         Copy-Item "vsbuild/src/${{ inputs.build_type }}/open3dstreamstatic.lib" $pluginLib -ErrorAction SilentlyContinue
         Copy-Item "thirdparty/build/nng/${{ inputs.build_type }}/nng.lib" $pluginLib -ErrorAction SilentlyContinue
         Copy-Item "thirdparty/build/flatbuffers/${{ inputs.build_type }}/flatbuffers.lib" $pluginLib -ErrorAction SilentlyContinue
+        Copy-Item "thirdparty/build/nng/${{ inputs.build_type }}/nng.lib" (Join-Path $pluginLibWin64 "nng.lib") -Force -ErrorAction SilentlyContinue
+        Copy-Item "thirdparty/build/flatbuffers/${{ inputs.build_type }}/flatbuffers.lib" (Join-Path $pluginLibWin64 "flatbuffers.lib") -Force -ErrorAction SilentlyContinue
+        foreach ($target in $moduleLibTargets) {
+          Copy-Item "thirdparty/build/nng/${{ inputs.build_type }}/nng.lib" (Join-Path $target "nng.lib") -Force -ErrorAction SilentlyContinue
+          Copy-Item "thirdparty/build/flatbuffers/${{ inputs.build_type }}/flatbuffers.lib" (Join-Path $target "flatbuffers.lib") -Force -ErrorAction SilentlyContinue
+        }
 
         Copy-Item "src/o3ds/*.h" (Join-Path $pluginLib "include/o3ds") -Force -ErrorAction SilentlyContinue
         Copy-Item "src/o3ds_generated.h" (Join-Path $pluginLib "include") -Force -ErrorAction SilentlyContinue
@@ -299,7 +360,7 @@ runs:
           param(
             [string]$root,
             [string[]]$libPatterns,
-            [string]$targetLibDir = $pluginLib,
+            [string]$targetLibDir,
             [string]$targetIncDir = (Join-Path $pluginLib "include")
           )
           if ([string]::IsNullOrWhiteSpace($root)) { return }
@@ -341,20 +402,18 @@ runs:
           $webrtcDir = Join-Path $pluginLib "webrtc"
           $webrtcIncDir = Join-Path $pluginLib "webrtc/include"
           Copy-Lib-And-Include -root $ldcRoot -libPatterns $patterns -targetLibDir $webrtcDir -targetIncDir $webrtcIncDir
+          Copy-Lib-And-Include -root $ldcRoot -libPatterns $patterns -targetLibDir $pluginLibWin64 -targetIncDir $webrtcIncDir
+          foreach ($target in $moduleLibTargets) {
+            Copy-Lib-And-Include -root $ldcRoot -libPatterns $patterns -targetLibDir $target -targetIncDir $webrtcIncDir
+          }
         }
 
         # Copy opus headers/libs to ThirdParty root for future use
         $opusRoot = "${{ steps.fetch-opus.outputs.opus_root }}"
         if (-not [string]::IsNullOrWhiteSpace($opusRoot)) {
-          Copy-Lib-And-Include -root $opusRoot -libPatterns $patterns
+          Copy-Lib-And-Include -root $opusRoot -libPatterns $patterns -targetLibDir $pluginLib
+          Copy-Lib-And-Include -root $opusRoot -libPatterns $patterns -targetLibDir $pluginLibWin64
+          foreach ($target in $moduleLibTargets) {
+            Copy-Lib-And-Include -root $opusRoot -libPatterns $patterns -targetLibDir $target
+          }
         }
-
-    - name: Locate plugin (.uplugin)
-      id: find
-      shell: pwsh
-      run: |
-        $pluginDir = Join-Path $PWD "plugins/unreal/${{ inputs.plugin_name }}"
-        $upluginPath = Join-Path $pluginDir "${{ inputs.plugin_name }}.uplugin"
-        if (!(Test-Path -LiteralPath $upluginPath)) { Write-Error "Plugin file not found: $upluginPath"; exit 1 }
-        "plugin_path=$upluginPath" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
-        "plugin_dir=$pluginDir" | Out-File -FilePath $env:GITHUB_OUTPUT -Append

--- a/.github/workflows/open3dbroadcast-plugin-ci.yml
+++ b/.github/workflows/open3dbroadcast-plugin-ci.yml
@@ -1,0 +1,161 @@
+name: Open3DBroadcast Plugin CI
+
+on:
+  pull_request:
+    branches: [ develop, main ]
+    types: [ opened, synchronize, ready_for_review ]
+  push:
+    branches: [ develop, main ]
+  workflow_dispatch:
+    inputs:
+      build_configuration:
+        description: "CMake build configuration"
+        required: false
+        type: choice
+        default: RelWithDebInfo
+        options:
+          - RelWithDebInfo
+          - Release
+      run_ctest:
+        description: "Run ctest after building core libraries"
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  checks: write
+  pull-requests: write
+
+concurrency:
+  group: open3dbroadcast-plugin-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  UE_ROOT: 'C:\\Program Files\\Epic Games\\UE_5.6'
+  PLUGIN_NAME: 'Open3DBroadcast'
+
+jobs:
+  changes:
+    name: Detect non-doc changes
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Filter paths (docs vs code)
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          filters: |
+            code:
+              - 'src/**'
+              - 'thirdparty/**'
+              - 'Build/**'
+              - 'CMakeLists.txt'
+              - 'package.py'
+              - 'o3ds.fbs'
+              - 'src/o3ds_generated.h'
+              - 'ProjectSandbox/ProjectSandbox.uproject'
+              - 'ProjectSandbox/Source/**'
+              - 'ProjectSandbox/Plugins/Open3DBroadcast/**'
+              - '.github/actions/**'
+              - '.github/workflows/open3dbroadcast-plugin-ci.yml'
+
+  build-and-test:
+    needs: changes
+    if: >-
+      (github.event_name == 'workflow_dispatch') ||
+      (needs.changes.outputs.code == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false))
+    runs-on: [ self-hosted, ue5, windows ]
+
+    steps:
+      - name: Checkout (full)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          lfs: true
+          submodules: recursive
+
+      - name: Post build started comment
+        if: github.event_name == 'pull_request' && github.event.pull_request.number != null
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `🚀 **Open3DBroadcast Plugin CI build started** for this PR!\n\n[View build logs →](${runUrl})`
+            });
+
+      - name: Build plugin core (composite)
+        id: core
+        uses: ./.github/actions/build-plugin-core
+        with:
+          ue_root: ${{ env.UE_ROOT }}
+          plugin_name: ${{ env.PLUGIN_NAME }}
+          plugin_relative_path: ProjectSandbox/Plugins/Open3DBroadcast
+          build_type: ${{ inputs.build_configuration || 'RelWithDebInfo' }}
+          enable_webrtc: true
+
+      - name: Optional ctest run
+        if: github.event_name == 'workflow_dispatch' && inputs.run_ctest == 'true'
+        shell: pwsh
+        run: |
+          if (-not (Test-Path 'vsbuild')) { throw 'vsbuild directory not found for ctest.' }
+          Push-Location vsbuild
+          try {
+            ctest -C ${{ inputs.build_configuration || 'RelWithDebInfo' }} --output-on-failure
+          } finally {
+            Pop-Location
+          }
+
+      - name: Build Open3DBroadcast plugin (Win64)
+        shell: powershell
+        run: |
+          $pkg = Join-Path $env:RUNNER_TEMP 'PluginPackage'
+          & .\Build\Scripts\Build-Plugin.ps1 `
+            -UEPath "$env:UE_ROOT" `
+            -PluginUPluginPath "${{ steps.core.outputs.uplugin_path }}" `
+            -OutDir "$pkg" `
+            -TargetPlatforms @("Win64") `
+            -Configuration "Development"
+
+      - name: Package artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Open3DBroadcast-Win64-${{ github.sha }}
+          path: ${{ runner.temp }}/PluginPackage
+          retention-days: 30
+
+      - name: Post build completed comment
+        if: github.event_name == 'pull_request' && github.event.pull_request.number != null && success()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `✅ **Open3DBroadcast Plugin CI build completed successfully!**\n\n[View build logs →](${runUrl})\n\n📦 Plugin artifacts are available for download in the workflow run.`
+            });
+
+      - name: Post build failed comment
+        if: github.event_name == 'pull_request' && github.event.pull_request.number != null && failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `❌ **Open3DBroadcast Plugin CI build failed.**\n\n[View build logs →](${runUrl})\n\nPlease check the logs for details.`
+            });

--- a/.github/workflows/open3dbroadcast-plugin-nightly.yml
+++ b/.github/workflows/open3dbroadcast-plugin-nightly.yml
@@ -1,0 +1,103 @@
+name: Open3DBroadcast Plugin Nightly
+
+on:
+  schedule:
+    - cron: "0 3 * * *"  # 3 AM UTC nightly
+  workflow_dispatch:
+    inputs:
+      build_configuration:
+        description: "CMake build configuration"
+        required: false
+        default: RelWithDebInfo
+        type: choice
+        options:
+          - RelWithDebInfo
+          - Release
+      run_editor_tests:
+        description: "Run Unreal automation tests"
+        required: false
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+  checks: write
+
+concurrency:
+  group: open3dbroadcast-plugin-nightly-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  UE_ROOT: 'C:\\Program Files\\Epic Games\\UE_5.6'
+  PLUGIN_NAME: 'Open3DBroadcast'
+
+jobs:
+  nightly-build:
+    runs-on: [ self-hosted, ue5, windows ]
+
+    steps:
+      - name: Build plugin core (composite)
+        id: core
+        uses: ./.github/actions/build-plugin-core
+        with:
+          ue_root: ${{ env.UE_ROOT }}
+          plugin_name: ${{ env.PLUGIN_NAME }}
+          plugin_relative_path: ProjectSandbox/Plugins/Open3DBroadcast
+          build_type: ${{ inputs.build_configuration || 'RelWithDebInfo' }}
+          enable_webrtc: true
+
+      - name: Run ctest
+        shell: pwsh
+        run: |
+          if (-not (Test-Path 'vsbuild')) { throw 'vsbuild directory not found for ctest.' }
+          Push-Location vsbuild
+          try {
+            ctest -C ${{ inputs.build_configuration || 'RelWithDebInfo' }} --output-on-failure
+          } finally {
+            Pop-Location
+          }
+
+      - name: Build Open3DBroadcast plugin (Win64)
+        shell: powershell
+        run: |
+          $pkg = Join-Path $env:RUNNER_TEMP 'PluginPackage'
+          & .\Build\Scripts\Build-Plugin.ps1 `
+            -UEPath "$env:UE_ROOT" `
+            -PluginUPluginPath "${{ steps.core.outputs.uplugin_path }}" `
+            -OutDir "$pkg" `
+            -TargetPlatforms @("Win64") `
+            -Configuration "Shipping"
+
+      - name: Upload plugin package
+        uses: actions/upload-artifact@v4
+        with:
+          name: Open3DBroadcast-Nightly-${{ github.sha }}
+          path: ${{ runner.temp }}/PluginPackage
+          retention-days: 21
+
+      - name: Run Unreal automation tests
+        if: inputs.run_editor_tests != 'false'
+        shell: powershell
+        run: |
+          & .\Build\Scripts\Run-AutomationTests.ps1 `
+            -UEPath "$env:UE_ROOT" `
+            -ProjectFile "$PWD\ProjectSandbox\ProjectSandbox.uproject" `
+            -ResultsDir "$PWD\Artifacts\NightlyAutomation" `
+            -TestFilter "Open3DBroadcast.*"
+
+      - name: Upload automation artifacts
+        if: inputs.run_editor_tests != 'false'
+        uses: actions/upload-artifact@v4
+        with:
+          name: Open3DBroadcast-NightlyTests-${{ github.sha }}
+          path: Artifacts/NightlyAutomation
+          if-no-files-found: ignore
+          retention-days: 21
+
+      - name: Report failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            console.log(`❌ Nightly Open3DBroadcast build failed. See: ${runUrl}`);

--- a/.github/workflows/open3dbroadcast-plugin-release.yml
+++ b/.github/workflows/open3dbroadcast-plugin-release.yml
@@ -1,0 +1,204 @@
+
+name: Open3DBroadcast Plugin Release
+
+on:
+  push:
+    tags:
+      - "open3dbroadcast-v*.*.*"
+  workflow_dispatch:
+    inputs:
+      version_tag:
+        description: 'Version tag (e.g., open3dbroadcast-v1.0.0)'
+        required: true
+        type: string
+      build_configuration:
+        description: 'CMake build configuration'
+        required: false
+        default: Release
+        type: choice
+        options:
+          - Release
+          - RelWithDebInfo
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: open3dbroadcast-plugin-release-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  UE_ROOT: 'C:\Program Files\Epic Games\UE_5.6'
+  PLUGIN_NAME: 'Open3DBroadcast'
+
+jobs:
+  build-release:
+    runs-on: [ self-hosted, ue5, windows ]
+
+    steps:
+      - name: Build plugin core (composite)
+        id: core
+        uses: ./.github/actions/build-plugin-core
+        with:
+          ue_root: ${{ env.UE_ROOT }}
+          plugin_name: ${{ env.PLUGIN_NAME }}
+          plugin_relative_path: ProjectSandbox/Plugins/Open3DBroadcast
+          build_type: ${{ inputs.build_configuration || 'Release' }}
+          enable_webrtc: true
+
+      - name: Determine version
+        id: version
+        shell: powershell
+        run: |
+          if ("${{ github.event_name }}" -eq "workflow_dispatch") {
+            $version = "${{ inputs.version_tag }}"
+          } else {
+            $version = "${{ github.ref_name }}"
+          }
+          $normalized = $version -replace '^open3dbroadcast-v', ''
+          "tag=$version" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          "number=$normalized" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          Write-Host "Version tag: $version"
+          Write-Host "Version number: $normalized"
+
+      - name: Verify required libraries
+        shell: powershell
+        run: |
+          $libRoot = Join-Path "${{ steps.core.outputs.plugin_dir }}" "ThirdParty/Lib/Win64"
+          $required = @(
+            "open3dstreamstatic.lib",
+            "flatbuffers.lib",
+            "nng.lib",
+            "opus.lib"
+          )
+          $missing = @()
+          foreach ($lib in $required) {
+            $full = Join-Path $libRoot $lib
+            if (-not (Test-Path $full)) {
+              $missing += $full
+            }
+          }
+          if ($missing.Count -gt 0) {
+            Write-Error "Missing required third-party libraries:"
+            $missing | ForEach-Object { Write-Error "  - $_" }
+            exit 1
+          }
+          Write-Host "[OK] All required libraries present in $libRoot"
+
+      - name: Update plugin descriptor version
+        shell: powershell
+        run: |
+          $uplugin = "${{ steps.core.outputs.uplugin_path }}"
+          $versionNumber = "${{ steps.version.outputs.number }}"
+          $content = Get-Content -Path $uplugin -Raw | ConvertFrom-Json
+          $content.VersionName = $versionNumber
+          if ($content.Version) {
+            $content.Version = [int]$content.Version + 1
+          }
+          $content | ConvertTo-Json -Depth 10 | Set-Content -Path $uplugin -Encoding UTF8
+          Write-Host "Updated $uplugin to version $versionNumber"
+
+      - name: Build Open3DBroadcast plugin (Win64, Shipping)
+        shell: powershell
+        run: |
+          $pkg = Join-Path $env:RUNNER_TEMP 'PluginPackage'
+          & .\Build\Scripts\Build-Plugin.ps1 `
+            -UEPath "$env:UE_ROOT" `
+            -PluginUPluginPath "${{ steps.core.outputs.uplugin_path }}" `
+            -OutDir "$pkg" `
+            -TargetPlatforms @("Win64") `
+            -Configuration "Shipping"
+
+      - name: Copy ThirdParty payload into packaged plugin
+        shell: powershell
+        run: |
+          $pkg = Join-Path $env:RUNNER_TEMP 'PluginPackage'
+          $sourceThirdParty = Join-Path "${{ steps.core.outputs.plugin_dir }}" 'ThirdParty'
+          $targetThirdParty = Join-Path $pkg 'HostProject/Plugins/Open3DBroadcast/ThirdParty'
+          if (Test-Path $sourceThirdParty) {
+            New-Item -ItemType Directory -Force -Path $targetThirdParty | Out-Null
+            Copy-Item -Path "$sourceThirdParty/*" -Destination $targetThirdParty -Recurse -Force
+            Write-Host "Copied ThirdParty assets into packaged plugin"
+          } else {
+            Write-Warning "No ThirdParty directory found at $sourceThirdParty"
+          }
+
+      - name: Restructure package for archive
+        id: restructure
+        shell: powershell
+        run: |
+          $pkg = Join-Path $env:RUNNER_TEMP 'PluginPackage'
+          $restructured = Join-Path $env:RUNNER_TEMP 'PluginArchive'
+
+          $ueVersionMatch = [regex]::Match($env:UE_ROOT, 'UE_(\d+\.\d+)')
+          if ($ueVersionMatch.Success) {
+            $ueVersion = $ueVersionMatch.Groups[1].Value
+          } else {
+            $ueVersion = '5.6'
+          }
+
+          $targetPath = Join-Path $restructured "UE_$ueVersion/Plugins/Open3DBroadcast"
+          New-Item -ItemType Directory -Force -Path $targetPath | Out-Null
+          Copy-Item -Path "$pkg/*" -Destination $targetPath -Recurse -Force
+          "archive_root=$restructured" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          "ue_version=$ueVersion" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+
+      - name: Create archive
+        id: archive
+        shell: powershell
+        run: |
+          $restructured = "${{ steps.restructure.outputs.archive_root }}"
+          $archiveName = "Open3DBroadcast-Plugin-${{ steps.version.outputs.number }}-Win64.zip"
+          $archivePath = Join-Path $env:RUNNER_TEMP $archiveName
+          Compress-Archive -Path "$restructured/*" -DestinationPath $archivePath -CompressionLevel Optimal
+          "path=$archivePath" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          "name=$archiveName" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          Write-Host "Created archive $archiveName"
+
+      - name: Generate release notes
+        id: notes
+        shell: powershell
+        run: |
+          $notes = @"
+          ## Open3DBroadcast ${{ steps.version.outputs.tag }}
+
+          ### Installation
+
+          1. Download the attached archive.
+          2. Extract the `UE_X.X/Plugins/Open3DBroadcast` folder that matches your Unreal Engine version.
+          3. Copy the folder into your project's `Plugins` directory.
+          4. Restart Unreal Editor and enable **Open3DBroadcast**.
+
+          ### Compatibility
+
+          - **Unreal Engine**: Built with ${{ steps.restructure.outputs.ue_version }} (compatible with UE 5.6+)
+          - **Platform**: Windows (Win64)
+
+          ### Contents
+
+          - Open3DBroadcast plugin modules (Sender, Receiver, Shared, Transport implementations)
+          - Required Open3DStream core libraries and third-party dependencies
+          - Host project with plugin pre-mounted for quick validation
+          "@
+          $notes | Out-File -FilePath "$env:RUNNER_TEMP\release_notes.md" -Encoding UTF8
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.version.outputs.tag }}
+          name: Open3DBroadcast ${{ steps.version.outputs.number }}
+          body_path: ${{ runner.temp }}/release_notes.md
+          files: ${{ steps.archive.outputs.path }}
+          draft: false
+          prerelease: false
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload plugin artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Open3DBroadcast-Release-${{ steps.version.outputs.number }}
+          path: ${{ runner.temp }}/PluginPackage
+          retention-days: 90

--- a/.github/workflows/open3dbroadcast-plugin-test.yml
+++ b/.github/workflows/open3dbroadcast-plugin-test.yml
@@ -1,0 +1,140 @@
+name: Open3DBroadcast Plugin Tests
+
+on:
+  push:
+    branches:
+      - feature/**
+      - bugfix/**
+      - hotfix/**
+  workflow_dispatch:
+    inputs:
+      build_configuration:
+        description: "CMake build configuration"
+        required: false
+        default: RelWithDebInfo
+        type: choice
+        options:
+          - RelWithDebInfo
+          - Debug
+          - Release
+      run_editor_tests:
+        description: "Run Unreal automation tests after packaging"
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+  checks: write
+
+concurrency:
+  group: open3dbroadcast-plugin-test-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  UE_ROOT: 'C:\\Program Files\\Epic Games\\UE_5.6'
+  PLUGIN_NAME: 'Open3DBroadcast'
+
+jobs:
+  changes:
+    name: Detect non-doc changes
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Filter paths (docs vs code)
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          filters: |
+            code:
+              - 'src/**'
+              - 'thirdparty/**'
+              - 'Build/**'
+              - 'CMakeLists.txt'
+              - 'package.py'
+              - 'o3ds.fbs'
+              - 'src/o3ds_generated.h'
+              - 'ProjectSandbox/ProjectSandbox.uproject'
+              - 'ProjectSandbox/Source/**'
+              - 'ProjectSandbox/Plugins/Open3DBroadcast/**'
+              - '.github/actions/**'
+              - '.github/workflows/open3dbroadcast-plugin-test.yml'
+
+  build-test:
+    needs: changes
+    if: >-
+      (github.event_name == 'workflow_dispatch') ||
+      (needs.changes.outputs.code == 'true')
+    runs-on: [ self-hosted, ue5, windows ]
+
+    steps:
+      - name: Checkout (full)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          lfs: true
+          submodules: recursive
+
+      - name: Build plugin core (composite)
+        id: core
+        uses: ./.github/actions/build-plugin-core
+        with:
+          ue_root: ${{ env.UE_ROOT }}
+          plugin_name: ${{ env.PLUGIN_NAME }}
+          plugin_relative_path: ProjectSandbox/Plugins/Open3DBroadcast
+          build_type: ${{ inputs.build_configuration || 'RelWithDebInfo' }}
+          enable_webrtc: true
+
+      - name: Run ctest
+        shell: pwsh
+        run: |
+          if (-not (Test-Path 'vsbuild')) { throw 'vsbuild directory not found for ctest.' }
+          Push-Location vsbuild
+          try {
+            ctest -C ${{ inputs.build_configuration || 'RelWithDebInfo' }} --output-on-failure
+          } finally {
+            Pop-Location
+          }
+
+      - name: Build Open3DBroadcast plugin (Win64)
+        shell: powershell
+        run: |
+          $pkg = Join-Path $env:RUNNER_TEMP 'PluginPackage'
+          & .\Build\Scripts\Build-Plugin.ps1 `
+            -UEPath "$env:UE_ROOT" `
+            -PluginUPluginPath "${{ steps.core.outputs.uplugin_path }}" `
+            -OutDir "$pkg" `
+            -TargetPlatforms @("Win64") `
+            -Configuration "Development"
+
+      - name: Upload plugin artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Open3DBroadcast-Test-${{ github.sha }}
+          path: ${{ runner.temp }}/PluginPackage
+          retention-days: 14
+
+      - name: Run Unreal automation tests
+        if: inputs.run_editor_tests == 'true'
+        shell: powershell
+        run: |
+          & .\Build\Scripts\Run-AutomationTests.ps1 `
+            -UEPath "$env:UE_ROOT" `
+            -ProjectFile "$PWD\ProjectSandbox\ProjectSandbox.uproject" `
+            -ResultsDir "$PWD\Artifacts\AutomationTests" `
+            -TestFilter "Open3DBroadcast.*"
+
+      - name: Upload automation test logs
+        if: inputs.run_editor_tests == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: Open3DBroadcast-AutomationLogs-${{ github.sha }}
+          path: Artifacts/AutomationTests
+          if-no-files-found: ignore
+          retention-days: 14


### PR DESCRIPTION
## Summary
- extend the shared build-plugin-core composite action to resolve custom plugin locations and populate module-level ThirdParty directories
- add CI, test, nightly, and release workflows for the ProjectSandbox/Plugins/Open3DBroadcast plugin with appropriate triggers and artifact publishing

## Testing
- not run (workflow definitions)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914ad56bc888322acaa9e625670d03f)