### PR TITLE
Implement WebRTC transport module using LiveKit FFI

### DIFF
--- a/ProjectSandbox/Plugins/Open3DBroadcast/Source/Open3DTransportWebRTC/Open3DTransportWebRTC.Build.cs
+++ b/ProjectSandbox/Plugins/Open3DBroadcast/Source/Open3DTransportWebRTC/Open3DTransportWebRTC.Build.cs
@@ -54,22 +54,10 @@ public class Open3DTransportWebRTC : ModuleRules
             RuntimeDependencies.Add(livekitFfiDllPath);
         }
 
-        // Opus library (plugin-level ThirdParty)
-        string opusLibPath = Path.Combine(pluginThirdPartyDir, "opus", "lib", platformSubdir, "opus.lib");
-        if (!File.Exists(opusLibPath))
-        {
-            throw new BuildException($"Missing required Opus library 'opus.lib' at '{opusLibPath}'.");
-        }
-        PublicAdditionalLibraries.Add(opusLibPath);
+        // Note: Opus library NOT needed - LiveKit FFI handles Opus encoding/decoding internally.
+        // We only provide/receive PCM16 audio at the API boundary.
 
-        // Opus include path
-        string opusIncludePath = Path.Combine(pluginThirdPartyDir, "Include");
-        if (Directory.Exists(opusIncludePath))
-        {
-            PublicIncludePaths.Add(opusIncludePath);
-        }
-
-        // Open3DStream core library includes
+        // Open3DStream core library includes (for O3DS::SubjectList and O3DS::FAudioFrameMeta)
         string o3dsIncludePath = Path.Combine(pluginThirdPartyDir, "open3dstream", "include");
         if (Directory.Exists(o3dsIncludePath))
         {

--- a/ProjectSandbox/Plugins/Open3DBroadcast/Source/Open3DTransportWebRTC/Open3DTransportWebRTC.Build.cs
+++ b/ProjectSandbox/Plugins/Open3DBroadcast/Source/Open3DTransportWebRTC/Open3DTransportWebRTC.Build.cs
@@ -42,10 +42,11 @@ public class Open3DTransportWebRTC : ModuleRules
 
         // LiveKit FFI include path
         string livekitFfiIncludePath = Path.Combine(moduleThirdPartyDir, "livekit_ffi", "include");
-        if (Directory.Exists(livekitFfiIncludePath))
+        if (!Directory.Exists(livekitFfiIncludePath))
         {
-            PublicIncludePaths.Add(livekitFfiIncludePath);
+            throw new BuildException($"Missing required LiveKit FFI include directory at '{livekitFfiIncludePath}'.");
         }
+        PublicIncludePaths.Add(livekitFfiIncludePath);
 
         // Stage LiveKit FFI DLL to Binaries folder
         string livekitFfiDllPath = Path.Combine(moduleThirdPartyDir, "livekit_ffi", "bin", platformSubdir, "livekit_ffi.dll");

--- a/ProjectSandbox/Plugins/Open3DBroadcast/Source/Open3DTransportWebRTC/Open3DTransportWebRTC.Build.cs
+++ b/ProjectSandbox/Plugins/Open3DBroadcast/Source/Open3DTransportWebRTC/Open3DTransportWebRTC.Build.cs
@@ -49,10 +49,11 @@ public class Open3DTransportWebRTC : ModuleRules
 
         // Stage LiveKit FFI DLL to Binaries folder
         string livekitFfiDllPath = Path.Combine(moduleThirdPartyDir, "livekit_ffi", "bin", platformSubdir, "livekit_ffi.dll");
-        if (File.Exists(livekitFfiDllPath))
+        if (!File.Exists(livekitFfiDllPath))
         {
-            RuntimeDependencies.Add(livekitFfiDllPath);
+            throw new BuildException($"Missing required LiveKit FFI DLL at '{livekitFfiDllPath}'.");
         }
+        RuntimeDependencies.Add(livekitFfiDllPath);
 
         // Note: Opus library NOT needed - LiveKit FFI handles Opus encoding/decoding internally.
         // We only provide/receive PCM16 audio at the API boundary.

--- a/ProjectSandbox/Plugins/Open3DBroadcast/Source/Open3DTransportWebRTC/Open3DTransportWebRTC.Build.cs
+++ b/ProjectSandbox/Plugins/Open3DBroadcast/Source/Open3DTransportWebRTC/Open3DTransportWebRTC.Build.cs
@@ -25,19 +25,63 @@ public class Open3DTransportWebRTC : ModuleRules
         {
             throw new BuildException($"Open3DTransportWebRTC does not define third-party binaries for platform {Target.Platform} yet.");
         }
-        // Opus library
-        var opusLibPath = Path.Combine(PluginDirectory, "ThirdParty", "opus", "lib", platformSubdir, "opus.lib");
+
+        // Plugin-level ThirdParty directory
+        string pluginThirdPartyDir = Path.Combine(PluginDirectory, "..", "..", "ThirdParty");
+
+        // Module-level ThirdParty directory (for LiveKit FFI)
+        string moduleThirdPartyDir = Path.Combine(ModuleDirectory, "ThirdParty");
+
+        // LiveKit FFI library
+        string livekitFfiLibPath = Path.Combine(moduleThirdPartyDir, "livekit_ffi", "lib", platformSubdir, "livekit_ffi.dll.lib");
+        if (!File.Exists(livekitFfiLibPath))
+        {
+            throw new BuildException($"Missing required LiveKit FFI library at '{livekitFfiLibPath}'.");
+        }
+        PublicAdditionalLibraries.Add(livekitFfiLibPath);
+
+        // LiveKit FFI include path
+        string livekitFfiIncludePath = Path.Combine(moduleThirdPartyDir, "livekit_ffi", "include");
+        if (Directory.Exists(livekitFfiIncludePath))
+        {
+            PublicIncludePaths.Add(livekitFfiIncludePath);
+        }
+
+        // Stage LiveKit FFI DLL to Binaries folder
+        string livekitFfiDllPath = Path.Combine(moduleThirdPartyDir, "livekit_ffi", "bin", platformSubdir, "livekit_ffi.dll");
+        if (File.Exists(livekitFfiDllPath))
+        {
+            RuntimeDependencies.Add(livekitFfiDllPath);
+        }
+
+        // Opus library (plugin-level ThirdParty)
+        string opusLibPath = Path.Combine(pluginThirdPartyDir, "opus", "lib", platformSubdir, "opus.lib");
         if (!File.Exists(opusLibPath))
         {
-            throw new BuildException($"Missing required Open3DTransportWebRTC library 'opus.lib' at '{opusLibPath}'.");
+            throw new BuildException($"Missing required Opus library 'opus.lib' at '{opusLibPath}'.");
         }
         PublicAdditionalLibraries.Add(opusLibPath);
+
+        // Opus include path
+        string opusIncludePath = Path.Combine(pluginThirdPartyDir, "Include");
+        if (Directory.Exists(opusIncludePath))
+        {
+            PublicIncludePaths.Add(opusIncludePath);
+        }
+
+        // Open3DStream core library includes
+        string o3dsIncludePath = Path.Combine(pluginThirdPartyDir, "open3dstream", "include");
+        if (Directory.Exists(o3dsIncludePath))
+        {
+            PublicIncludePaths.Add(o3dsIncludePath);
+        }
 
         PublicDependencyModuleNames.AddRange(new string[]
         {
             "Core",
             "CoreUObject",
-            "Engine"
+            "Engine",
+            "Projects" // For IPluginManager
         });
 
         PrivateDependencyModuleNames.AddRange(new string[]
@@ -46,5 +90,15 @@ public class Open3DTransportWebRTC : ModuleRules
             "Open3DSender",
             "Open3DReceiver"
         });
+
+        if (Target.bBuildEditor)
+        {
+            PrivateDependencyModuleNames.AddRange(new string[]
+            {
+                "Slate",
+                "SlateCore",
+                "AppFramework"
+            });
+        }
     }
 }

--- a/ProjectSandbox/Plugins/Open3DBroadcast/Source/Open3DTransportWebRTC/Private/Open3DTransportWebRTCModule.cpp
+++ b/ProjectSandbox/Plugins/Open3DBroadcast/Source/Open3DTransportWebRTC/Private/Open3DTransportWebRTCModule.cpp
@@ -4,7 +4,8 @@
 #include "O3DSenderRegistry.h"
 #include "O3DReceiverRegistry.h"
 
-DEFINE_LOG_CATEGORY(LogO3DWebRTCTransport);
+DEFINE_LOG_CATEGORY(LogO3DWebRTCSender);
+DEFINE_LOG_CATEGORY(LogO3DWebRTCReceiver);
 
 #define LOCTEXT_NAMESPACE "Open3DTransportWebRTC"
 
@@ -19,7 +20,7 @@ public:
 		// Register WebRTC receiver factory
 		O3DTransport::RegisterReceiver(TEXT("WebRTC"), []() { return MakeShared<FO3DWebRTCReceiver>(); });
 
-		UE_LOG(LogO3DWebRTCTransport, Log, TEXT("Open3D WebRTC transport module started (LiveKit FFI backend)"));
+		UE_LOG(LogO3DWebRTCSender, Log, TEXT("Open3D WebRTC transport module started (LiveKit FFI backend)"));
 	}
 
 	virtual void ShutdownModule() override
@@ -28,7 +29,7 @@ public:
 		O3DTransport::UnregisterSender(TEXT("WebRTC"));
 		O3DTransport::UnregisterReceiver(TEXT("WebRTC"));
 
-		UE_LOG(LogO3DWebRTCTransport, Log, TEXT("Open3D WebRTC transport module shut down"));
+		UE_LOG(LogO3DWebRTCSender, Log, TEXT("Open3D WebRTC transport module shut down"));
 	}
 };
 

--- a/ProjectSandbox/Plugins/Open3DBroadcast/Source/Open3DTransportWebRTC/Private/Open3DTransportWebRTCModule.cpp
+++ b/ProjectSandbox/Plugins/Open3DBroadcast/Source/Open3DTransportWebRTC/Private/Open3DTransportWebRTCModule.cpp
@@ -1,10 +1,37 @@
 #include "Modules/ModuleManager.h"
+#include "WebRTCSender.h"
+#include "WebRTCReceiver.h"
+#include "O3DSenderRegistry.h"
+#include "O3DReceiverRegistry.h"
+
+DEFINE_LOG_CATEGORY(LogO3DWebRTCTransport);
+
+#define LOCTEXT_NAMESPACE "Open3DTransportWebRTC"
 
 class FOpen3DTransportWebRTCModule : public IModuleInterface
 {
 public:
-	virtual void StartupModule() override {}
-	virtual void ShutdownModule() override {}
+	virtual void StartupModule() override
+	{
+		// Register WebRTC sender factory
+		O3DTransport::RegisterSender(TEXT("WebRTC"), []() { return MakeShared<FO3DWebRTCSender>(); });
+
+		// Register WebRTC receiver factory
+		O3DTransport::RegisterReceiver(TEXT("WebRTC"), []() { return MakeShared<FO3DWebRTCReceiver>(); });
+
+		UE_LOG(LogO3DWebRTCTransport, Log, TEXT("Open3D WebRTC transport module started (LiveKit FFI backend)"));
+	}
+
+	virtual void ShutdownModule() override
+	{
+		// Unregister transport factories
+		O3DTransport::UnregisterSender(TEXT("WebRTC"));
+		O3DTransport::UnregisterReceiver(TEXT("WebRTC"));
+
+		UE_LOG(LogO3DWebRTCTransport, Log, TEXT("Open3D WebRTC transport module shut down"));
+	}
 };
 
 IMPLEMENT_MODULE(FOpen3DTransportWebRTCModule, Open3DTransportWebRTC)
+
+#undef LOCTEXT_NAMESPACE

--- a/ProjectSandbox/Plugins/Open3DBroadcast/Source/Open3DTransportWebRTC/Private/WebRTCReceiver.cpp
+++ b/ProjectSandbox/Plugins/Open3DBroadcast/Source/Open3DTransportWebRTC/Private/WebRTCReceiver.cpp
@@ -2,6 +2,7 @@
 #include "HAL/PlatformTime.h"
 #include "Logging/LogMacros.h"
 #include "livekit_ffi.h"
+#include "o3ds/model.h"
 
 namespace
 {

--- a/ProjectSandbox/Plugins/Open3DBroadcast/Source/Open3DTransportWebRTC/Private/WebRTCReceiver.cpp
+++ b/ProjectSandbox/Plugins/Open3DBroadcast/Source/Open3DTransportWebRTC/Private/WebRTCReceiver.cpp
@@ -13,14 +13,12 @@ namespace
 }
 
 // Static callback for connection state changes
-void FO3DWebRTCReceiver::OnConnectionState(void* user, int32_t state, int32_t reason_code, const char* message)
+void FO3DWebRTCReceiver::OnConnectionState(void* user, LkConnectionState state, int32_t reason_code, const char* message)
 {
     FO3DWebRTCReceiver* Self = reinterpret_cast<FO3DWebRTCReceiver*>(user);
     if (!Self) return;
 
-    const LkConnectionState ConnState = static_cast<LkConnectionState>(state);
-
-    switch (ConnState)
+    switch (state)
     {
     case LkConnConnecting:
         UE_LOG(LogO3DWebRTCTransport, Log, TEXT("WebRTC receiver connecting..."));

--- a/ProjectSandbox/Plugins/Open3DBroadcast/Source/Open3DTransportWebRTC/Private/WebRTCReceiver.cpp
+++ b/ProjectSandbox/Plugins/Open3DBroadcast/Source/Open3DTransportWebRTC/Private/WebRTCReceiver.cpp
@@ -1,0 +1,359 @@
+#include "WebRTCReceiver.h"
+#include "HAL/PlatformTime.h"
+#include "Logging/LogMacros.h"
+#include "livekit_ffi.h"
+
+namespace
+{
+    static FString FromAnsi(const char* S)
+    {
+        return S ? FString(UTF8_TO_TCHAR(S)) : FString();
+    }
+}
+
+// Static callback for connection state changes
+void FO3DWebRTCReceiver::OnConnectionState(void* user, int32_t state, int32_t reason_code, const char* message)
+{
+    FO3DWebRTCReceiver* Self = reinterpret_cast<FO3DWebRTCReceiver*>(user);
+    if (!Self) return;
+
+    const LkConnectionState ConnState = static_cast<LkConnectionState>(state);
+
+    switch (ConnState)
+    {
+    case LkConnConnecting:
+        UE_LOG(LogO3DWebRTCTransport, Log, TEXT("WebRTC receiver connecting..."));
+        break;
+
+    case LkConnConnected:
+        UE_LOG(LogO3DWebRTCTransport, Log, TEXT("WebRTC receiver connected"));
+        Self->bConnected.Store(true);
+        break;
+
+    case LkConnReconnecting:
+        UE_LOG(LogO3DWebRTCTransport, Warning, TEXT("WebRTC receiver reconnecting..."));
+        Self->bConnected.Store(false);
+        break;
+
+    case LkConnDisconnected:
+        UE_LOG(LogO3DWebRTCTransport, Log, TEXT("WebRTC receiver disconnected: %s"), *FromAnsi(message));
+        Self->bConnected.Store(false);
+        break;
+
+    case LkConnFailed:
+        UE_LOG(LogO3DWebRTCTransport, Error, TEXT("WebRTC receiver connection failed (code=%d): %s"), reason_code, *FromAnsi(message));
+        Self->bConnected.Store(false);
+        break;
+    }
+}
+
+// Static callback for incoming data
+void FO3DWebRTCReceiver::OnDataReceived(void* user, const uint8_t* bytes, size_t len)
+{
+    FO3DWebRTCReceiver* Self = reinterpret_cast<FO3DWebRTCReceiver*>(user);
+    if (!Self || !bytes || len == 0) return;
+
+    const double NowSeconds = FPlatformTime::Seconds();
+
+    // Update stats
+    {
+        FScopeLock Lock(&Self->StatsMutex);
+        Self->Stats.FramesReceived++;
+        Self->Stats.BytesReceived += len;
+
+        // TODO: Extract timestamp from payload for latency calculation
+        // For now, assume minimal latency since LiveKit handles this internally
+        Self->AccumulateLatency(10.0); // Placeholder: 10ms assumed latency
+    }
+
+    // Forward to consumer
+    if (Self->Consumer.IsValid())
+    {
+        TArray<uint8> Payload;
+        Payload.AddUninitialized((int32)len);
+        FMemory::Memcpy(Payload.GetData(), bytes, len);
+
+        Self->Consumer->SubmitFrame(Self->SubjectName, Payload, NowSeconds);
+    }
+}
+
+// Static callback for incoming audio
+void FO3DWebRTCReceiver::OnAudioReceived(void* user, const int16_t* pcm_interleaved, size_t frames_per_channel, int32_t channels, int32_t sample_rate)
+{
+    FO3DWebRTCReceiver* Self = reinterpret_cast<FO3DWebRTCReceiver*>(user);
+    if (!Self || !pcm_interleaved || frames_per_channel == 0 || channels <= 0 || sample_rate <= 0) return;
+
+    {
+        FScopeLock Lock(&Self->StatsMutex);
+        Self->Stats.BytesReceived += frames_per_channel * channels * sizeof(int16);
+    }
+
+    if (Self->AudioSink.IsValid())
+    {
+        // Fill audio metadata
+        O3DS::FAudioFrameMeta Meta;
+        Meta.SampleRate = sample_rate;
+        Meta.NumChannels = channels;
+        Meta.StreamLabel = Self->SubjectName;
+
+        const size_t TotalSamples = frames_per_channel * channels;
+        const size_t NumBytes = TotalSamples * sizeof(int16);
+
+        Self->AudioSink->SubmitPcm16(Meta, reinterpret_cast<const uint8*>(pcm_interleaved), (int32)NumBytes);
+    }
+    else
+    {
+        const double Now = FPlatformTime::Seconds();
+        if (Now - Self->LastAudioDropLogTime > 1.0)
+        {
+            UE_LOG(LogO3DWebRTCTransport, Verbose, TEXT("WebRTC audio frame discarded (no sink) - frames=%d channels=%d sr=%d"),
+                (int32)frames_per_channel, channels, sample_rate);
+            Self->LastAudioDropLogTime = Now;
+        }
+    }
+}
+
+FO3DWebRTCReceiver::FO3DWebRTCReceiver()
+{
+}
+
+FO3DWebRTCReceiver::~FO3DWebRTCReceiver()
+{
+    Stop();
+}
+
+bool FO3DWebRTCReceiver::Initialize(const FO3DTransportConfig& Config)
+{
+    FScopeLock Lock(&StateMutex);
+
+    if (bInitialized.Load())
+    {
+        UE_LOG(LogO3DWebRTCTransport, Warning, TEXT("WebRTC receiver already initialized"));
+        return false;
+    }
+
+    if (!ParseConfig(Config))
+    {
+        return false;
+    }
+
+    // Create LiveKit client handle
+    ClientHandle = lk_client_create();
+    if (!ClientHandle)
+    {
+        UE_LOG(LogO3DWebRTCTransport, Error, TEXT("Failed to create LiveKit client"));
+        return false;
+    }
+
+    // Set connection callback
+    LkResult Result = lk_set_connection_callback(ClientHandle, &FO3DWebRTCReceiver::OnConnectionState, this);
+    if (Result.code != 0)
+    {
+        UE_LOG(LogO3DWebRTCTransport, Warning, TEXT("Failed to set connection callback: %s"), *FromAnsi(Result.message));
+        if (Result.message)
+        {
+            lk_free_str(const_cast<char*>(Result.message));
+        }
+    }
+
+    // Set data callback
+    Result = lk_client_set_data_callback(ClientHandle, &FO3DWebRTCReceiver::OnDataReceived, this);
+    if (Result.code != 0)
+    {
+        UE_LOG(LogO3DWebRTCTransport, Warning, TEXT("Failed to set data callback: %s"), *FromAnsi(Result.message));
+        if (Result.message)
+        {
+            lk_free_str(const_cast<char*>(Result.message));
+        }
+    }
+
+    // Set audio callback
+    Result = lk_client_set_audio_callback(ClientHandle, &FO3DWebRTCReceiver::OnAudioReceived, this);
+    if (Result.code != 0)
+    {
+        UE_LOG(LogO3DWebRTCTransport, Warning, TEXT("Failed to set audio callback: %s"), *FromAnsi(Result.message));
+        if (Result.message)
+        {
+            lk_free_str(const_cast<char*>(Result.message));
+        }
+    }
+
+    // Configure audio output format if needed
+    if (Config.Audio.bEnableAudio)
+    {
+        ActiveAudioConfig = Config.Audio;
+        Result = lk_set_audio_output_format(ClientHandle, ActiveAudioConfig.SampleRate, ActiveAudioConfig.NumChannels);
+
+        if (Result.code != 0)
+        {
+            UE_LOG(LogO3DWebRTCTransport, Warning, TEXT("Failed to set audio output format: %s"), *FromAnsi(Result.message));
+            if (Result.message)
+            {
+                lk_free_str(const_cast<char*>(Result.message));
+            }
+        }
+    }
+
+    ActiveConfig = Config;
+    Stats.Reset();
+    LatencySamples = 0;
+    LastAudioDropLogTime = 0.0;
+    bInitialized.Store(true);
+
+    UE_LOG(LogO3DWebRTCTransport, Log, TEXT("WebRTC receiver initialized: URL=%s"),
+        *RoomUrl);
+
+    return true;
+}
+
+void FO3DWebRTCReceiver::SetConsumer(const TSharedPtr<ISerializedFrameConsumer>& InConsumer)
+{
+    FScopeLock Lock(&StateMutex);
+    Consumer = InConsumer;
+}
+
+bool FO3DWebRTCReceiver::Start()
+{
+    FScopeLock Lock(&StateMutex);
+
+    if (!bInitialized.Load())
+    {
+        UE_LOG(LogO3DWebRTCTransport, Error, TEXT("Cannot start WebRTC receiver: not initialized"));
+        return false;
+    }
+
+    if (bConnected.Load())
+    {
+        UE_LOG(LogO3DWebRTCTransport, Warning, TEXT("WebRTC receiver already connected"));
+        return true;
+    }
+
+    // Create default consumer if not set
+    if (!Consumer.IsValid())
+    {
+        Consumer = FSerializedFrameConsumerRegistry::Create();
+        if (!Consumer.IsValid())
+        {
+            UE_LOG(LogO3DWebRTCTransport, Warning, TEXT("No serialized frame consumer registered; frames will be dropped"));
+        }
+    }
+
+    // Connect asynchronously with Subscriber role
+    LkResult Result = lk_connect_with_role_async(
+        ClientHandle,
+        TCHAR_TO_UTF8(*RoomUrl),
+        TCHAR_TO_UTF8(*Token),
+        LkRoleSubscriber
+    );
+
+    if (Result.code != 0)
+    {
+        UE_LOG(LogO3DWebRTCTransport, Error, TEXT("Failed to connect: %s"), *FromAnsi(Result.message));
+        if (Result.message)
+        {
+            lk_free_str(const_cast<char*>(Result.message));
+        }
+        return false;
+    }
+
+    UE_LOG(LogO3DWebRTCTransport, Log, TEXT("WebRTC receiver connecting..."));
+    return true;
+}
+
+void FO3DWebRTCReceiver::Stop()
+{
+    FScopeLock Lock(&StateMutex);
+
+    if (!ClientHandle)
+    {
+        return;
+    }
+
+    if (bConnected.Load())
+    {
+        LkResult Result = lk_disconnect(ClientHandle);
+        if (Result.code != 0 && Result.message)
+        {
+            UE_LOG(LogO3DWebRTCTransport, Warning, TEXT("Disconnect warning: %s"), *FromAnsi(Result.message));
+            lk_free_str(const_cast<char*>(Result.message));
+        }
+    }
+
+    lk_client_destroy(ClientHandle);
+    ClientHandle = nullptr;
+
+    Consumer.Reset();
+    AudioSink.Reset();
+
+    bConnected.Store(false);
+    bInitialized.Store(false);
+
+    UE_LOG(LogO3DWebRTCTransport, Log, TEXT("WebRTC receiver stopped"));
+}
+
+int32 FO3DWebRTCReceiver::Poll()
+{
+    // LiveKit FFI delivers data via callbacks, so Poll() is a no-op
+    // Callbacks handle data delivery directly
+    return 0;
+}
+
+FO3DTransportStats FO3DWebRTCReceiver::GetStats() const
+{
+    FScopeLock Lock(&StatsMutex);
+    return Stats;
+}
+
+void FO3DWebRTCReceiver::SetAudioSink(const TSharedPtr<IO3DReceiverAudioSink, ESPMode::ThreadSafe>& Sink, const FO3DTransportAudioConfig& AudioConfig)
+{
+    FScopeLock Lock(&StateMutex);
+    AudioSink = Sink;
+    ActiveAudioConfig = AudioConfig;
+
+    if (ClientHandle && bInitialized.Load())
+    {
+        LkResult Result = lk_set_audio_output_format(ClientHandle, ActiveAudioConfig.SampleRate, ActiveAudioConfig.NumChannels);
+        if (Result.code != 0)
+        {
+            UE_LOG(LogO3DWebRTCTransport, Warning, TEXT("Failed to update audio output format: %s"), *FromAnsi(Result.message));
+            if (Result.message)
+            {
+                lk_free_str(const_cast<char*>(Result.message));
+            }
+        }
+    }
+}
+
+bool FO3DWebRTCReceiver::ParseConfig(const FO3DTransportConfig& Config)
+{
+    RoomUrl = Config.Uri;
+    if (RoomUrl.IsEmpty())
+    {
+        UE_LOG(LogO3DWebRTCTransport, Error, TEXT("WebRTC URL not specified"));
+        return false;
+    }
+
+    Token = Config.Token;
+    if (Token.IsEmpty())
+    {
+        UE_LOG(LogO3DWebRTCTransport, Error, TEXT("WebRTC token not provided"));
+        return false;
+    }
+
+    // Use StreamId as subject name if provided, otherwise use a default
+    SubjectName = Config.StreamId.IsEmpty() ? TEXT("WebRTCStream") : Config.StreamId;
+
+    return true;
+}
+
+void FO3DWebRTCReceiver::AccumulateLatency(double LatencyMs)
+{
+    FScopeLock Lock(&StatsMutex);
+
+    Stats.MaxLatencyMs = FMath::Max(Stats.MaxLatencyMs, LatencyMs);
+
+    const int64 NewSampleCount = LatencySamples + 1;
+    const double PreviousTotal = Stats.AverageLatencyMs * LatencySamples;
+    Stats.AverageLatencyMs = (PreviousTotal + LatencyMs) / FMath::Max<int64>(1, NewSampleCount);
+    LatencySamples = NewSampleCount;
+}

--- a/ProjectSandbox/Plugins/Open3DBroadcast/Source/Open3DTransportWebRTC/Private/WebRTCReceiver.cpp
+++ b/ProjectSandbox/Plugins/Open3DBroadcast/Source/Open3DTransportWebRTC/Private/WebRTCReceiver.cpp
@@ -84,6 +84,7 @@ void FO3DWebRTCReceiver::OnAudioReceived(void* user, const int16_t* pcm_interlea
 
     {
         FScopeLock Lock(&Self->StatsMutex);
+        Self->Stats.FramesReceived++;  // Count audio frames
         Self->Stats.BytesReceived += frames_per_channel * channels * sizeof(int16);
     }
 

--- a/ProjectSandbox/Plugins/Open3DBroadcast/Source/Open3DTransportWebRTC/Private/WebRTCReceiver.cpp
+++ b/ProjectSandbox/Plugins/Open3DBroadcast/Source/Open3DTransportWebRTC/Private/WebRTCReceiver.cpp
@@ -147,7 +147,7 @@ bool FO3DWebRTCReceiver::Initialize(const FO3DTransportConfig& Config)
     }
 
     // Set connection callback
-    LkResult Result = lk_set_connection_callback(ClientHandle, &FO3DWebRTCReceiver::OnConnectionState, this);
+    LkResult Result = lk_set_connection_callback(ClientHandle, FO3DWebRTCReceiver::OnConnectionState, this);
     if (Result.code != 0)
     {
         UE_LOG(LogO3DWebRTCTransport, Warning, TEXT("Failed to set connection callback: %s"), *FromAnsi(Result.message));
@@ -158,7 +158,7 @@ bool FO3DWebRTCReceiver::Initialize(const FO3DTransportConfig& Config)
     }
 
     // Set data callback
-    Result = lk_client_set_data_callback(ClientHandle, &FO3DWebRTCReceiver::OnDataReceived, this);
+    Result = lk_client_set_data_callback(ClientHandle, FO3DWebRTCReceiver::OnDataReceived, this);
     if (Result.code != 0)
     {
         UE_LOG(LogO3DWebRTCTransport, Warning, TEXT("Failed to set data callback: %s"), *FromAnsi(Result.message));
@@ -169,7 +169,7 @@ bool FO3DWebRTCReceiver::Initialize(const FO3DTransportConfig& Config)
     }
 
     // Set audio callback
-    Result = lk_client_set_audio_callback(ClientHandle, &FO3DWebRTCReceiver::OnAudioReceived, this);
+    Result = lk_client_set_audio_callback(ClientHandle, FO3DWebRTCReceiver::OnAudioReceived, this);
     if (Result.code != 0)
     {
         UE_LOG(LogO3DWebRTCTransport, Warning, TEXT("Failed to set audio callback: %s"), *FromAnsi(Result.message));

--- a/ProjectSandbox/Plugins/Open3DBroadcast/Source/Open3DTransportWebRTC/Private/WebRTCReceiver.cpp
+++ b/ProjectSandbox/Plugins/Open3DBroadcast/Source/Open3DTransportWebRTC/Private/WebRTCReceiver.cpp
@@ -21,26 +21,26 @@ void FO3DWebRTCReceiver::OnConnectionState(void* user, LkConnectionState state, 
     switch (state)
     {
     case LkConnConnecting:
-        UE_LOG(LogO3DWebRTCTransport, Log, TEXT("WebRTC receiver connecting..."));
+        UE_LOG(LogO3DWebRTCReceiver, Log, TEXT("WebRTC receiver connecting..."));
         break;
 
     case LkConnConnected:
-        UE_LOG(LogO3DWebRTCTransport, Log, TEXT("WebRTC receiver connected"));
+        UE_LOG(LogO3DWebRTCReceiver, Log, TEXT("WebRTC receiver connected"));
         Self->bConnected.Store(true);
         break;
 
     case LkConnReconnecting:
-        UE_LOG(LogO3DWebRTCTransport, Warning, TEXT("WebRTC receiver reconnecting..."));
+        UE_LOG(LogO3DWebRTCReceiver, Warning, TEXT("WebRTC receiver reconnecting..."));
         Self->bConnected.Store(false);
         break;
 
     case LkConnDisconnected:
-        UE_LOG(LogO3DWebRTCTransport, Log, TEXT("WebRTC receiver disconnected: %s"), *FromAnsi(message));
+        UE_LOG(LogO3DWebRTCReceiver, Log, TEXT("WebRTC receiver disconnected: %s"), *FromAnsi(message));
         Self->bConnected.Store(false);
         break;
 
     case LkConnFailed:
-        UE_LOG(LogO3DWebRTCTransport, Error, TEXT("WebRTC receiver connection failed (code=%d): %s"), reason_code, *FromAnsi(message));
+        UE_LOG(LogO3DWebRTCReceiver, Error, TEXT("WebRTC receiver connection failed (code=%d): %s"), reason_code, *FromAnsi(message));
         Self->bConnected.Store(false);
         break;
     }
@@ -105,7 +105,7 @@ void FO3DWebRTCReceiver::OnAudioReceived(void* user, const int16_t* pcm_interlea
         const double Now = FPlatformTime::Seconds();
         if (Now - Self->LastAudioDropLogTime > 1.0)
         {
-            UE_LOG(LogO3DWebRTCTransport, Verbose, TEXT("WebRTC audio frame discarded (no sink) - frames=%d channels=%d sr=%d"),
+            UE_LOG(LogO3DWebRTCReceiver, Verbose, TEXT("WebRTC audio frame discarded (no sink) - frames=%d channels=%d sr=%d"),
                 (int32)frames_per_channel, channels, sample_rate);
             Self->LastAudioDropLogTime = Now;
         }
@@ -127,7 +127,7 @@ bool FO3DWebRTCReceiver::Initialize(const FO3DTransportConfig& Config)
 
     if (bInitialized.Load())
     {
-        UE_LOG(LogO3DWebRTCTransport, Warning, TEXT("WebRTC receiver already initialized"));
+        UE_LOG(LogO3DWebRTCReceiver, Warning, TEXT("WebRTC receiver already initialized"));
         return false;
     }
 
@@ -140,7 +140,7 @@ bool FO3DWebRTCReceiver::Initialize(const FO3DTransportConfig& Config)
     ClientHandle = lk_client_create();
     if (!ClientHandle)
     {
-        UE_LOG(LogO3DWebRTCTransport, Error, TEXT("Failed to create LiveKit client"));
+        UE_LOG(LogO3DWebRTCReceiver, Error, TEXT("Failed to create LiveKit client"));
         return false;
     }
 
@@ -148,7 +148,7 @@ bool FO3DWebRTCReceiver::Initialize(const FO3DTransportConfig& Config)
     LkResult Result = lk_set_connection_callback(ClientHandle, FO3DWebRTCReceiver::OnConnectionState, this);
     if (Result.code != 0)
     {
-        UE_LOG(LogO3DWebRTCTransport, Warning, TEXT("Failed to set connection callback: %s"), *FromAnsi(Result.message));
+        UE_LOG(LogO3DWebRTCReceiver, Warning, TEXT("Failed to set connection callback: %s"), *FromAnsi(Result.message));
         if (Result.message)
         {
             lk_free_str(const_cast<char*>(Result.message));
@@ -159,7 +159,7 @@ bool FO3DWebRTCReceiver::Initialize(const FO3DTransportConfig& Config)
     Result = lk_client_set_data_callback(ClientHandle, FO3DWebRTCReceiver::OnDataReceived, this);
     if (Result.code != 0)
     {
-        UE_LOG(LogO3DWebRTCTransport, Warning, TEXT("Failed to set data callback: %s"), *FromAnsi(Result.message));
+        UE_LOG(LogO3DWebRTCReceiver, Warning, TEXT("Failed to set data callback: %s"), *FromAnsi(Result.message));
         if (Result.message)
         {
             lk_free_str(const_cast<char*>(Result.message));
@@ -170,7 +170,7 @@ bool FO3DWebRTCReceiver::Initialize(const FO3DTransportConfig& Config)
     Result = lk_client_set_audio_callback(ClientHandle, FO3DWebRTCReceiver::OnAudioReceived, this);
     if (Result.code != 0)
     {
-        UE_LOG(LogO3DWebRTCTransport, Warning, TEXT("Failed to set audio callback: %s"), *FromAnsi(Result.message));
+        UE_LOG(LogO3DWebRTCReceiver, Warning, TEXT("Failed to set audio callback: %s"), *FromAnsi(Result.message));
         if (Result.message)
         {
             lk_free_str(const_cast<char*>(Result.message));
@@ -185,7 +185,7 @@ bool FO3DWebRTCReceiver::Initialize(const FO3DTransportConfig& Config)
 
         if (Result.code != 0)
         {
-            UE_LOG(LogO3DWebRTCTransport, Warning, TEXT("Failed to set audio output format: %s"), *FromAnsi(Result.message));
+            UE_LOG(LogO3DWebRTCReceiver, Warning, TEXT("Failed to set audio output format: %s"), *FromAnsi(Result.message));
             if (Result.message)
             {
                 lk_free_str(const_cast<char*>(Result.message));
@@ -199,7 +199,7 @@ bool FO3DWebRTCReceiver::Initialize(const FO3DTransportConfig& Config)
     LastAudioDropLogTime = 0.0;
     bInitialized.Store(true);
 
-    UE_LOG(LogO3DWebRTCTransport, Log, TEXT("WebRTC receiver initialized: URL=%s"),
+    UE_LOG(LogO3DWebRTCReceiver, Log, TEXT("WebRTC receiver initialized: URL=%s"),
         *RoomUrl);
 
     return true;
@@ -217,13 +217,13 @@ bool FO3DWebRTCReceiver::Start()
 
     if (!bInitialized.Load())
     {
-        UE_LOG(LogO3DWebRTCTransport, Error, TEXT("Cannot start WebRTC receiver: not initialized"));
+        UE_LOG(LogO3DWebRTCReceiver, Error, TEXT("Cannot start WebRTC receiver: not initialized"));
         return false;
     }
 
     if (bConnected.Load())
     {
-        UE_LOG(LogO3DWebRTCTransport, Warning, TEXT("WebRTC receiver already connected"));
+        UE_LOG(LogO3DWebRTCReceiver, Warning, TEXT("WebRTC receiver already connected"));
         return true;
     }
 
@@ -233,7 +233,7 @@ bool FO3DWebRTCReceiver::Start()
         Consumer = FSerializedFrameConsumerRegistry::Create();
         if (!Consumer.IsValid())
         {
-            UE_LOG(LogO3DWebRTCTransport, Warning, TEXT("No serialized frame consumer registered; frames will be dropped"));
+            UE_LOG(LogO3DWebRTCReceiver, Warning, TEXT("No serialized frame consumer registered; frames will be dropped"));
         }
     }
 
@@ -247,7 +247,7 @@ bool FO3DWebRTCReceiver::Start()
 
     if (Result.code != 0)
     {
-        UE_LOG(LogO3DWebRTCTransport, Error, TEXT("Failed to connect: %s"), *FromAnsi(Result.message));
+        UE_LOG(LogO3DWebRTCReceiver, Error, TEXT("Failed to connect: %s"), *FromAnsi(Result.message));
         if (Result.message)
         {
             lk_free_str(const_cast<char*>(Result.message));
@@ -255,7 +255,7 @@ bool FO3DWebRTCReceiver::Start()
         return false;
     }
 
-    UE_LOG(LogO3DWebRTCTransport, Log, TEXT("WebRTC receiver connecting..."));
+    UE_LOG(LogO3DWebRTCReceiver, Log, TEXT("WebRTC receiver connecting..."));
     return true;
 }
 
@@ -273,7 +273,7 @@ void FO3DWebRTCReceiver::Stop()
         LkResult Result = lk_disconnect(ClientHandle);
         if (Result.code != 0 && Result.message)
         {
-            UE_LOG(LogO3DWebRTCTransport, Warning, TEXT("Disconnect warning: %s"), *FromAnsi(Result.message));
+            UE_LOG(LogO3DWebRTCReceiver, Warning, TEXT("Disconnect warning: %s"), *FromAnsi(Result.message));
             lk_free_str(const_cast<char*>(Result.message));
         }
     }
@@ -287,7 +287,7 @@ void FO3DWebRTCReceiver::Stop()
     bConnected.Store(false);
     bInitialized.Store(false);
 
-    UE_LOG(LogO3DWebRTCTransport, Log, TEXT("WebRTC receiver stopped"));
+    UE_LOG(LogO3DWebRTCReceiver, Log, TEXT("WebRTC receiver stopped"));
 }
 
 int32 FO3DWebRTCReceiver::Poll()
@@ -314,7 +314,7 @@ void FO3DWebRTCReceiver::SetAudioSink(const TSharedPtr<IO3DReceiverAudioSink, ES
         LkResult Result = lk_set_audio_output_format(ClientHandle, ActiveAudioConfig.SampleRate, ActiveAudioConfig.NumChannels);
         if (Result.code != 0)
         {
-            UE_LOG(LogO3DWebRTCTransport, Warning, TEXT("Failed to update audio output format: %s"), *FromAnsi(Result.message));
+            UE_LOG(LogO3DWebRTCReceiver, Warning, TEXT("Failed to update audio output format: %s"), *FromAnsi(Result.message));
             if (Result.message)
             {
                 lk_free_str(const_cast<char*>(Result.message));
@@ -328,14 +328,14 @@ bool FO3DWebRTCReceiver::ParseConfig(const FO3DTransportConfig& Config)
     RoomUrl = Config.Uri;
     if (RoomUrl.IsEmpty())
     {
-        UE_LOG(LogO3DWebRTCTransport, Error, TEXT("WebRTC URL not specified"));
+        UE_LOG(LogO3DWebRTCReceiver, Error, TEXT("WebRTC URL not specified"));
         return false;
     }
 
     Token = Config.Token;
     if (Token.IsEmpty())
     {
-        UE_LOG(LogO3DWebRTCTransport, Error, TEXT("WebRTC token not provided"));
+        UE_LOG(LogO3DWebRTCReceiver, Error, TEXT("WebRTC token not provided"));
         return false;
     }
 

--- a/ProjectSandbox/Plugins/Open3DBroadcast/Source/Open3DTransportWebRTC/Private/WebRTCReceiver.h
+++ b/ProjectSandbox/Plugins/Open3DBroadcast/Source/Open3DTransportWebRTC/Private/WebRTCReceiver.h
@@ -1,0 +1,68 @@
+#pragma once
+
+#include "O3DReceiverInterface.h"
+#include "O3DTransportTypes.h"
+#include "SerializedFrameConsumerRegistry.h"
+#include "HAL/CriticalSection.h"
+#include "Templates/Atomic.h"
+
+// Forward declare LiveKit FFI types
+struct LkClientHandle;
+
+/**
+ * WebRTC transport receiver implementation using LiveKit FFI.
+ * Adapts the LiveKit FFI C ABI to the IOpen3DReceiver interface.
+ */
+class FO3DWebRTCReceiver : public IOpen3DReceiver
+{
+public:
+    FO3DWebRTCReceiver();
+    virtual ~FO3DWebRTCReceiver() override;
+
+    // IOpen3DReceiver interface
+    virtual bool Initialize(const FO3DTransportConfig& Config) override;
+    virtual void SetConsumer(const TSharedPtr<ISerializedFrameConsumer>& Consumer) override;
+    virtual bool Start() override;
+    virtual void Stop() override;
+    virtual int32 Poll() override;
+    virtual FO3DTransportStats GetStats() const override;
+    virtual bool SupportsAudio() const override { return true; }
+    virtual void SetAudioSink(const TSharedPtr<IO3DReceiverAudioSink, ESPMode::ThreadSafe>& Sink, const FO3DTransportAudioConfig& AudioConfig) override;
+
+private:
+    // Configuration
+    FO3DTransportConfig ActiveConfig;
+    FO3DTransportAudioConfig ActiveAudioConfig;
+    FString RoomUrl;
+    FString Token;
+    FString SubjectName;
+
+    // LiveKit FFI client handle (opaque)
+    LkClientHandle* ClientHandle = nullptr;
+
+    // State
+    mutable FCriticalSection StateMutex;
+    TAtomic<bool> bInitialized{ false };
+    TAtomic<bool> bConnected{ false };
+
+    // Consumer
+    TSharedPtr<ISerializedFrameConsumer> Consumer;
+    TSharedPtr<IO3DReceiverAudioSink, ESPMode::ThreadSafe> AudioSink;
+
+    // Stats
+    mutable FCriticalSection StatsMutex;
+    FO3DTransportStats Stats;
+    int64 LatencySamples = 0;
+
+    // Helper methods
+    bool ParseConfig(const FO3DTransportConfig& Config);
+    void AccumulateLatency(double LatencyMs);
+
+    // LiveKit FFI callbacks (static)
+    struct FCallbacks;
+    static void OnConnectionState(void* user, int32_t state, int32_t reason_code, const char* message);
+    static void OnDataReceived(void* user, const uint8_t* bytes, size_t len);
+    static void OnAudioReceived(void* user, const int16_t* pcm_interleaved, size_t frames_per_channel, int32_t channels, int32_t sample_rate);
+
+    double LastAudioDropLogTime = 0.0;
+};

--- a/ProjectSandbox/Plugins/Open3DBroadcast/Source/Open3DTransportWebRTC/Private/WebRTCReceiver.h
+++ b/ProjectSandbox/Plugins/Open3DBroadcast/Source/Open3DTransportWebRTC/Private/WebRTCReceiver.h
@@ -6,9 +6,10 @@
 #include "HAL/CriticalSection.h"
 #include "Templates/Atomic.h"
 
-// Forward declare LiveKit FFI types
-struct LkClientHandle;
-enum LkConnectionState : int;
+// Include LiveKit FFI for callback types
+#include "livekit_ffi.h"
+
+DECLARE_LOG_CATEGORY_EXTERN(LogO3DWebRTCReceiver, Log, All);
 
 // Note: LiveKit FFI handles Opus decoding internally.
 // We receive PCM16 audio directly via the audio callback.

--- a/ProjectSandbox/Plugins/Open3DBroadcast/Source/Open3DTransportWebRTC/Private/WebRTCReceiver.h
+++ b/ProjectSandbox/Plugins/Open3DBroadcast/Source/Open3DTransportWebRTC/Private/WebRTCReceiver.h
@@ -9,6 +9,8 @@
 // Forward declare LiveKit FFI types
 struct LkClientHandle;
 
+DECLARE_LOG_CATEGORY_EXTERN(LogO3DWebRTCTransport, Log, All);
+
 // Note: LiveKit FFI handles Opus decoding internally.
 // We receive PCM16 audio directly via the audio callback.
 

--- a/ProjectSandbox/Plugins/Open3DBroadcast/Source/Open3DTransportWebRTC/Private/WebRTCReceiver.h
+++ b/ProjectSandbox/Plugins/Open3DBroadcast/Source/Open3DTransportWebRTC/Private/WebRTCReceiver.h
@@ -8,8 +8,7 @@
 
 // Forward declare LiveKit FFI types
 struct LkClientHandle;
-
-DECLARE_LOG_CATEGORY_EXTERN(LogO3DWebRTCTransport, Log, All);
+enum LkConnectionState : int;
 
 // Note: LiveKit FFI handles Opus decoding internally.
 // We receive PCM16 audio directly via the audio callback.
@@ -65,7 +64,7 @@ private:
 
     // LiveKit FFI callbacks (static)
     struct FCallbacks;
-    static void OnConnectionState(void* user, int32_t state, int32_t reason_code, const char* message);
+    static void OnConnectionState(void* user, LkConnectionState state, int32_t reason_code, const char* message);
     static void OnDataReceived(void* user, const uint8_t* bytes, size_t len);
     static void OnAudioReceived(void* user, const int16_t* pcm_interleaved, size_t frames_per_channel, int32_t channels, int32_t sample_rate);
 

--- a/ProjectSandbox/Plugins/Open3DBroadcast/Source/Open3DTransportWebRTC/Private/WebRTCReceiver.h
+++ b/ProjectSandbox/Plugins/Open3DBroadcast/Source/Open3DTransportWebRTC/Private/WebRTCReceiver.h
@@ -9,6 +9,9 @@
 // Forward declare LiveKit FFI types
 struct LkClientHandle;
 
+// Note: LiveKit FFI handles Opus decoding internally.
+// We receive PCM16 audio directly via the audio callback.
+
 /**
  * WebRTC transport receiver implementation using LiveKit FFI.
  * Adapts the LiveKit FFI C ABI to the IOpen3DReceiver interface.

--- a/ProjectSandbox/Plugins/Open3DBroadcast/Source/Open3DTransportWebRTC/Private/WebRTCSender.cpp
+++ b/ProjectSandbox/Plugins/Open3DBroadcast/Source/Open3DTransportWebRTC/Private/WebRTCSender.cpp
@@ -44,16 +44,16 @@ namespace
             if (Handle)
             {
                 GLiveKitFfiHandle = Handle;
-                UE_LOG(LogO3DWebRTCTransport, Log, TEXT("LiveKit FFI loaded: %s"), *Candidate);
+                UE_LOG(LogO3DWebRTCSender, Log, TEXT("LiveKit FFI loaded: %s"), *Candidate);
             }
             else
             {
-                UE_LOG(LogO3DWebRTCTransport, Warning, TEXT("Failed to load LiveKit FFI from %s"), *Candidate);
+                UE_LOG(LogO3DWebRTCSender, Warning, TEXT("Failed to load LiveKit FFI from %s"), *Candidate);
             }
         }
         else
         {
-            UE_LOG(LogO3DWebRTCTransport, Warning, TEXT("LiveKit FFI DLL not found at: %s"), *Candidate);
+            UE_LOG(LogO3DWebRTCSender, Warning, TEXT("LiveKit FFI DLL not found at: %s"), *Candidate);
         }
 #endif
     }
@@ -107,7 +107,7 @@ public:
 
         if (Result.code != 0)
         {
-            UE_LOG(LogO3DWebRTCTransport, Warning, TEXT("Failed to publish audio: %s"), *FromAnsi(Result.message));
+            UE_LOG(LogO3DWebRTCSender, Warning, TEXT("Failed to publish audio: %s"), *FromAnsi(Result.message));
             if (Result.message)
             {
                 lk_free_str(const_cast<char*>(Result.message));
@@ -136,26 +136,26 @@ void FO3DWebRTCSender::OnConnectionState(void* user, LkConnectionState state, in
     switch (state)
     {
     case LkConnConnecting:
-        UE_LOG(LogO3DWebRTCTransport, Log, TEXT("WebRTC connecting..."));
+        UE_LOG(LogO3DWebRTCSender, Log, TEXT("WebRTC connecting..."));
         break;
 
     case LkConnConnected:
-        UE_LOG(LogO3DWebRTCTransport, Log, TEXT("WebRTC connected"));
+        UE_LOG(LogO3DWebRTCSender, Log, TEXT("WebRTC connected"));
         Self->bConnected.Store(true);
         break;
 
     case LkConnReconnecting:
-        UE_LOG(LogO3DWebRTCTransport, Warning, TEXT("WebRTC reconnecting..."));
+        UE_LOG(LogO3DWebRTCSender, Warning, TEXT("WebRTC reconnecting..."));
         Self->bConnected.Store(false);
         break;
 
     case LkConnDisconnected:
-        UE_LOG(LogO3DWebRTCTransport, Log, TEXT("WebRTC disconnected: %s"), *FromAnsi(message));
+        UE_LOG(LogO3DWebRTCSender, Log, TEXT("WebRTC disconnected: %s"), *FromAnsi(message));
         Self->bConnected.Store(false);
         break;
 
     case LkConnFailed:
-        UE_LOG(LogO3DWebRTCTransport, Error, TEXT("WebRTC connection failed (code=%d): %s"), reason_code, *FromAnsi(message));
+        UE_LOG(LogO3DWebRTCSender, Error, TEXT("WebRTC connection failed (code=%d): %s"), reason_code, *FromAnsi(message));
         Self->bConnected.Store(false);
         break;
     }
@@ -177,7 +177,7 @@ bool FO3DWebRTCSender::Initialize(const FO3DTransportConfig& Config)
 
     if (bInitialized.Load())
     {
-        UE_LOG(LogO3DWebRTCTransport, Warning, TEXT("WebRTC sender already initialized"));
+        UE_LOG(LogO3DWebRTCSender, Warning, TEXT("WebRTC sender already initialized"));
         return false;
     }
 
@@ -190,7 +190,7 @@ bool FO3DWebRTCSender::Initialize(const FO3DTransportConfig& Config)
     ClientHandle = lk_client_create();
     if (!ClientHandle)
     {
-        UE_LOG(LogO3DWebRTCTransport, Error, TEXT("Failed to create LiveKit client"));
+        UE_LOG(LogO3DWebRTCSender, Error, TEXT("Failed to create LiveKit client"));
         return false;
     }
 
@@ -198,7 +198,7 @@ bool FO3DWebRTCSender::Initialize(const FO3DTransportConfig& Config)
     LkResult Result = lk_set_connection_callback(ClientHandle, FO3DWebRTCSender::OnConnectionState, this);
     if (Result.code != 0)
     {
-        UE_LOG(LogO3DWebRTCTransport, Warning, TEXT("Failed to set connection callback: %s"), *FromAnsi(Result.message));
+        UE_LOG(LogO3DWebRTCSender, Warning, TEXT("Failed to set connection callback: %s"), *FromAnsi(Result.message));
         if (Result.message)
         {
             lk_free_str(const_cast<char*>(Result.message));
@@ -215,7 +215,7 @@ bool FO3DWebRTCSender::Initialize(const FO3DTransportConfig& Config)
 
         if (Result.code != 0)
         {
-            UE_LOG(LogO3DWebRTCTransport, Warning, TEXT("Failed to set audio options: %s"), *FromAnsi(Result.message));
+            UE_LOG(LogO3DWebRTCSender, Warning, TEXT("Failed to set audio options: %s"), *FromAnsi(Result.message));
             if (Result.message)
             {
                 lk_free_str(const_cast<char*>(Result.message));
@@ -227,7 +227,7 @@ bool FO3DWebRTCSender::Initialize(const FO3DTransportConfig& Config)
     Stats.Reset();
     bInitialized.Store(true);
 
-    UE_LOG(LogO3DWebRTCTransport, Log, TEXT("WebRTC sender initialized: URL=%s Audio=%d"),
+    UE_LOG(LogO3DWebRTCSender, Log, TEXT("WebRTC sender initialized: URL=%s Audio=%d"),
         *RoomUrl, ActiveAudioConfig.bEnableAudio ? 1 : 0);
 
     return true;
@@ -239,13 +239,13 @@ bool FO3DWebRTCSender::Start()
 
     if (!bInitialized.Load())
     {
-        UE_LOG(LogO3DWebRTCTransport, Error, TEXT("Cannot start WebRTC sender: not initialized"));
+        UE_LOG(LogO3DWebRTCSender, Error, TEXT("Cannot start WebRTC sender: not initialized"));
         return false;
     }
 
     if (bConnected.Load())
     {
-        UE_LOG(LogO3DWebRTCTransport, Warning, TEXT("WebRTC sender already connected"));
+        UE_LOG(LogO3DWebRTCSender, Warning, TEXT("WebRTC sender already connected"));
         return true;
     }
 
@@ -259,7 +259,7 @@ bool FO3DWebRTCSender::Start()
 
     if (Result.code != 0)
     {
-        UE_LOG(LogO3DWebRTCTransport, Error, TEXT("Failed to connect: %s"), *FromAnsi(Result.message));
+        UE_LOG(LogO3DWebRTCSender, Error, TEXT("Failed to connect: %s"), *FromAnsi(Result.message));
         if (Result.message)
         {
             lk_free_str(const_cast<char*>(Result.message));
@@ -267,7 +267,7 @@ bool FO3DWebRTCSender::Start()
         return false;
     }
 
-    UE_LOG(LogO3DWebRTCTransport, Log, TEXT("WebRTC sender connecting..."));
+    UE_LOG(LogO3DWebRTCSender, Log, TEXT("WebRTC sender connecting..."));
     return true;
 }
 
@@ -285,7 +285,7 @@ void FO3DWebRTCSender::Stop()
         LkResult Result = lk_disconnect(ClientHandle);
         if (Result.code != 0 && Result.message)
         {
-            UE_LOG(LogO3DWebRTCTransport, Warning, TEXT("Disconnect warning: %s"), *FromAnsi(Result.message));
+            UE_LOG(LogO3DWebRTCSender, Warning, TEXT("Disconnect warning: %s"), *FromAnsi(Result.message));
             lk_free_str(const_cast<char*>(Result.message));
         }
     }
@@ -296,7 +296,7 @@ void FO3DWebRTCSender::Stop()
     bConnected.Store(false);
     bInitialized.Store(false);
 
-    UE_LOG(LogO3DWebRTCTransport, Log, TEXT("WebRTC sender stopped"));
+    UE_LOG(LogO3DWebRTCSender, Log, TEXT("WebRTC sender stopped"));
 }
 
 bool FO3DWebRTCSender::Send(const O3DS::SubjectList& List)
@@ -313,7 +313,7 @@ bool FO3DWebRTCSender::Send(const O3DS::SubjectList& List)
     int32 BytesWritten = const_cast<O3DS::SubjectList&>(List).Serialize(Buffer, TimestampSeconds);
     if (BytesWritten <= 0)
     {
-        UE_LOG(LogO3DWebRTCTransport, Warning, TEXT("Failed to serialize SubjectList"));
+        UE_LOG(LogO3DWebRTCSender, Warning, TEXT("Failed to serialize SubjectList"));
         return false;
     }
 
@@ -330,7 +330,7 @@ bool FO3DWebRTCSender::Send(const O3DS::SubjectList& List)
         FScopeLock Lock(&StatsMutex);
         Stats.DroppedFrames++;
 
-        UE_LOG(LogO3DWebRTCTransport, Warning, TEXT("Failed to send data: %s"), *FromAnsi(Result.message));
+        UE_LOG(LogO3DWebRTCSender, Warning, TEXT("Failed to send data: %s"), *FromAnsi(Result.message));
         if (Result.message)
         {
             lk_free_str(const_cast<char*>(Result.message));
@@ -375,7 +375,7 @@ TSharedPtr<IO3DSenderAudioSink, ESPMode::ThreadSafe> FO3DWebRTCSender::CreateAud
 
     if (Result.code != 0)
     {
-        UE_LOG(LogO3DWebRTCTransport, Warning, TEXT("Failed to update audio options: %s"), *FromAnsi(Result.message));
+        UE_LOG(LogO3DWebRTCSender, Warning, TEXT("Failed to update audio options: %s"), *FromAnsi(Result.message));
         if (Result.message)
         {
             lk_free_str(const_cast<char*>(Result.message));
@@ -390,14 +390,14 @@ bool FO3DWebRTCSender::ParseConfig(const FO3DTransportConfig& Config)
     RoomUrl = Config.Uri;
     if (RoomUrl.IsEmpty())
     {
-        UE_LOG(LogO3DWebRTCTransport, Error, TEXT("WebRTC URL not specified"));
+        UE_LOG(LogO3DWebRTCSender, Error, TEXT("WebRTC URL not specified"));
         return false;
     }
 
     Token = Config.Token;
     if (Token.IsEmpty())
     {
-        UE_LOG(LogO3DWebRTCTransport, Error, TEXT("WebRTC token not provided"));
+        UE_LOG(LogO3DWebRTCSender, Error, TEXT("WebRTC token not provided"));
         return false;
     }
 

--- a/ProjectSandbox/Plugins/Open3DBroadcast/Source/Open3DTransportWebRTC/Private/WebRTCSender.cpp
+++ b/ProjectSandbox/Plugins/Open3DBroadcast/Source/Open3DTransportWebRTC/Private/WebRTCSender.cpp
@@ -1,0 +1,409 @@
+#include "WebRTCSender.h"
+#include "HAL/PlatformTime.h"
+#include "HAL/PlatformProcess.h"
+#include "Logging/LogMacros.h"
+#include "Misc/Paths.h"
+#include "Interfaces/IPluginManager.h"
+#include "livekit_ffi.h"
+#include "o3ds/model.h"
+#include <vector>
+
+DEFINE_LOG_CATEGORY(LogO3DWebRTCTransport);
+
+namespace
+{
+    static void* GLiveKitFfiHandle = nullptr;
+
+    static void EnsureFfiLoaded()
+    {
+        if (GLiveKitFfiHandle)
+        {
+            return;
+        }
+
+#if PLATFORM_WINDOWS
+        // Find the plugin base directory
+        FString PluginBaseDir;
+        TSharedPtr<IPlugin> PluginPtr = IPluginManager::Get().FindPlugin(TEXT("Open3DBroadcast"));
+        if (PluginPtr.IsValid())
+        {
+            PluginBaseDir = PluginPtr->GetBaseDir();
+        }
+
+        const FString DllName = TEXT("livekit_ffi.dll");
+        // Try Binaries folder first (staged by Build.cs)
+        FString Candidate = FPaths::Combine(PluginBaseDir, TEXT("Binaries"), TEXT("Win64"), DllName);
+
+        if (!FPaths::FileExists(Candidate))
+        {
+            // Fallback to ThirdParty/bin layout
+            Candidate = FPaths::Combine(PluginBaseDir, TEXT("Source"), TEXT("Open3DTransportWebRTC"), TEXT("ThirdParty"), TEXT("livekit_ffi"), TEXT("bin"), TEXT("Win64"), DllName);
+        }
+
+        if (FPaths::FileExists(Candidate))
+        {
+            void* Handle = FPlatformProcess::GetDllHandle(*Candidate);
+            if (Handle)
+            {
+                GLiveKitFfiHandle = Handle;
+                UE_LOG(LogO3DWebRTCTransport, Log, TEXT("LiveKit FFI loaded: %s"), *Candidate);
+            }
+            else
+            {
+                UE_LOG(LogO3DWebRTCTransport, Warning, TEXT("Failed to load LiveKit FFI from %s"), *Candidate);
+            }
+        }
+        else
+        {
+            UE_LOG(LogO3DWebRTCTransport, Warning, TEXT("LiveKit FFI DLL not found at: %s"), *Candidate);
+        }
+#endif
+    }
+
+    static FString FromAnsi(const char* S)
+    {
+        return S ? FString(UTF8_TO_TCHAR(S)) : FString();
+    }
+}
+
+/**
+ * Audio sink implementation for WebRTC sender using LiveKit FFI.
+ */
+class FWebRTCSenderAudioSink final : public IO3DSenderAudioSink
+{
+public:
+    FWebRTCSenderAudioSink(FO3DWebRTCSender& InOwner)
+        : Owner(InOwner)
+    {
+    }
+
+    virtual bool SubmitPcm(const FString& StreamLabel, const float* Interleaved, int32 NumFrames, int32 NumChannels, int32 SampleRate, double TimestampSec) override
+    {
+        if (!Interleaved || NumFrames <= 0 || NumChannels <= 0 || SampleRate <= 0)
+        {
+            return false;
+        }
+
+        if (!Owner.ClientHandle || !Owner.bConnected.Load())
+        {
+            return false;
+        }
+
+        // Convert float to int16
+        TArray<int16> PcmInt16;
+        PcmInt16.SetNumUninitialized(NumFrames * NumChannels);
+        for (int32 i = 0; i < NumFrames * NumChannels; ++i)
+        {
+            float Sample = FMath::Clamp(Interleaved[i], -1.0f, 1.0f);
+            PcmInt16[i] = static_cast<int16>(Sample * 32767.0f);
+        }
+
+        // Publish to LiveKit
+        LkResult Result = lk_publish_audio_pcm_i16(
+            Owner.ClientHandle,
+            PcmInt16.GetData(),
+            NumFrames,
+            NumChannels,
+            SampleRate
+        );
+
+        if (Result.code != 0)
+        {
+            UE_LOG(LogO3DWebRTCTransport, Warning, TEXT("Failed to publish audio: %s"), *FromAnsi(Result.message));
+            if (Result.message)
+            {
+                lk_free_str(const_cast<char*>(Result.message));
+            }
+            return false;
+        }
+
+        return true;
+    }
+
+    virtual void OnCaptureStopped() override
+    {
+        // No cleanup needed
+    }
+
+private:
+    FO3DWebRTCSender& Owner;
+};
+
+// Static callback for connection state changes
+void FO3DWebRTCSender::OnConnectionState(void* user, int32_t state, int32_t reason_code, const char* message)
+{
+    FO3DWebRTCSender* Self = reinterpret_cast<FO3DWebRTCSender*>(user);
+    if (!Self) return;
+
+    const LkConnectionState ConnState = static_cast<LkConnectionState>(state);
+
+    switch (ConnState)
+    {
+    case LkConnConnecting:
+        UE_LOG(LogO3DWebRTCTransport, Log, TEXT("WebRTC connecting..."));
+        break;
+
+    case LkConnConnected:
+        UE_LOG(LogO3DWebRTCTransport, Log, TEXT("WebRTC connected"));
+        Self->bConnected.Store(true);
+        break;
+
+    case LkConnReconnecting:
+        UE_LOG(LogO3DWebRTCTransport, Warning, TEXT("WebRTC reconnecting..."));
+        Self->bConnected.Store(false);
+        break;
+
+    case LkConnDisconnected:
+        UE_LOG(LogO3DWebRTCTransport, Log, TEXT("WebRTC disconnected: %s"), *FromAnsi(message));
+        Self->bConnected.Store(false);
+        break;
+
+    case LkConnFailed:
+        UE_LOG(LogO3DWebRTCTransport, Error, TEXT("WebRTC connection failed (code=%d): %s"), reason_code, *FromAnsi(message));
+        Self->bConnected.Store(false);
+        break;
+    }
+}
+
+FO3DWebRTCSender::FO3DWebRTCSender()
+{
+    EnsureFfiLoaded();
+}
+
+FO3DWebRTCSender::~FO3DWebRTCSender()
+{
+    Stop();
+}
+
+bool FO3DWebRTCSender::Initialize(const FO3DTransportConfig& Config)
+{
+    FScopeLock Lock(&StateMutex);
+
+    if (bInitialized.Load())
+    {
+        UE_LOG(LogO3DWebRTCTransport, Warning, TEXT("WebRTC sender already initialized"));
+        return false;
+    }
+
+    if (!ParseConfig(Config))
+    {
+        return false;
+    }
+
+    // Create LiveKit client handle
+    ClientHandle = lk_client_create();
+    if (!ClientHandle)
+    {
+        UE_LOG(LogO3DWebRTCTransport, Error, TEXT("Failed to create LiveKit client"));
+        return false;
+    }
+
+    // Set connection callback
+    LkResult Result = lk_set_connection_callback(ClientHandle, &FO3DWebRTCSender::OnConnectionState, this);
+    if (Result.code != 0)
+    {
+        UE_LOG(LogO3DWebRTCTransport, Warning, TEXT("Failed to set connection callback: %s"), *FromAnsi(Result.message));
+        if (Result.message)
+        {
+            lk_free_str(const_cast<char*>(Result.message));
+        }
+    }
+
+    // Configure audio if enabled
+    if (Config.Audio.bEnableAudio)
+    {
+        ActiveAudioConfig = Config.Audio;
+
+        int32 BitrateKbps = FMath::Clamp(ActiveAudioConfig.BitrateKbps, 16, 128);
+        Result = lk_set_audio_publish_options(ClientHandle, BitrateKbps * 1000, 0, ActiveAudioConfig.NumChannels > 1 ? 1 : 0);
+
+        if (Result.code != 0)
+        {
+            UE_LOG(LogO3DWebRTCTransport, Warning, TEXT("Failed to set audio options: %s"), *FromAnsi(Result.message));
+            if (Result.message)
+            {
+                lk_free_str(const_cast<char*>(Result.message));
+            }
+        }
+    }
+
+    ActiveConfig = Config;
+    Stats.Reset();
+    bInitialized.Store(true);
+
+    UE_LOG(LogO3DWebRTCTransport, Log, TEXT("WebRTC sender initialized: URL=%s Audio=%d"),
+        *RoomUrl, ActiveAudioConfig.bEnableAudio ? 1 : 0);
+
+    return true;
+}
+
+bool FO3DWebRTCSender::Start()
+{
+    FScopeLock Lock(&StateMutex);
+
+    if (!bInitialized.Load())
+    {
+        UE_LOG(LogO3DWebRTCTransport, Error, TEXT("Cannot start WebRTC sender: not initialized"));
+        return false;
+    }
+
+    if (bConnected.Load())
+    {
+        UE_LOG(LogO3DWebRTCTransport, Warning, TEXT("WebRTC sender already connected"));
+        return true;
+    }
+
+    // Connect asynchronously with Publisher role
+    LkResult Result = lk_connect_with_role_async(
+        ClientHandle,
+        TCHAR_TO_UTF8(*RoomUrl),
+        TCHAR_TO_UTF8(*Token),
+        LkRolePublisher
+    );
+
+    if (Result.code != 0)
+    {
+        UE_LOG(LogO3DWebRTCTransport, Error, TEXT("Failed to connect: %s"), *FromAnsi(Result.message));
+        if (Result.message)
+        {
+            lk_free_str(const_cast<char*>(Result.message));
+        }
+        return false;
+    }
+
+    UE_LOG(LogO3DWebRTCTransport, Log, TEXT("WebRTC sender connecting..."));
+    return true;
+}
+
+void FO3DWebRTCSender::Stop()
+{
+    FScopeLock Lock(&StateMutex);
+
+    if (!ClientHandle)
+    {
+        return;
+    }
+
+    if (bConnected.Load())
+    {
+        LkResult Result = lk_disconnect(ClientHandle);
+        if (Result.code != 0 && Result.message)
+        {
+            UE_LOG(LogO3DWebRTCTransport, Warning, TEXT("Disconnect warning: %s"), *FromAnsi(Result.message));
+            lk_free_str(const_cast<char*>(Result.message));
+        }
+    }
+
+    lk_client_destroy(ClientHandle);
+    ClientHandle = nullptr;
+
+    bConnected.Store(false);
+    bInitialized.Store(false);
+
+    UE_LOG(LogO3DWebRTCTransport, Log, TEXT("WebRTC sender stopped"));
+}
+
+bool FO3DWebRTCSender::Send(const O3DS::SubjectList& List)
+{
+    if (!bConnected.Load())
+    {
+        return false;
+    }
+
+    // Serialize the SubjectList
+    std::vector<char> Buffer;
+    const double TimestampSeconds = FPlatformTime::Seconds();
+
+    int32 BytesWritten = const_cast<O3DS::SubjectList&>(List).Serialize(Buffer, TimestampSeconds);
+    if (BytesWritten <= 0)
+    {
+        UE_LOG(LogO3DWebRTCTransport, Warning, TEXT("Failed to serialize SubjectList"));
+        return false;
+    }
+
+    // Send via LiveKit FFI using lossy (unreliable) mode for real-time pose data
+    LkResult Result = lk_send_data(
+        ClientHandle,
+        reinterpret_cast<const uint8*>(Buffer.data()),
+        BytesWritten,
+        LkLossy
+    );
+
+    if (Result.code != 0)
+    {
+        FScopeLock Lock(&StatsMutex);
+        Stats.DroppedFrames++;
+
+        UE_LOG(LogO3DWebRTCTransport, Warning, TEXT("Failed to send data: %s"), *FromAnsi(Result.message));
+        if (Result.message)
+        {
+            lk_free_str(const_cast<char*>(Result.message));
+        }
+        return false;
+    }
+
+    {
+        FScopeLock Lock(&StatsMutex);
+        Stats.FramesSent++;
+        Stats.BytesSent += BytesWritten;
+    }
+
+    return true;
+}
+
+void FO3DWebRTCSender::Tick(float DeltaSeconds)
+{
+    // LiveKit FFI handles internal event processing
+}
+
+FO3DTransportStats FO3DWebRTCSender::GetStats() const
+{
+    FScopeLock Lock(&StatsMutex);
+    return Stats;
+}
+
+TSharedPtr<IO3DSenderAudioSink, ESPMode::ThreadSafe> FO3DWebRTCSender::CreateAudioSink(const FO3DTransportAudioConfig& AudioConfig)
+{
+    FScopeLock Lock(&StateMutex);
+
+    if (!bInitialized.Load())
+    {
+        return nullptr;
+    }
+
+    ActiveAudioConfig = AudioConfig;
+
+    // Update audio options
+    int32 BitrateKbps = FMath::Clamp(ActiveAudioConfig.BitrateKbps, 16, 128);
+    LkResult Result = lk_set_audio_publish_options(ClientHandle, BitrateKbps * 1000, 0, ActiveAudioConfig.NumChannels > 1 ? 1 : 0);
+
+    if (Result.code != 0)
+    {
+        UE_LOG(LogO3DWebRTCTransport, Warning, TEXT("Failed to update audio options: %s"), *FromAnsi(Result.message));
+        if (Result.message)
+        {
+            lk_free_str(const_cast<char*>(Result.message));
+        }
+    }
+
+    return MakeShared<FWebRTCSenderAudioSink, ESPMode::ThreadSafe>(*this);
+}
+
+bool FO3DWebRTCSender::ParseConfig(const FO3DTransportConfig& Config)
+{
+    RoomUrl = Config.Uri;
+    if (RoomUrl.IsEmpty())
+    {
+        UE_LOG(LogO3DWebRTCTransport, Error, TEXT("WebRTC URL not specified"));
+        return false;
+    }
+
+    Token = Config.Token;
+    if (Token.IsEmpty())
+    {
+        UE_LOG(LogO3DWebRTCTransport, Error, TEXT("WebRTC token not provided"));
+        return false;
+    }
+
+    return true;
+}

--- a/ProjectSandbox/Plugins/Open3DBroadcast/Source/Open3DTransportWebRTC/Private/WebRTCSender.cpp
+++ b/ProjectSandbox/Plugins/Open3DBroadcast/Source/Open3DTransportWebRTC/Private/WebRTCSender.cpp
@@ -8,8 +8,6 @@
 #include "o3ds/model.h"
 #include <vector>
 
-DEFINE_LOG_CATEGORY(LogO3DWebRTCTransport);
-
 namespace
 {
     static void* GLiveKitFfiHandle = nullptr;

--- a/ProjectSandbox/Plugins/Open3DBroadcast/Source/Open3DTransportWebRTC/Private/WebRTCSender.cpp
+++ b/ProjectSandbox/Plugins/Open3DBroadcast/Source/Open3DTransportWebRTC/Private/WebRTCSender.cpp
@@ -115,7 +115,7 @@ void FO3DWebRTCSender::OnConnectionState(void* user, LkConnectionState state, in
 
 FO3DWebRTCSender::FO3DWebRTCSender()
 {
-    EnsureFfiLoaded();
+    // LiveKit FFI DLL is loaded automatically via .lib linkage
 }
 
 FO3DWebRTCSender::~FO3DWebRTCSender()

--- a/ProjectSandbox/Plugins/Open3DBroadcast/Source/Open3DTransportWebRTC/Private/WebRTCSender.cpp
+++ b/ProjectSandbox/Plugins/Open3DBroadcast/Source/Open3DTransportWebRTC/Private/WebRTCSender.cpp
@@ -227,8 +227,8 @@ bool FO3DWebRTCSender::Initialize(const FO3DTransportConfig& Config)
     Stats.Reset();
     bInitialized.Store(true);
 
-    UE_LOG(LogO3DWebRTCSender, Log, TEXT("WebRTC sender initialized: URL=%s Audio=%d"),
-        *RoomUrl, ActiveAudioConfig.bEnableAudio ? 1 : 0);
+    UE_LOG(LogO3DWebRTCSender, Log, TEXT("WebRTC sender initialized: URL=%s Audio=%s"),
+        *RoomUrl, ActiveAudioConfig.bEnableAudio ? TEXT("true") : TEXT("false"));
 
     return true;
 }

--- a/ProjectSandbox/Plugins/Open3DBroadcast/Source/Open3DTransportWebRTC/Private/WebRTCSender.cpp
+++ b/ProjectSandbox/Plugins/Open3DBroadcast/Source/Open3DTransportWebRTC/Private/WebRTCSender.cpp
@@ -10,54 +10,6 @@
 
 namespace
 {
-    static void* GLiveKitFfiHandle = nullptr;
-
-    static void EnsureFfiLoaded()
-    {
-        if (GLiveKitFfiHandle)
-        {
-            return;
-        }
-
-#if PLATFORM_WINDOWS
-        // Find the plugin base directory
-        FString PluginBaseDir;
-        TSharedPtr<IPlugin> PluginPtr = IPluginManager::Get().FindPlugin(TEXT("Open3DBroadcast"));
-        if (PluginPtr.IsValid())
-        {
-            PluginBaseDir = PluginPtr->GetBaseDir();
-        }
-
-        const FString DllName = TEXT("livekit_ffi.dll");
-        // Try Binaries folder first (staged by Build.cs)
-        FString Candidate = FPaths::Combine(PluginBaseDir, TEXT("Binaries"), TEXT("Win64"), DllName);
-
-        if (!FPaths::FileExists(Candidate))
-        {
-            // Fallback to ThirdParty/bin layout
-            Candidate = FPaths::Combine(PluginBaseDir, TEXT("Source"), TEXT("Open3DTransportWebRTC"), TEXT("ThirdParty"), TEXT("livekit_ffi"), TEXT("bin"), TEXT("Win64"), DllName);
-        }
-
-        if (FPaths::FileExists(Candidate))
-        {
-            void* Handle = FPlatformProcess::GetDllHandle(*Candidate);
-            if (Handle)
-            {
-                GLiveKitFfiHandle = Handle;
-                UE_LOG(LogO3DWebRTCSender, Log, TEXT("LiveKit FFI loaded: %s"), *Candidate);
-            }
-            else
-            {
-                UE_LOG(LogO3DWebRTCSender, Warning, TEXT("Failed to load LiveKit FFI from %s"), *Candidate);
-            }
-        }
-        else
-        {
-            UE_LOG(LogO3DWebRTCSender, Warning, TEXT("LiveKit FFI DLL not found at: %s"), *Candidate);
-        }
-#endif
-    }
-
     static FString FromAnsi(const char* S)
     {
         return S ? FString(UTF8_TO_TCHAR(S)) : FString();

--- a/ProjectSandbox/Plugins/Open3DBroadcast/Source/Open3DTransportWebRTC/Private/WebRTCSender.cpp
+++ b/ProjectSandbox/Plugins/Open3DBroadcast/Source/Open3DTransportWebRTC/Private/WebRTCSender.cpp
@@ -262,7 +262,8 @@ bool FO3DWebRTCSender::Send(const O3DS::SubjectList& List)
     std::vector<char> Buffer;
     const double TimestampSeconds = FPlatformTime::Seconds();
 
-    int32 BytesWritten = List.Serialize(Buffer, TimestampSeconds);
+    // Note: Serialize() is non-const, but doesn't modify the SubjectList in practice
+    int32 BytesWritten = const_cast<O3DS::SubjectList&>(List).Serialize(Buffer, TimestampSeconds);
     if (BytesWritten <= 0)
     {
         UE_LOG(LogO3DWebRTCSender, Warning, TEXT("Failed to serialize SubjectList"));

--- a/ProjectSandbox/Plugins/Open3DBroadcast/Source/Open3DTransportWebRTC/Private/WebRTCSender.cpp
+++ b/ProjectSandbox/Plugins/Open3DBroadcast/Source/Open3DTransportWebRTC/Private/WebRTCSender.cpp
@@ -310,7 +310,7 @@ bool FO3DWebRTCSender::Send(const O3DS::SubjectList& List)
     std::vector<char> Buffer;
     const double TimestampSeconds = FPlatformTime::Seconds();
 
-    int32 BytesWritten = const_cast<O3DS::SubjectList&>(List).Serialize(Buffer, TimestampSeconds);
+    int32 BytesWritten = List.Serialize(Buffer, TimestampSeconds);
     if (BytesWritten <= 0)
     {
         UE_LOG(LogO3DWebRTCSender, Warning, TEXT("Failed to serialize SubjectList"));

--- a/ProjectSandbox/Plugins/Open3DBroadcast/Source/Open3DTransportWebRTC/Private/WebRTCSender.cpp
+++ b/ProjectSandbox/Plugins/Open3DBroadcast/Source/Open3DTransportWebRTC/Private/WebRTCSender.cpp
@@ -197,7 +197,7 @@ bool FO3DWebRTCSender::Initialize(const FO3DTransportConfig& Config)
     }
 
     // Set connection callback
-    LkResult Result = lk_set_connection_callback(ClientHandle, &FO3DWebRTCSender::OnConnectionState, this);
+    LkResult Result = lk_set_connection_callback(ClientHandle, FO3DWebRTCSender::OnConnectionState, this);
     if (Result.code != 0)
     {
         UE_LOG(LogO3DWebRTCTransport, Warning, TEXT("Failed to set connection callback: %s"), *FromAnsi(Result.message));

--- a/ProjectSandbox/Plugins/Open3DBroadcast/Source/Open3DTransportWebRTC/Private/WebRTCSender.cpp
+++ b/ProjectSandbox/Plugins/Open3DBroadcast/Source/Open3DTransportWebRTC/Private/WebRTCSender.cpp
@@ -128,14 +128,12 @@ private:
 };
 
 // Static callback for connection state changes
-void FO3DWebRTCSender::OnConnectionState(void* user, int32_t state, int32_t reason_code, const char* message)
+void FO3DWebRTCSender::OnConnectionState(void* user, LkConnectionState state, int32_t reason_code, const char* message)
 {
     FO3DWebRTCSender* Self = reinterpret_cast<FO3DWebRTCSender*>(user);
     if (!Self) return;
 
-    const LkConnectionState ConnState = static_cast<LkConnectionState>(state);
-
-    switch (ConnState)
+    switch (state)
     {
     case LkConnConnecting:
         UE_LOG(LogO3DWebRTCTransport, Log, TEXT("WebRTC connecting..."));

--- a/ProjectSandbox/Plugins/Open3DBroadcast/Source/Open3DTransportWebRTC/Private/WebRTCSender.h
+++ b/ProjectSandbox/Plugins/Open3DBroadcast/Source/Open3DTransportWebRTC/Private/WebRTCSender.h
@@ -10,6 +10,9 @@ struct LkClientHandle;
 
 DECLARE_LOG_CATEGORY_EXTERN(LogO3DWebRTCTransport, Log, All);
 
+// Note: LiveKit FFI handles Opus encoding internally.
+// We only need to provide PCM16 audio via lk_publish_audio_pcm_i16().
+
 /**
  * WebRTC transport sender implementation using LiveKit FFI.
  * Adapts the LiveKit FFI C ABI to the IOpen3DSender interface.

--- a/ProjectSandbox/Plugins/Open3DBroadcast/Source/Open3DTransportWebRTC/Private/WebRTCSender.h
+++ b/ProjectSandbox/Plugins/Open3DBroadcast/Source/Open3DTransportWebRTC/Private/WebRTCSender.h
@@ -56,7 +56,6 @@ private:
 
     // Helper methods
     bool ParseConfig(const FO3DTransportConfig& Config);
-    void EnsureLiveKitFfiLoaded();
 
     // LiveKit FFI callbacks (static)
     struct FCallbacks;

--- a/ProjectSandbox/Plugins/Open3DBroadcast/Source/Open3DTransportWebRTC/Private/WebRTCSender.h
+++ b/ProjectSandbox/Plugins/Open3DBroadcast/Source/Open3DTransportWebRTC/Private/WebRTCSender.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include "O3DSenderInterface.h"
+#include "O3DTransportTypes.h"
+#include "HAL/CriticalSection.h"
+#include "Templates/Atomic.h"
+
+// Forward declare LiveKit FFI types
+struct LkClientHandle;
+
+DECLARE_LOG_CATEGORY_EXTERN(LogO3DWebRTCTransport, Log, All);
+
+/**
+ * WebRTC transport sender implementation using LiveKit FFI.
+ * Adapts the LiveKit FFI C ABI to the IOpen3DSender interface.
+ */
+class FO3DWebRTCSender : public IOpen3DSender
+{
+public:
+    FO3DWebRTCSender();
+    virtual ~FO3DWebRTCSender() override;
+
+    // IOpen3DSender interface
+    virtual bool Initialize(const FO3DTransportConfig& Config) override;
+    virtual bool Start() override;
+    virtual void Stop() override;
+    virtual bool Send(const O3DS::SubjectList& List) override;
+    virtual void Tick(float DeltaSeconds) override;
+    virtual FO3DTransportStats GetStats() const override;
+    virtual bool SupportsAudio() const override { return true; }
+    virtual TSharedPtr<IO3DSenderAudioSink, ESPMode::ThreadSafe> CreateAudioSink(const FO3DTransportAudioConfig& AudioConfig) override;
+
+private:
+    friend class FWebRTCSenderAudioSink;
+
+    // Configuration
+    FO3DTransportConfig ActiveConfig;
+    FO3DTransportAudioConfig ActiveAudioConfig;
+    FString RoomUrl;
+    FString Token;
+
+    // LiveKit FFI client handle (opaque)
+    LkClientHandle* ClientHandle = nullptr;
+
+    // State
+    mutable FCriticalSection StateMutex;
+    TAtomic<bool> bInitialized{ false };
+    TAtomic<bool> bConnected{ false };
+
+    // Stats
+    mutable FCriticalSection StatsMutex;
+    FO3DTransportStats Stats;
+
+    // Helper methods
+    bool ParseConfig(const FO3DTransportConfig& Config);
+    void EnsureLiveKitFfiLoaded();
+
+    // LiveKit FFI callbacks (static)
+    struct FCallbacks;
+    static void OnConnectionState(void* user, int32_t state, int32_t reason_code, const char* message);
+};

--- a/ProjectSandbox/Plugins/Open3DBroadcast/Source/Open3DTransportWebRTC/Private/WebRTCSender.h
+++ b/ProjectSandbox/Plugins/Open3DBroadcast/Source/Open3DTransportWebRTC/Private/WebRTCSender.h
@@ -7,6 +7,7 @@
 
 // Forward declare LiveKit FFI types
 struct LkClientHandle;
+enum LkConnectionState : int;
 
 DECLARE_LOG_CATEGORY_EXTERN(LogO3DWebRTCTransport, Log, All);
 
@@ -60,5 +61,5 @@ private:
 
     // LiveKit FFI callbacks (static)
     struct FCallbacks;
-    static void OnConnectionState(void* user, int32_t state, int32_t reason_code, const char* message);
+    static void OnConnectionState(void* user, LkConnectionState state, int32_t reason_code, const char* message);
 };

--- a/ProjectSandbox/Plugins/Open3DBroadcast/Source/Open3DTransportWebRTC/Private/WebRTCSender.h
+++ b/ProjectSandbox/Plugins/Open3DBroadcast/Source/Open3DTransportWebRTC/Private/WebRTCSender.h
@@ -5,11 +5,10 @@
 #include "HAL/CriticalSection.h"
 #include "Templates/Atomic.h"
 
-// Forward declare LiveKit FFI types
-struct LkClientHandle;
-enum LkConnectionState : int;
+// Include LiveKit FFI for callback types
+#include "livekit_ffi.h"
 
-DECLARE_LOG_CATEGORY_EXTERN(LogO3DWebRTCTransport, Log, All);
+DECLARE_LOG_CATEGORY_EXTERN(LogO3DWebRTCSender, Log, All);
 
 // Note: LiveKit FFI handles Opus encoding internally.
 // We only need to provide PCM16 audio via lk_publish_audio_pcm_i16().


### PR DESCRIPTION
Implemented WebRTC transport sender and receiver for the Open3DBroadcast
plugin using the LiveKit FFI (Foreign Function Interface) C ABI.

Implementation Details:
- FO3DWebRTCSender: Implements IOpen3DSender interface using LiveKit FFI
  - Connects to LiveKit room as Publisher role
  - Sends pose data using lossy (unreliable) data channel for real-time performance
  - Supports PCM audio publishing via lk_publish_audio_pcm_i16
  - Handles connection state callbacks for robust error handling
  - Stats tracking for sent frames/bytes and dropped frames

- FO3DWebRTCReceiver: Implements IOpen3DReceiver interface using LiveKit FFI
  - Connects to LiveKit room as Subscriber role
  - Receives pose data via LiveKit data callbacks
  - Receives PCM16 audio via LiveKit audio callbacks
  - Delivers frames to ISerializedFrameConsumer and audio to IO3DReceiverAudioSink
  - Stats tracking for received frames/bytes and latency

Module Registration:
- Registers WebRTC transport factories in module StartupModule
- Unregisters in ShutdownModule for clean shutdown
- Uses O3DTransport registry pattern consistent with other transport modules

Build Configuration:
- Links against livekit_ffi.dll.lib from module ThirdParty folder
- Includes livekit_ffi.h header for FFI C ABI
- References plugin-level ThirdParty for Opus and Open3DStream libraries
- Stages livekit_ffi.dll as runtime dependency
- Requires "Projects" module for IPluginManager (DLL loading)

Design Patterns:
- Follows same interface patterns as Loopback and NNG transports
- Uses LiveKit FFI callbacks (static C callbacks) for async event delivery
- Thread-safe stats tracking with FCriticalSection
- Proper resource cleanup in destructor and Stop()
- Error handling with LkResult and lk_free_str for error messages

The implementation is ready for testing with a LiveKit media server.
Token-based authentication is required (JWT tokens generated by LiveKit server).