### PR TITLE
A1: sequencing, transmit clock, and receiver reorder gate

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -102,6 +102,8 @@ add_custom_target(protocol DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/_generated/o3ds_g
 set(pub_headers			
 	o3ds/o3ds.h
 	o3ds/getTime.h
+	o3ds/sequencing.h
+	o3ds/reorder_gate.h
 	o3ds/model.h
 	o3ds/base_connector.h
 	o3ds/nng_connector.h
@@ -137,7 +139,9 @@ endif()
 set(SOURCES 
 	o3ds/o3ds.cpp
 	o3ds/getTime.cpp
-	o3ds/model.cpp	
+	o3ds/sequencing.cpp
+	o3ds/reorder_gate.cpp
+	o3ds/model.cpp
 	o3ds/base_connector.cpp
 	o3ds/nng_connector.cpp
 	o3ds/subscriber.cpp

--- a/src/o3ds.fbs
+++ b/src/o3ds.fbs
@@ -97,6 +97,14 @@ table SubjectList {
    subjects:[Subject];
    updates:[SubjectUpdate];
    time:double;
+
+   // Appended fields (do not reorder/remove the above; append-only from here).
+   // 0 == unset on all three; a receiver must treat 0 exactly like an old
+   // sender that never set these fields (see ReorderGate legacy bypass).
+   tx_seq:ulong = 0;            // monotonic per logical (sender->receiver) stream, not per process
+   tx_wallclock_us:ulong = 0;   // UTC microseconds at transmit; distinct from `time` (content clock)
+   frame_epoch:uint = 0;        // bumped once per publisher process/session; lets a receiver detect
+                                 // a sender restart unambiguously instead of guessing from a seq backward-jump
 }
 
 

--- a/src/o3ds/model.cpp
+++ b/src/o3ds/model.cpp
@@ -504,8 +504,9 @@ flatbuffers::Offset<flatbuffers::Vector<const O3DS::Data::CurveUpdate *>> Subjec
 		return static_cast<int>(outbuf.size());
 	}
 
-	int SubjectList::Serialize(std::vector<char> &outbuf, double timestamp)
-	{	
+	int SubjectList::Serialize(std::vector<char> &outbuf, double timestamp,
+		uint64_t tx_seq, uint64_t tx_wallclock_us, uint32_t frame_epoch)
+	{
 		if(timestamp == 0.0) timestamp = GetTime();
 
 		flatbuffers::FlatBufferBuilder builder;
@@ -520,7 +521,7 @@ flatbuffers::Offset<flatbuffers::Vector<const O3DS::Data::CurveUpdate *>> Subjec
 
 		auto ovSubjects = builder.CreateVector(subjects);
 
-		auto root = CreateSubjectList(builder, ovSubjects, 0, timestamp);
+		auto root = CreateSubjectList(builder, ovSubjects, 0, timestamp, tx_seq, tx_wallclock_us, frame_epoch);
 
 		builder.Finish(root);
 
@@ -554,7 +555,8 @@ flatbuffers::Offset<flatbuffers::Vector<const O3DS::Data::CurveUpdate *>> Subjec
 
 	// Subject List
 
-	int SubjectList::SerializeUpdate(std::vector<char> &outbuf, size_t& count, double timestamp)
+	int SubjectList::SerializeUpdate(std::vector<char> &outbuf, size_t& count, double timestamp,
+		uint64_t tx_seq, uint64_t tx_wallclock_us, uint32_t frame_epoch)
 	{
 		if (timestamp == 0.0)
 		{
@@ -566,19 +568,47 @@ flatbuffers::Offset<flatbuffers::Vector<const O3DS::Data::CurveUpdate *>> Subjec
 		std::vector<flatbuffers::Offset<O3DS::Data::SubjectUpdate>> outSubjectUpdates;
 
 		for (auto& subject : this->mItems)
-		{			
+		{
 			outSubjectUpdates.push_back(subject->SerializeUpdate(builder, count, mDeltaThreshold));
 		}
 
 		auto ovSubjectUpdates = builder.CreateVector(outSubjectUpdates);
 
-		auto root = CreateSubjectList(builder, 0, ovSubjectUpdates, timestamp);
+		auto root = CreateSubjectList(builder, 0, ovSubjectUpdates, timestamp, tx_seq, tx_wallclock_us, frame_epoch);
 
 		builder.Finish(root);
 
 		finalize(builder, outbuf, 1);
 
 		return static_cast<int>(outbuf.size());
+	}
+
+	bool SubjectList::PeekMeta(const char* data, size_t len,
+		uint64_t& outTxSeq, uint64_t& outTxWallclockUs, uint32_t& outFrameEpoch)
+	{
+		outTxSeq = 0;
+		outTxWallclockUs = 0;
+		outFrameEpoch = 0;
+
+		// Header is 8 bytes (flags + CRC) followed by the FlatBuffers payload;
+		// reject anything too short before doing arithmetic on len or
+		// dereferencing data (len - 8 would otherwise underflow).
+		if (data == nullptr || len < 8)
+			return false;
+
+		flatbuffers::Verifier verifier(
+			reinterpret_cast<const uint8_t*>(data + 8), len - 8);
+		if (!O3DS::Data::VerifySubjectListBuffer(verifier))
+			return false;
+
+		auto root = GetSubjectList(data + 8);
+		if (root == nullptr)
+			return false;
+
+		outTxSeq = root->tx_seq();
+		outTxWallclockUs = root->tx_wallclock_us();
+		outFrameEpoch = root->frame_epoch();
+		return true;
 	}
 
 	bool SubjectList::Parse(const char *data, size_t len, TransformBuilder *builder, bool clearInactive)

--- a/src/o3ds/model.h
+++ b/src/o3ds/model.h
@@ -264,13 +264,34 @@ namespace O3DS
 		double mDeltaThreshold;
 		std::string mError;
 
-		//! Encode all of the items in the subject list as binary data
-		int Serialize(std::vector<char> &outbuf, double timestamp=0.0);
+		//! Encode all of the items in the subject list as binary data.
+		//! tx_seq/tx_wallclock_us/frame_epoch are optional (0 == unset, the
+		//! default); a receiver must treat 0 exactly like a sender that
+		//! predates these fields. See src/o3ds/sequencing.h for generating
+		//! them - callers own a SequenceCounter per outbound stream, this
+		//! function does not generate them itself, it only writes what it's
+		//! given onto the wire.
+		int Serialize(std::vector<char> &outbuf, double timestamp = 0.0,
+			uint64_t tx_seq = 0, uint64_t tx_wallclock_us = 0, uint32_t frame_epoch = 0);
 
-		int SerializeUpdate(std::vector<char>& outbuf, size_t& count, double timestamp=0.0);
+		int SerializeUpdate(std::vector<char>& outbuf, size_t& count, double timestamp = 0.0,
+			uint64_t tx_seq = 0, uint64_t tx_wallclock_us = 0, uint32_t frame_epoch = 0);
 
 		//! Populate or update the subject list with the binary data provided (created by Serialize)
 		bool Parse(const char *data, size_t len, TransformBuilder* = nullptr, bool clearInactive = true);
+
+		//! Extract just the transmit-sequencing metadata (tx_seq/
+		//! tx_wallclock_us/frame_epoch) from a wire buffer, without doing a
+		//! full parse of its subjects/updates. Used by ReorderGate to make
+		//! ordering decisions before paying the cost of a full Parse().
+		//! Validates buffer length and runs the FlatBuffers Verifier (this
+		//! reads untrusted network bytes) but does NOT check the CRC - a
+		//! corrupt-but-well-formed-enough buffer that fails CRC is still
+		//! caught later, when it's actually delivered and Parse()'d.
+		//! Returns false (outputs left at 0, their "unset" value) if the
+		//! buffer is too short or fails FlatBuffers verification.
+		static bool PeekMeta(const char* data, size_t len,
+			uint64_t& outTxSeq, uint64_t& outTxWallclockUs, uint32_t& outFrameEpoch);
 
 		void ParseSubject(const O3DS::Data::Subject*, TransformBuilder* = nullptr);
 

--- a/src/o3ds/reorder_gate.cpp
+++ b/src/o3ds/reorder_gate.cpp
@@ -48,27 +48,46 @@ namespace O3DS
 			return;
 		}
 
-		// Restart detection. frame_epoch is unambiguous when present: any
-		// change means a new publisher session, full stop. The backward-jump
-		// heuristic is only consulted for streams that have never shown a
-		// non-zero epoch - once a stream demonstrates it carries epochs, a
-		// low seq is trusted to mean stale/duplicate, not a restart, since a
-		// real restart would already have been caught via the epoch change.
+		// Restart detection. frame_epoch, when present, must be treated as an
+		// ORDERED value, not just "changed vs not": a network can reorder a
+		// straggler from an OLDER session to arrive after the first frame of
+		// a new one (this is exactly the kind of reordering this whole gate
+		// exists to handle), and naively treating any epoch != mLastEpoch as
+		// a restart would misapply that stale frame as if it were current -
+		// and, if it also let mLastEpoch regress, would make every
+		// subsequent legitimate frame look like yet another restart.
 		bool isRestart = false;
-		if (frame.epoch != 0 && mHaveEpoch && frame.epoch != mLastEpoch)
+		if (frame.epoch != 0)
 		{
-			isRestart = true;
+			if (mHaveEpoch && frame.epoch < mLastEpoch)
+			{
+				// Straggler from an older session, not a restart. Drop it
+				// like any other out-of-window frame; do NOT touch mLastEpoch.
+				mStats.stale_dropped++;
+				CheckTimeouts(now_s, emit);
+				return;
+			}
+
+			if (mHaveEpoch && frame.epoch > mLastEpoch)
+			{
+				isRestart = true;
+			}
+
+			// Only ever advances - a legacy (epoch==0) frame or an already-
+			// rejected older-epoch straggler must never move this backward.
+			if (frame.epoch > mLastEpoch)
+			{
+				mLastEpoch = frame.epoch;
+			}
+			mHaveEpoch = true;
 		}
 		else if (mInitialized && !mHaveEpoch && frame.seq <= mLastApplied
 			&& (mLastApplied - frame.seq) > mConfig.reset_backjump)
 		{
+			// Legacy-only fallback (frame_epoch unavailable on this stream):
+			// only consulted when we have no better signal, since a stream
+			// that does carry epochs already resolves restarts above.
 			isRestart = true;
-		}
-
-		if (frame.epoch != 0)
-		{
-			mLastEpoch = frame.epoch;
-			mHaveEpoch = true;
 		}
 
 		if (isRestart)
@@ -96,16 +115,18 @@ namespace O3DS
 
 		if (frame.seq == mLastApplied + 1)
 		{
-			DeliverAndDrain(std::move(frame), emit);
+			DeliverAndDrain(std::move(frame), emit, /*countDrainAsReordered*/ true);
 		}
 		else
 		{
 			// Gap: buffer this frame and remember when we started waiting.
-			// map::emplace with a duplicate key (a resend of an already-
-			// pending seq) is a silent no-op, which is fine - we already
-			// have a copy waiting.
+			// A resend of a seq we're already holding (duplicate key) is a
+			// genuine duplicate arrival - the original buffered copy (and
+			// its wait timer) is kept, but still count it.
 			uint64_t seq = frame.seq;
-			mPending.emplace(seq, PendingEntry{ std::move(frame), now_s });
+			auto result = mPending.emplace(seq, PendingEntry{ std::move(frame), now_s });
+			if (!result.second)
+				mStats.dup_dropped++;
 		}
 
 		CheckTimeouts(now_s, emit);
@@ -116,7 +137,7 @@ namespace O3DS
 		CheckTimeouts(now_s, emit);
 	}
 
-	void ReorderGate::DeliverAndDrain(Frame&& frame, const std::function<void(Frame&&)>& emit)
+	void ReorderGate::DeliverAndDrain(Frame&& frame, const std::function<void(Frame&&)>& emit, bool countDrainAsReordered)
 	{
 		uint64_t seq = frame.seq;
 		emit(std::move(frame));
@@ -138,7 +159,8 @@ namespace O3DS
 			uint64_t nextSeq = next.seq;
 			emit(std::move(next));
 			mStats.delivered++;
-			mStats.reordered++; // arrived out of order relative to its predecessor; caught up now
+			if (countDrainAsReordered)
+				mStats.reordered++; // arrived out of order relative to its predecessor; caught up now
 			mLastApplied = nextSeq;
 			mRecentlyDelivered.insert(nextSeq);
 			PruneRecentlyDelivered();
@@ -169,7 +191,10 @@ namespace O3DS
 			mPending.erase(first);
 
 			mLastApplied = gapSeq - 1; // pretend caught up to just before the frame we're giving up on
-			DeliverAndDrain(std::move(frame), emit);
+			// These frames were simply waiting behind a hole we're giving up
+			// on, not reordered relative to each other - don't inflate the
+			// reordered stat for frames that arrived in perfectly good order.
+			DeliverAndDrain(std::move(frame), emit, /*countDrainAsReordered*/ false);
 		}
 	}
 

--- a/src/o3ds/reorder_gate.cpp
+++ b/src/o3ds/reorder_gate.cpp
@@ -1,0 +1,190 @@
+/*
+Open 3D Stream
+
+Copyright 2026 Alastair Macleod
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#include "reorder_gate.h"
+
+namespace O3DS
+{
+	ReorderGate::ReorderGate()
+		: ReorderGate(Config())
+	{
+	}
+
+	ReorderGate::ReorderGate(const Config& config)
+		: mConfig(config)
+	{
+	}
+
+	void ReorderGate::Push(Frame&& frame, double now_s, const std::function<void(Frame&&)>& emit)
+	{
+		// Legacy/unset: no ordering info at all. Pass straight through
+		// exactly like pre-A1 behavior (this preserves old-sender interop,
+		// and lets a single stream mix sequenced and unsequenced frames
+		// without the unsequenced ones disturbing gate state for the rest).
+		if (frame.seq == 0)
+		{
+			emit(std::move(frame));
+			return;
+		}
+
+		// Restart detection. frame_epoch is unambiguous when present: any
+		// change means a new publisher session, full stop. The backward-jump
+		// heuristic is only consulted for streams that have never shown a
+		// non-zero epoch - once a stream demonstrates it carries epochs, a
+		// low seq is trusted to mean stale/duplicate, not a restart, since a
+		// real restart would already have been caught via the epoch change.
+		bool isRestart = false;
+		if (frame.epoch != 0 && mHaveEpoch && frame.epoch != mLastEpoch)
+		{
+			isRestart = true;
+		}
+		else if (mInitialized && !mHaveEpoch && frame.seq <= mLastApplied
+			&& (mLastApplied - frame.seq) > mConfig.reset_backjump)
+		{
+			isRestart = true;
+		}
+
+		if (frame.epoch != 0)
+		{
+			mLastEpoch = frame.epoch;
+			mHaveEpoch = true;
+		}
+
+		if (isRestart)
+		{
+			mPending.clear();
+			mRecentlyDelivered.clear();
+			mInitialized = false;
+		}
+
+		if (!mInitialized)
+		{
+			mInitialized = true;
+			mLastApplied = frame.seq - 1;
+		}
+		else if (frame.seq <= mLastApplied)
+		{
+			if (mRecentlyDelivered.count(frame.seq))
+				mStats.dup_dropped++;
+			else
+				mStats.stale_dropped++;
+
+			CheckTimeouts(now_s, emit);
+			return;
+		}
+
+		if (frame.seq == mLastApplied + 1)
+		{
+			DeliverAndDrain(std::move(frame), emit);
+		}
+		else
+		{
+			// Gap: buffer this frame and remember when we started waiting.
+			// map::emplace with a duplicate key (a resend of an already-
+			// pending seq) is a silent no-op, which is fine - we already
+			// have a copy waiting.
+			uint64_t seq = frame.seq;
+			mPending.emplace(seq, PendingEntry{ std::move(frame), now_s });
+		}
+
+		CheckTimeouts(now_s, emit);
+	}
+
+	void ReorderGate::Flush(double now_s, const std::function<void(Frame&&)>& emit)
+	{
+		CheckTimeouts(now_s, emit);
+	}
+
+	void ReorderGate::DeliverAndDrain(Frame&& frame, const std::function<void(Frame&&)>& emit)
+	{
+		uint64_t seq = frame.seq;
+		emit(std::move(frame));
+		mStats.delivered++;
+		mLastApplied = seq;
+		mRecentlyDelivered.insert(seq);
+		PruneRecentlyDelivered();
+
+		// Drain any buffered consecutive successors this delivery unblocked.
+		for (;;)
+		{
+			auto it = mPending.find(mLastApplied + 1);
+			if (it == mPending.end())
+				break;
+
+			Frame next = std::move(it->second.frame);
+			mPending.erase(it);
+
+			uint64_t nextSeq = next.seq;
+			emit(std::move(next));
+			mStats.delivered++;
+			mStats.reordered++; // arrived out of order relative to its predecessor; caught up now
+			mLastApplied = nextSeq;
+			mRecentlyDelivered.insert(nextSeq);
+			PruneRecentlyDelivered();
+		}
+	}
+
+	void ReorderGate::CheckTimeouts(double now_s, const std::function<void(Frame&&)>& emit)
+	{
+		// Give up waiting on the lowest pending gap once it's been buffered
+		// too long or the buffer has grown past max_window; everything
+		// strictly below its seq that we never received counts as lost.
+		// Loop (not just once) since giving up on one gap can immediately
+		// expose the next one if multiple holes exist at once.
+		while (!mPending.empty())
+		{
+			auto first = mPending.begin();
+			bool windowFull = mPending.size() >= mConfig.max_window;
+			bool timedOut = (now_s - first->second.buffered_at_s) >= mConfig.max_delay_s;
+
+			if (!windowFull && !timedOut)
+				break; // still within budget; keep waiting for the hole to fill
+
+			uint64_t gapSeq = first->first;
+			uint64_t gapCount = gapSeq - (mLastApplied + 1);
+			mStats.lost += gapCount;
+
+			Frame frame = std::move(first->second.frame);
+			mPending.erase(first);
+
+			mLastApplied = gapSeq - 1; // pretend caught up to just before the frame we're giving up on
+			DeliverAndDrain(std::move(frame), emit);
+		}
+	}
+
+	void ReorderGate::PruneRecentlyDelivered()
+	{
+		// Bound memory to roughly the same window as gap buffering. A
+		// duplicate arriving so late it falls outside this window gets
+		// classified as stale_dropped instead of dup_dropped - a diagnostic
+		// difference only; either way the frame is correctly dropped.
+		if (mLastApplied < mConfig.max_window)
+			return;
+
+		uint64_t cutoff = mLastApplied - mConfig.max_window;
+		auto it = mRecentlyDelivered.begin();
+		while (it != mRecentlyDelivered.end() && *it < cutoff)
+			it = mRecentlyDelivered.erase(it);
+	}
+}

--- a/src/o3ds/reorder_gate.h
+++ b/src/o3ds/reorder_gate.h
@@ -1,0 +1,128 @@
+/*
+Open 3D Stream
+
+Copyright 2026 Alastair Macleod
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#ifndef OPEN3D_STREAM_REORDER_GATE_H
+#define OPEN3D_STREAM_REORDER_GATE_H
+
+#include <cstdint>
+#include <functional>
+#include <map>
+#include <set>
+#include <vector>
+
+namespace O3DS
+{
+	//! One frame's worth of wire bytes plus the sequencing metadata a
+	//! ReorderGate needs to make ordering decisions. The gate never inspects
+	//! `bytes` - it is opaque payload, handed to `emit` unparsed so a frame
+	//! that gets buffered and later dropped (superseded, stale, etc.) is
+	//! never paid for with a full O3DS::SubjectList::Parse().
+	struct Frame
+	{
+		uint64_t seq = 0;          // SubjectList.tx_seq from the wire (0 = legacy/unset)
+		uint64_t wallclock_us = 0; // SubjectList.tx_wallclock_us; pass-through only - the
+		                           // gate's own gap-timeout bookkeeping uses the caller-supplied
+		                           // `now_s` clock (see Push/Flush below), never this field
+		uint32_t epoch = 0;        // SubjectList.frame_epoch (0 = legacy/unset)
+		std::vector<char> bytes;   // raw wire bytes, unparsed
+	};
+
+	struct ReorderStats
+	{
+		uint64_t delivered = 0;
+		uint64_t dup_dropped = 0;
+		uint64_t stale_dropped = 0;
+		uint64_t lost = 0;
+		uint64_t reordered = 0;
+	};
+
+	//! Per-source (per-sender-stream) reordering/dedup/stale-drop gate.
+	//! Not thread-safe: confine one instance to a single thread (see A2.a).
+	//!
+	//! Frames are delivered to `emit` in ascending tx_seq order. A gap
+	//! (missing seq) buffers later frames for up to Config::max_window
+	//! entries or Config::max_delay_s, whichever comes first, then gives up
+	//! and delivers what it has, counting the hole as `lost`.
+	//!
+	//! Publisher restarts (the sender's SequenceCounter resets to 1) are
+	//! detected via frame_epoch when the stream carries it - an epoch
+	//! change is unambiguous, unlike guessing from a sequence backward jump.
+	//! Config::reset_backjump is used only as a fallback for streams that
+	//! never set frame_epoch (legacy senders): once a stream has shown a
+	//! non-zero epoch, the backjump heuristic is not consulted again for it.
+	class ReorderGate
+	{
+	public:
+		struct Config
+		{
+			uint32_t max_window = 16;       // max frames buffered waiting on one gap
+			double max_delay_s = 0.05;      // max time to wait on one gap, in the caller's `now_s` clock
+			uint64_t reset_backjump = 256;  // legacy-only (no frame_epoch) restart heuristic threshold
+		};
+
+		ReorderGate();
+		explicit ReorderGate(const Config& config);
+
+		//! Feed one incoming frame. May synchronously call `emit` zero or
+		//! more times (zero if buffered pending a gap or dropped as
+		//! dup/stale; one or more if it fills a gap and drains successors).
+		//! `now_s` is the caller's own clock (any monotonic seconds-based
+		//! clock is fine; it is only ever compared to other `now_s` values
+		//! passed to this same gate instance) - NOT derived from the
+		//! frame's wallclock_us.
+		void Push(Frame&& frame, double now_s, const std::function<void(Frame&&)>& emit);
+
+		//! Check pending gaps for timeout even when no new frame has
+		//! arrived; call periodically (e.g. once per receiver tick) so a
+		//! stalled gap doesn't wait forever for a Push that never comes.
+		void Flush(double now_s, const std::function<void(Frame&&)>& emit);
+
+		const ReorderStats& Stats() const { return mStats; }
+
+	private:
+		struct PendingEntry
+		{
+			Frame frame;
+			double buffered_at_s;
+		};
+
+		void DeliverAndDrain(Frame&& frame, const std::function<void(Frame&&)>& emit);
+		void CheckTimeouts(double now_s, const std::function<void(Frame&&)>& emit);
+		void PruneRecentlyDelivered();
+
+		Config mConfig;
+		ReorderStats mStats;
+
+		bool mInitialized = false;
+		uint64_t mLastApplied = 0;
+
+		bool mHaveEpoch = false;
+		uint32_t mLastEpoch = 0;
+
+		std::map<uint64_t, PendingEntry> mPending;    // seq -> buffered frame, ordered by seq
+		std::set<uint64_t> mRecentlyDelivered;        // bounded window, for dup-vs-stale classification
+	};
+}
+
+#endif

--- a/src/o3ds/reorder_gate.h
+++ b/src/o3ds/reorder_gate.h
@@ -66,8 +66,17 @@ namespace O3DS
 	//! and delivers what it has, counting the hole as `lost`.
 	//!
 	//! Publisher restarts (the sender's SequenceCounter resets to 1) are
-	//! detected via frame_epoch when the stream carries it - an epoch
-	//! change is unambiguous, unlike guessing from a sequence backward jump.
+	//! detected via frame_epoch when the stream carries it: an epoch strictly
+	//! greater than the last one seen means a new session. frame_epoch is
+	//! treated as an ORDERED value, not just "changed vs not" - a smaller
+	//! epoch than the last one seen is a straggler from an older session
+	//! reordered in flight across the restart boundary (a real network
+	//! condition, not a hypothetical), and is dropped as stale rather than
+	//! mistaken for yet another restart; it never moves the tracked epoch
+	//! backward. Senders should generate frame_epoch with
+	//! O3DS::NewSessionEpoch() (sequencing.h), which is best-effort
+	//! monotonic across restarts (derived from wall-clock seconds) - see
+	//! its own doc comment for the failure mode this doesn't cover.
 	//! Config::reset_backjump is used only as a fallback for streams that
 	//! never set frame_epoch (legacy senders): once a stream has shown a
 	//! non-zero epoch, the backjump heuristic is not consulted again for it.
@@ -107,7 +116,16 @@ namespace O3DS
 			double buffered_at_s;
 		};
 
-		void DeliverAndDrain(Frame&& frame, const std::function<void(Frame&&)>& emit);
+		// countDrainAsReordered distinguishes two callers: when a frame
+		// fills a genuine gap (its predecessor arrived, and this frame had
+		// been waiting because it arrived ahead of that predecessor), any
+		// successors drained after it really were reordered relative to
+		// what unblocked them - true. When CheckTimeouts gives up on a lost
+		// gap instead, the frames it then drains were simply waiting behind
+		// a hole, in perfectly good order relative to each other - false,
+		// or they would inflate the reordered stat for frames that were
+		// never actually reordered.
+		void DeliverAndDrain(Frame&& frame, const std::function<void(Frame&&)>& emit, bool countDrainAsReordered);
 		void CheckTimeouts(double now_s, const std::function<void(Frame&&)>& emit);
 		void PruneRecentlyDelivered();
 

--- a/src/o3ds/sequencing.cpp
+++ b/src/o3ds/sequencing.cpp
@@ -1,0 +1,36 @@
+/*
+Open 3D Stream
+
+Copyright 2026 Alastair Macleod
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#include "sequencing.h"
+
+#include <chrono>
+
+namespace O3DS
+{
+	uint64_t NowUtcMicros()
+	{
+		using namespace std::chrono;
+		return (uint64_t)duration_cast<microseconds>(system_clock::now().time_since_epoch()).count();
+	}
+}

--- a/src/o3ds/sequencing.cpp
+++ b/src/o3ds/sequencing.cpp
@@ -33,4 +33,9 @@ namespace O3DS
 		using namespace std::chrono;
 		return (uint64_t)duration_cast<microseconds>(system_clock::now().time_since_epoch()).count();
 	}
+
+	uint32_t NewSessionEpoch()
+	{
+		return (uint32_t)(NowUtcMicros() / 1000000ull);
+	}
 }

--- a/src/o3ds/sequencing.h
+++ b/src/o3ds/sequencing.h
@@ -1,0 +1,71 @@
+/*
+Open 3D Stream
+
+Copyright 2026 Alastair Macleod
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#ifndef OPEN3D_STREAM_SEQUENCING_H
+#define OPEN3D_STREAM_SEQUENCING_H
+
+#include <atomic>
+#include <cstdint>
+
+namespace O3DS
+{
+	//! Monotonic sequence generator for a single logical sender->receiver
+	//! stream (see SubjectList's tx_seq field). Deliberately per-stream, not
+	//! a process-global counter: sharing one counter across fan-out to
+	//! multiple receivers would make each receiver's view have "gaps" that
+	//! are just other receivers' frames, not real loss - one instance should
+	//! be owned by whatever object represents a single outbound stream
+	//! (e.g. the per-transport serializer), not shared across streams.
+	class SequenceCounter
+	{
+	public:
+		SequenceCounter() : mNext(1) {}
+
+		//! Returns the next sequence number, starting at 1. 0 is reserved to
+		//! mean "unset" on the wire (see SubjectList.tx_seq), so this never
+		//! returns 0.
+		uint64_t Next()
+		{
+			return mNext.fetch_add(1, std::memory_order_relaxed);
+		}
+
+		//! Reset back to the initial state (new session/epoch on this stream).
+		void Reset()
+		{
+			mNext.store(1, std::memory_order_relaxed);
+		}
+
+	private:
+		std::atomic<uint64_t> mNext;
+	};
+
+	//! Current UTC time in microseconds since the Unix epoch, for
+	//! SubjectList.tx_wallclock_us. This is a wall clock (not monotonic) and
+	//! can jump under NTP adjustment - it is transmitted for latency/
+	//! staleness estimation only. Frame *ordering* must never depend on it;
+	//! use tx_seq for that.
+	uint64_t NowUtcMicros();
+}
+
+#endif

--- a/src/o3ds/sequencing.h
+++ b/src/o3ds/sequencing.h
@@ -66,6 +66,28 @@ namespace O3DS
 	//! staleness estimation only. Frame *ordering* must never depend on it;
 	//! use tx_seq for that.
 	uint64_t NowUtcMicros();
+
+	//! Generates a value for SubjectList.frame_epoch. Call this ONCE per
+	//! publisher session (e.g. alongside SequenceCounter::Reset(), when a
+	//! stream (re)starts) - never per frame.
+	//!
+	//! ReorderGate (reorder_gate.h) relies on frame_epoch being strictly
+	//! greater on every new session than on the previous one, so it can
+	//! tell a restart from an old-session straggler that simply arrived
+	//! late. This returns wall-clock seconds since the Unix epoch
+	//! (truncated to 32 bits, wrapping only once every ~136 years - not a
+	//! practical concern), which is monotonic across restarts in virtually
+	//! every real deployment and is never 0 in any deployable timeframe.
+	//!
+	//! Known limitation: two restarts of the same stream within the same
+	//! wall-clock second produce the same epoch, which ReorderGate would
+	//! then be unable to distinguish from a continuing session - a restart
+	//! that fast falls back to being detected only via the (weaker)
+	//! backward-jump heuristic, or not at all if the new session's
+	//! sequence happens to climb back above the old one before the gate
+	//! would otherwise flag it as stale. A future revision could use a
+	//! persisted counter instead if this proves insufficient in practice.
+	uint32_t NewSessionEpoch();
 }
 
 #endif

--- a/src/o3ds_generated.h
+++ b/src/o3ds_generated.h
@@ -825,7 +825,10 @@ struct SubjectList FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_SUBJECTS = 4,
     VT_UPDATES = 6,
-    VT_TIME = 8
+    VT_TIME = 8,
+    VT_TX_SEQ = 10,
+    VT_TX_WALLCLOCK_US = 12,
+    VT_FRAME_EPOCH = 14
   };
   const flatbuffers::Vector<flatbuffers::Offset<O3DS::Data::Subject>> *subjects() const {
     return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<O3DS::Data::Subject>> *>(VT_SUBJECTS);
@@ -836,6 +839,15 @@ struct SubjectList FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   double time() const {
     return GetField<double>(VT_TIME, 0.0);
   }
+  uint64_t tx_seq() const {
+    return GetField<uint64_t>(VT_TX_SEQ, 0);
+  }
+  uint64_t tx_wallclock_us() const {
+    return GetField<uint64_t>(VT_TX_WALLCLOCK_US, 0);
+  }
+  uint32_t frame_epoch() const {
+    return GetField<uint32_t>(VT_FRAME_EPOCH, 0);
+  }
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
            VerifyOffset(verifier, VT_SUBJECTS) &&
@@ -845,6 +857,9 @@ struct SubjectList FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
            verifier.VerifyVector(updates()) &&
            verifier.VerifyVectorOfTables(updates()) &&
            VerifyField<double>(verifier, VT_TIME, 8) &&
+           VerifyField<uint64_t>(verifier, VT_TX_SEQ, 8) &&
+           VerifyField<uint64_t>(verifier, VT_TX_WALLCLOCK_US, 8) &&
+           VerifyField<uint32_t>(verifier, VT_FRAME_EPOCH, 4) &&
            verifier.EndTable();
   }
 };
@@ -862,6 +877,15 @@ struct SubjectListBuilder {
   void add_time(double time) {
     fbb_.AddElement<double>(SubjectList::VT_TIME, time, 0.0);
   }
+  void add_tx_seq(uint64_t tx_seq) {
+    fbb_.AddElement<uint64_t>(SubjectList::VT_TX_SEQ, tx_seq, 0);
+  }
+  void add_tx_wallclock_us(uint64_t tx_wallclock_us) {
+    fbb_.AddElement<uint64_t>(SubjectList::VT_TX_WALLCLOCK_US, tx_wallclock_us, 0);
+  }
+  void add_frame_epoch(uint32_t frame_epoch) {
+    fbb_.AddElement<uint32_t>(SubjectList::VT_FRAME_EPOCH, frame_epoch, 0);
+  }
   explicit SubjectListBuilder(flatbuffers::FlatBufferBuilder &_fbb)
         : fbb_(_fbb) {
     start_ = fbb_.StartTable();
@@ -877,9 +901,15 @@ inline flatbuffers::Offset<SubjectList> CreateSubjectList(
     flatbuffers::FlatBufferBuilder &_fbb,
     flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<O3DS::Data::Subject>>> subjects = 0,
     flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<O3DS::Data::SubjectUpdate>>> updates = 0,
-    double time = 0.0) {
+    double time = 0.0,
+    uint64_t tx_seq = 0,
+    uint64_t tx_wallclock_us = 0,
+    uint32_t frame_epoch = 0) {
   SubjectListBuilder builder_(_fbb);
+  builder_.add_tx_wallclock_us(tx_wallclock_us);
+  builder_.add_tx_seq(tx_seq);
   builder_.add_time(time);
+  builder_.add_frame_epoch(frame_epoch);
   builder_.add_updates(updates);
   builder_.add_subjects(subjects);
   return builder_.Finish();
@@ -889,14 +919,20 @@ inline flatbuffers::Offset<SubjectList> CreateSubjectListDirect(
     flatbuffers::FlatBufferBuilder &_fbb,
     const std::vector<flatbuffers::Offset<O3DS::Data::Subject>> *subjects = nullptr,
     const std::vector<flatbuffers::Offset<O3DS::Data::SubjectUpdate>> *updates = nullptr,
-    double time = 0.0) {
+    double time = 0.0,
+    uint64_t tx_seq = 0,
+    uint64_t tx_wallclock_us = 0,
+    uint32_t frame_epoch = 0) {
   auto subjects__ = subjects ? _fbb.CreateVector<flatbuffers::Offset<O3DS::Data::Subject>>(*subjects) : 0;
   auto updates__ = updates ? _fbb.CreateVector<flatbuffers::Offset<O3DS::Data::SubjectUpdate>>(*updates) : 0;
   return O3DS::Data::CreateSubjectList(
       _fbb,
       subjects__,
       updates__,
-      time);
+      time,
+      tx_seq,
+      tx_wallclock_us,
+      frame_epoch);
 }
 
 struct Curve FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,6 +9,8 @@ add_executable(o3ds_core_tests
 	test_framework.h
 	main.cpp
 	model_tests.cpp
+	sequencing_tests.cpp
+	reorder_gate_tests.cpp
 )
 
 target_link_libraries(o3ds_core_tests PRIVATE open3dstreamstatic)

--- a/test/reorder_gate_tests.cpp
+++ b/test/reorder_gate_tests.cpp
@@ -1,0 +1,225 @@
+// Acceptance matrix for src/o3ds/reorder_gate.h, per the roadmap doc's A1
+// spec (docs/roadmap/resilient-streaming-and-motion-prediction.md, §3/A1.c).
+#include "test_framework.h"
+
+#include "o3ds/reorder_gate.h"
+
+using namespace O3DS;
+
+namespace
+{
+	// Frames carry no real payload in these tests - only the sequencing
+	// metadata under test. `bytes` holds the seq as a marker so assertions
+	// can identify which frame was delivered without depending on Frame's
+	// move semantics leaving seq intact (it does, but this is self-evident
+	// either way when reading a failure message).
+	Frame MakeFrame(uint64_t seq, uint32_t epoch = 0)
+	{
+		Frame f;
+		f.seq = seq;
+		f.epoch = epoch;
+		f.wallclock_us = 0;
+		return f;
+	}
+
+	struct Delivered
+	{
+		std::vector<uint64_t> seqs;
+
+		std::function<void(Frame&&)> Sink()
+		{
+			return [this](Frame&& f) { seqs.push_back(f.seq); };
+		}
+	};
+}
+
+O3DS_TEST(ReorderGate_InOrder_AllDelivered)
+{
+	ReorderGate gate;
+	Delivered out;
+
+	gate.Push(MakeFrame(1), 0.0, out.Sink());
+	gate.Push(MakeFrame(2), 0.0, out.Sink());
+	gate.Push(MakeFrame(3), 0.0, out.Sink());
+
+	O3DS_CHECK_EQ(out.seqs.size(), (size_t)3);
+	O3DS_CHECK_EQ(out.seqs[0], (uint64_t)1);
+	O3DS_CHECK_EQ(out.seqs[1], (uint64_t)2);
+	O3DS_CHECK_EQ(out.seqs[2], (uint64_t)3);
+	O3DS_CHECK_EQ(gate.Stats().lost, (uint64_t)0);
+	O3DS_CHECK_EQ(gate.Stats().reordered, (uint64_t)0);
+	O3DS_CHECK_EQ(gate.Stats().delivered, (uint64_t)3);
+}
+
+O3DS_TEST(ReorderGate_ReorderRecovered)
+{
+	// 100, 102, 101 -> emit 100,101,102; reordered==1; lost==0
+	ReorderGate gate;
+	Delivered out;
+
+	gate.Push(MakeFrame(100), 0.0, out.Sink());
+	gate.Push(MakeFrame(102), 0.0, out.Sink());
+	gate.Push(MakeFrame(101), 0.0, out.Sink());
+
+	O3DS_CHECK_EQ(out.seqs.size(), (size_t)3);
+	O3DS_CHECK_EQ(out.seqs[0], (uint64_t)100);
+	O3DS_CHECK_EQ(out.seqs[1], (uint64_t)101);
+	O3DS_CHECK_EQ(out.seqs[2], (uint64_t)102);
+	O3DS_CHECK_EQ(gate.Stats().reordered, (uint64_t)1);
+	O3DS_CHECK_EQ(gate.Stats().lost, (uint64_t)0);
+}
+
+O3DS_TEST(ReorderGate_StaleAfterSuccessor_Dropped)
+{
+	// 100, 101, 99 -> emit 100,101; 99 dropped stale; lost==0
+	ReorderGate gate;
+	Delivered out;
+
+	gate.Push(MakeFrame(100), 0.0, out.Sink());
+	gate.Push(MakeFrame(101), 0.0, out.Sink());
+	gate.Push(MakeFrame(99), 0.0, out.Sink());
+
+	O3DS_CHECK_EQ(out.seqs.size(), (size_t)2);
+	O3DS_CHECK_EQ(out.seqs[0], (uint64_t)100);
+	O3DS_CHECK_EQ(out.seqs[1], (uint64_t)101);
+	O3DS_CHECK_EQ(gate.Stats().stale_dropped, (uint64_t)1);
+	O3DS_CHECK_EQ(gate.Stats().dup_dropped, (uint64_t)0);
+	O3DS_CHECK_EQ(gate.Stats().lost, (uint64_t)0);
+}
+
+O3DS_TEST(ReorderGate_Duplicate_Dropped)
+{
+	ReorderGate gate;
+	Delivered out;
+
+	gate.Push(MakeFrame(100), 0.0, out.Sink());
+	gate.Push(MakeFrame(100), 0.0, out.Sink());
+
+	O3DS_CHECK_EQ(out.seqs.size(), (size_t)1);
+	O3DS_CHECK_EQ(gate.Stats().dup_dropped, (uint64_t)1);
+	O3DS_CHECK_EQ(gate.Stats().stale_dropped, (uint64_t)0);
+}
+
+O3DS_TEST(ReorderGate_GapTimeout_LostCounted)
+{
+	// 100, 102, then advance the clock past max_delay_s with no 101 -> emit
+	// 102, lost==1.
+	ReorderGate::Config config;
+	config.max_delay_s = 0.05;
+	ReorderGate gate(config);
+	Delivered out;
+
+	gate.Push(MakeFrame(100), 0.0, out.Sink());
+	gate.Push(MakeFrame(102), 0.0, out.Sink());
+	O3DS_CHECK_EQ(out.seqs.size(), (size_t)1); // 102 still held, waiting on 101
+
+	gate.Flush(0.1, out.Sink()); // now well past max_delay_s
+
+	O3DS_CHECK_EQ(out.seqs.size(), (size_t)2);
+	O3DS_CHECK_EQ(out.seqs[1], (uint64_t)102);
+	O3DS_CHECK_EQ(gate.Stats().lost, (uint64_t)1);
+}
+
+O3DS_TEST(ReorderGate_WindowOverflow_FlushesPastHole)
+{
+	// A persistent gap that fills the buffering window must flush even
+	// before max_delay_s elapses.
+	ReorderGate::Config config;
+	config.max_window = 4;
+	config.max_delay_s = 1000.0; // effectively disabled; window is the trigger here
+	ReorderGate gate(config);
+	Delivered out;
+
+	gate.Push(MakeFrame(100), 0.0, out.Sink());
+	// 101 is missing. Buffer 102..105 (4 entries == max_window) without ever
+	// sending 101 or advancing the clock meaningfully.
+	gate.Push(MakeFrame(102), 0.0, out.Sink());
+	gate.Push(MakeFrame(103), 0.0, out.Sink());
+	gate.Push(MakeFrame(104), 0.0, out.Sink());
+	gate.Push(MakeFrame(105), 0.0, out.Sink());
+
+	// The window is full, so the gap must have already been given up on
+	// without needing an explicit Flush().
+	O3DS_CHECK(out.seqs.size() >= (size_t)2); // at least 100 and the unblocked 102
+	O3DS_CHECK_EQ(gate.Stats().lost, (uint64_t)1); // exactly seq 101
+}
+
+O3DS_TEST(ReorderGate_LegacyTxSeqZero_BypassesGate)
+{
+	ReorderGate gate;
+	Delivered out;
+
+	// seq==0 must pass straight through regardless of arrival order and
+	// must not perturb gate state for subsequently-sequenced frames.
+	gate.Push(MakeFrame(0), 0.0, out.Sink());
+	gate.Push(MakeFrame(0), 0.0, out.Sink());
+	gate.Push(MakeFrame(1), 0.0, out.Sink());
+	gate.Push(MakeFrame(2), 0.0, out.Sink());
+
+	O3DS_CHECK_EQ(out.seqs.size(), (size_t)4);
+	O3DS_CHECK_EQ(gate.Stats().delivered, (uint64_t)2); // only the two sequenced frames counted
+	O3DS_CHECK_EQ(gate.Stats().dup_dropped, (uint64_t)0);
+}
+
+O3DS_TEST(ReorderGate_RestartViaEpoch_Rebaselines)
+{
+	ReorderGate gate;
+	Delivered out;
+
+	gate.Push(MakeFrame(500, /*epoch*/ 1), 0.0, out.Sink());
+	gate.Push(MakeFrame(501, /*epoch*/ 1), 0.0, out.Sink());
+
+	// Publisher restarts: its SequenceCounter resets to 1 and frame_epoch
+	// bumps. A naive backward-jump-only gate would treat seq 1 as ancient
+	// stale traffic; the epoch change must instead trigger a clean
+	// re-baseline and deliver seq 1 immediately.
+	gate.Push(MakeFrame(1, /*epoch*/ 2), 0.0, out.Sink());
+	gate.Push(MakeFrame(2, /*epoch*/ 2), 0.0, out.Sink());
+
+	O3DS_CHECK_EQ(out.seqs.size(), (size_t)4);
+	O3DS_CHECK_EQ(out.seqs[2], (uint64_t)1);
+	O3DS_CHECK_EQ(out.seqs[3], (uint64_t)2);
+	// The old session's data must not be misreported as loss on restart.
+	O3DS_CHECK_EQ(gate.Stats().lost, (uint64_t)0);
+}
+
+O3DS_TEST(ReorderGate_RestartViaBackjumpHeuristic_LegacyStreamWithoutEpoch)
+{
+	// No frame_epoch ever set on this stream (epoch stays 0 throughout) -
+	// restart must fall back to the backward-jump heuristic.
+	ReorderGate::Config config;
+	config.reset_backjump = 50;
+	ReorderGate gate(config);
+	Delivered out;
+
+	gate.Push(MakeFrame(1000), 0.0, out.Sink());
+	gate.Push(MakeFrame(1001), 0.0, out.Sink());
+
+	// Small backward step (within threshold) must NOT be treated as a
+	// restart - it's ordinary stale/duplicate traffic.
+	gate.Push(MakeFrame(990), 0.0, out.Sink());
+	O3DS_CHECK_EQ(out.seqs.size(), (size_t)2);
+	O3DS_CHECK_EQ(gate.Stats().stale_dropped, (uint64_t)1);
+
+	// Large backward jump (beyond threshold) must re-baseline.
+	gate.Push(MakeFrame(1), 0.0, out.Sink());
+	O3DS_CHECK_EQ(out.seqs.size(), (size_t)3);
+	O3DS_CHECK_EQ(out.seqs[2], (uint64_t)1);
+}
+
+O3DS_TEST(ReorderGate_MalformedInputsAreSafe)
+{
+	// The gate itself only ever touches Frame's scalar fields (seq/epoch/
+	// wallclock_us); it never dereferences `bytes`. This test exists mainly
+	// to document/guard that an empty payload is a legitimate input, not a
+	// crash - the real untrusted-buffer hardening lives in
+	// SubjectList::PeekMeta (see sequencing_tests.cpp).
+	ReorderGate gate;
+	Delivered out;
+
+	Frame f = MakeFrame(1);
+	f.bytes.clear();
+	gate.Push(std::move(f), 0.0, out.Sink());
+
+	O3DS_CHECK_EQ(out.seqs.size(), (size_t)1);
+}

--- a/test/reorder_gate_tests.cpp
+++ b/test/reorder_gate_tests.cpp
@@ -161,6 +161,99 @@ O3DS_TEST(ReorderGate_LegacyTxSeqZero_BypassesGate)
 	O3DS_CHECK_EQ(gate.Stats().dup_dropped, (uint64_t)0);
 }
 
+O3DS_TEST(ReorderGate_GiveUpDrain_DoesNotInflateReorderedStat)
+{
+	// Regression test for a review finding: frames drained after
+	// CheckTimeouts gives up on a lost gap were being counted as
+	// `reordered`, even when they arrived in perfectly good order relative
+	// to each other - they were just waiting behind a hole, not reordered.
+	ReorderGate::Config config;
+	config.max_window = 4;
+	ReorderGate gate(config);
+	Delivered out;
+
+	gate.Push(MakeFrame(100), 0.0, out.Sink()); // delivered normally
+	// 101 is missing. 102..105 arrive in strict ascending order and fill
+	// the window, forcing a give-up on the 101 gap.
+	gate.Push(MakeFrame(102), 0.0, out.Sink());
+	gate.Push(MakeFrame(103), 0.0, out.Sink());
+	gate.Push(MakeFrame(104), 0.0, out.Sink());
+	gate.Push(MakeFrame(105), 0.0, out.Sink());
+
+	O3DS_CHECK_EQ(gate.Stats().lost, (uint64_t)1);       // exactly seq 101
+	O3DS_CHECK_EQ(gate.Stats().reordered, (uint64_t)0);  // nothing here was actually reordered
+}
+
+O3DS_TEST(ReorderGate_DuplicateOfPendingFrame_CountedAsDup)
+{
+	// Regression test for a review finding: a resend of a seq that's
+	// already sitting in the pending-gap buffer was silently dropped by
+	// map::emplace with no stats update at all.
+	ReorderGate gate;
+	Delivered out;
+
+	gate.Push(MakeFrame(100), 0.0, out.Sink()); // delivered
+	gate.Push(MakeFrame(102), 0.0, out.Sink()); // buffered, waiting on 101
+	gate.Push(MakeFrame(102), 0.0, out.Sink()); // a duplicate of the buffered frame
+
+	O3DS_CHECK_EQ(gate.Stats().dup_dropped, (uint64_t)1);
+}
+
+O3DS_TEST(ReorderGate_OldEpochStraggler_DroppedNotMisappliedAsRestart)
+{
+	// Regression test for the review's critical finding: a frame from an
+	// OLDER epoch, reordered in flight to arrive after the new session has
+	// already started, must not be mistaken for another restart. Treating
+	// frame_epoch as "changed vs not" instead of an ORDERED value would
+	// apply this stale frame mid-stream and, because it would also drag
+	// mLastEpoch backward, make every subsequent legitimate frame look like
+	// yet another false restart.
+	ReorderGate gate;
+	Delivered out;
+
+	gate.Push(MakeFrame(500, /*epoch*/ 1), 0.0, out.Sink());
+	gate.Push(MakeFrame(501, /*epoch*/ 1), 0.0, out.Sink());
+	gate.Push(MakeFrame(1, /*epoch*/ 2), 0.0, out.Sink());   // genuine restart
+	gate.Push(MakeFrame(2, /*epoch*/ 2), 0.0, out.Sink());
+	gate.Push(MakeFrame(502, /*epoch*/ 1), 0.0, out.Sink()); // stale straggler from epoch 1
+	gate.Push(MakeFrame(3, /*epoch*/ 2), 0.0, out.Sink());   // must NOT look like another restart
+	gate.Push(MakeFrame(4, /*epoch*/ 2), 0.0, out.Sink());
+
+	// 502 must never be delivered - it's stale data from a dead session.
+	O3DS_CHECK_EQ(out.seqs.size(), (size_t)6);
+	O3DS_CHECK_EQ(out.seqs[0], (uint64_t)500);
+	O3DS_CHECK_EQ(out.seqs[1], (uint64_t)501);
+	O3DS_CHECK_EQ(out.seqs[2], (uint64_t)1);
+	O3DS_CHECK_EQ(out.seqs[3], (uint64_t)2);
+	O3DS_CHECK_EQ(out.seqs[4], (uint64_t)3);
+	O3DS_CHECK_EQ(out.seqs[5], (uint64_t)4);
+	O3DS_CHECK_EQ(gate.Stats().stale_dropped, (uint64_t)1); // the 502 straggler
+}
+
+O3DS_TEST(ReorderGate_OldEpochStraggler_DoesNotWipeBufferedNewSessionFrames)
+{
+	// Worse variant of the above: if the straggler were still (incorrectly)
+	// treated as a restart, its state-clearing would silently discard any
+	// legitimately-buffered new-session frame, not just misapply itself.
+	ReorderGate gate;
+	Delivered out;
+
+	gate.Push(MakeFrame(500, /*epoch*/ 1), 0.0, out.Sink());
+	gate.Push(MakeFrame(1, /*epoch*/ 2), 0.0, out.Sink());
+	// 3 arrives before 2, so 3 sits buffered in the pending-gap map.
+	gate.Push(MakeFrame(3, /*epoch*/ 2), 0.0, out.Sink());
+	// An old-epoch straggler must not wipe that buffered frame.
+	gate.Push(MakeFrame(600, /*epoch*/ 1), 0.0, out.Sink());
+	gate.Push(MakeFrame(2, /*epoch*/ 2), 0.0, out.Sink()); // unblocks the buffered 3
+
+	O3DS_CHECK_EQ(out.seqs.size(), (size_t)4);
+	O3DS_CHECK_EQ(out.seqs[0], (uint64_t)500);
+	O3DS_CHECK_EQ(out.seqs[1], (uint64_t)1);
+	O3DS_CHECK_EQ(out.seqs[2], (uint64_t)2);
+	O3DS_CHECK_EQ(out.seqs[3], (uint64_t)3); // proves 3 survived the straggler, not lost
+	O3DS_CHECK_EQ(gate.Stats().lost, (uint64_t)0);
+}
+
 O3DS_TEST(ReorderGate_RestartViaEpoch_Rebaselines)
 {
 	ReorderGate gate;

--- a/test/sequencing_tests.cpp
+++ b/test/sequencing_tests.cpp
@@ -43,6 +43,18 @@ O3DS_TEST(NowUtcMicrosIsPlausibleAndAdvances)
 	O3DS_CHECK(t2 >= t1);
 }
 
+O3DS_TEST(NewSessionEpochIsPlausibleAndNonZero)
+{
+	uint32_t epoch = NewSessionEpoch();
+
+	// Same sanity bound as NowUtcMicros, in seconds: any time after
+	// ~2020-01-01. Also confirms it's never 0 (0 means "unset" on the
+	// wire), which ReorderGate depends on to distinguish a real epoch from
+	// a legacy/unset one.
+	O3DS_CHECK(epoch > 1577836800u);
+	O3DS_CHECK(epoch != 0);
+}
+
 O3DS_TEST(TxSeqAndWallclockRoundTripThroughSerializeAndParse)
 {
 	SubjectList subjects;

--- a/test/sequencing_tests.cpp
+++ b/test/sequencing_tests.cpp
@@ -1,0 +1,109 @@
+// Tests for src/o3ds/sequencing.h and the tx_seq/tx_wallclock_us/frame_epoch
+// wire fields (SubjectList::Serialize/SerializeUpdate/PeekMeta).
+#include "test_framework.h"
+
+#include "o3ds/model.h"
+#include "o3ds/sequencing.h"
+
+#include <cstring>
+
+using namespace O3DS;
+
+O3DS_TEST(SequenceCounterIsMonotonicAndStartsAtOne)
+{
+	SequenceCounter counter;
+	uint64_t a = counter.Next();
+	uint64_t b = counter.Next();
+	uint64_t c = counter.Next();
+
+	O3DS_CHECK_EQ(a, (uint64_t)1);
+	O3DS_CHECK_EQ(b, (uint64_t)2);
+	O3DS_CHECK_EQ(c, (uint64_t)3);
+}
+
+O3DS_TEST(SequenceCounterResetReturnsToOne)
+{
+	SequenceCounter counter;
+	counter.Next();
+	counter.Next();
+	counter.Reset();
+
+	O3DS_CHECK_EQ(counter.Next(), (uint64_t)1);
+}
+
+O3DS_TEST(NowUtcMicrosIsPlausibleAndAdvances)
+{
+	uint64_t t1 = NowUtcMicros();
+	uint64_t t2 = NowUtcMicros();
+
+	// Sanity bound: any time after ~2020-01-01 in microseconds. Catches a
+	// unit mistake (e.g. accidentally returning milliseconds or seconds)
+	// without pinning down an exact value.
+	O3DS_CHECK(t1 > 1577836800000000ull);
+	O3DS_CHECK(t2 >= t1);
+}
+
+O3DS_TEST(TxSeqAndWallclockRoundTripThroughSerializeAndParse)
+{
+	SubjectList subjects;
+	subjects.addSubject("Performer")->addTransform("Root", -1);
+
+	std::vector<char> buffer;
+	int size = subjects.Serialize(buffer, /*timestamp*/ 1.0,
+		/*tx_seq*/ 42, /*tx_wallclock_us*/ 1234567890123ull, /*frame_epoch*/ 7);
+	O3DS_CHECK(size > 0);
+
+	uint64_t peekedSeq = 0, peekedWallclock = 0;
+	uint32_t peekedEpoch = 0;
+	bool peeked = SubjectList::PeekMeta(buffer.data(), buffer.size(), peekedSeq, peekedWallclock, peekedEpoch);
+	O3DS_CHECK(peeked);
+	O3DS_CHECK_EQ(peekedSeq, (uint64_t)42);
+	O3DS_CHECK_EQ(peekedWallclock, (uint64_t)1234567890123ull);
+	O3DS_CHECK_EQ(peekedEpoch, (uint32_t)7);
+
+	// A full Parse() must also see the subject data as usual - the new
+	// fields are additive, not a replacement for the existing payload.
+	SubjectList parsed;
+	bool ok = parsed.Parse(buffer.data(), buffer.size());
+	O3DS_CHECK(ok);
+	O3DS_CHECK(parsed.findSubject("Performer") != nullptr);
+}
+
+O3DS_TEST(UnsetTxFieldsDefaultToZeroLikeALegacySender)
+{
+	SubjectList subjects;
+	subjects.addSubject("Legacy")->addTransform("Root", -1);
+
+	std::vector<char> buffer;
+	// Deliberately omit tx_seq/tx_wallclock_us/frame_epoch - matches how an
+	// old sender that predates these fields would call Serialize().
+	int size = subjects.Serialize(buffer, /*timestamp*/ 1.0);
+	O3DS_CHECK(size > 0);
+
+	uint64_t peekedSeq = 1, peekedWallclock = 1; // pre-seed with non-zero to prove they get zeroed
+	uint32_t peekedEpoch = 1;
+	bool peeked = SubjectList::PeekMeta(buffer.data(), buffer.size(), peekedSeq, peekedWallclock, peekedEpoch);
+	O3DS_CHECK(peeked);
+	O3DS_CHECK_EQ(peekedSeq, (uint64_t)0);
+	O3DS_CHECK_EQ(peekedWallclock, (uint64_t)0);
+	O3DS_CHECK_EQ(peekedEpoch, (uint32_t)0);
+}
+
+O3DS_TEST(PeekMetaRejectsShortAndMalformedBuffers)
+{
+	uint64_t seq = 0, wallclock = 0;
+	uint32_t epoch = 0;
+
+	// Too short to even contain the 8-byte header.
+	char tiny[4] = { 0, 0, 0, 0 };
+	O3DS_CHECK(SubjectList::PeekMeta(tiny, 4, seq, wallclock, epoch) == false);
+	O3DS_CHECK(SubjectList::PeekMeta(tiny, 0, seq, wallclock, epoch) == false);
+	O3DS_CHECK(SubjectList::PeekMeta(nullptr, 100, seq, wallclock, epoch) == false);
+
+	// Long enough for the header, but garbage FlatBuffers payload - must
+	// fail the Verifier rather than reading out-of-bounds or garbage data.
+	char garbage[32];
+	memset(garbage, 0xFF, sizeof(garbage));
+	O3DS_CHECK(SubjectList::PeekMeta(garbage, sizeof(garbage), seq, wallclock, epoch) == false);
+	O3DS_CHECK_EQ(seq, (uint64_t)0);
+}


### PR DESCRIPTION
## Summary
Implements roadmap phase A1 (docs/roadmap/resilient-streaming-and-motion-prediction.md §3, issue #216) — the real, working version of the `tx_seq` capability that was previously shipped as a non-compiling, never-wired placeholder and removed in #201. Entirely in `src/o3ds`, built and tested against the CTest harness landed in #227.

### A1.a — Schema (append-only)
`SubjectList` gains `tx_seq:ulong=0`, `tx_wallclock_us:ulong=0`, `frame_epoch:uint=0`. All three default to 0 = unset; an old sender/receiver on either side of the wire sees exactly today's behavior.

`frame_epoch` was left as an open decision in the roadmap doc — decided **yes**: it lets the reorder gate detect a publisher restart from an epoch change instead of relying only on a backward-jump heuristic.

Regenerated `src/o3ds_generated.h` via `flatc --cpp`; normalized line endings back to CRLF so the diff is just the 3 new fields' boilerplate (a straight Linux regen produced ~2000 lines of pure LF/CRLF noise against the Windows-generated original — confirmed via `file`/byte comparison before normalizing). Existing `CreateSubjectList(...)` call sites are untouched and remain valid (trailing defaulted params).

### A1.b — Sender (`src/o3ds/sequencing.h/.cpp`)
- `SequenceCounter`: atomic, starts at 1, **one instance per logical stream** (not process-global — a shared counter would make ordinary fan-out to multiple receivers look like loss to each of them).
- `NowUtcMicros()`: UTC wall clock for `tx_wallclock_us`, explicitly **not** used for ordering.
- `NewSessionEpoch()`: generates `frame_epoch` (wall-clock seconds, best-effort monotonic across restarts) — added during the review pass below to specify a contract that was otherwise unstated.
- `SubjectList::Serialize`/`SerializeUpdate` extended with 3 appended defaulted params — every existing call site is untouched and remains valid.
- `SubjectList::PeekMeta()` (new): extracts the 3 scalar fields from a wire buffer via a length check + FlatBuffers `Verifier`, without a full `Parse()`. Hardened from the start since it reads untrusted network bytes.

### A1.c — Receiver gate (`src/o3ds/reorder_gate.h/.cpp`)
`ReorderGate`: a per-source, single-threaded state machine — in-order delivery, out-of-order recovery with a bounded buffer, dup-vs-stale classification, gap-timeout give-up with accurate `lost` accounting, and restart re-baselining. `tx_seq==0` bypasses the gate entirely.

### Not done here
Not mirrored into the vendored core copy under `ProjectSandbox/.../ThirdParty/open3dstream/` (#203) — A1 is core/CTest-only, UE integration is A2, zero UE call sites exist yet. Will mirror as part of A2.

## Dedicated Opus review pass — completed, findings fixed
Per the plan (core phases implemented at Sonnet tier, reviewed at Opus tier for the highest-risk component), I ran an adversarial review specifically targeting `reorder_gate.h/.cpp`, briefed to empirically prove any bugs with a standalone repro rather than speculate. It found and empirically confirmed:

- **Critical (fixed):** restart detection compared `frame_epoch` as "changed vs not" instead of an ordered value. A straggler frame from an **older** epoch, reordered in flight to arrive after a restart's first frame (an ordinary occurrence on a lossy/reordering network — exactly what this gate exists to handle), was misread as *another* restart: applied as stale motion data, and because `mLastEpoch` also got dragged backward, every subsequent legitimate frame then looked like a restart too (epoch flapping). Worse, if a legitimate new-session frame was buffered behind a gap when the straggler landed, the false restart's state-clear silently discarded it as an uncounted loss. **Fixed** with an ordered comparison (`>` = restart, `<` = stale straggler that never regresses `mLastEpoch`, `==` = normal), plus `NewSessionEpoch()` to specify the sender-side contract this depends on.
- **Minor (fixed), stats-only:** `reordered` was inflated by frames drained after a lost-gap give-up, even when they'd arrived in perfectly good order (just waiting behind a hole) — over-reported the reorder-rate metric this feeds into the A2 HUD.
- **Minor (fixed), stats-only:** a duplicate landing on an already-pending (buffered) seq was silently dropped with zero stats update.
- Everything else the review specifically hunted for — integer overflow/underflow on the seq/epoch arithmetic, use-after-move, off-by-ones in the window/timeout math — came back clean (confirmed via a standalone ASan/UBSan repro).

5 regression tests added reproducing each finding exactly (including the "wipes a legitimately-buffered frame" variant of the critical one), plus a `NewSessionEpoch` sanity test.

## Verified, not just written
**24/24 tests pass under ASan/UBSan**, run against a fully clean from-scratch configure/build/`ctest` (mirroring the rigor established in #227) — including the original 19 plus the 5 review-driven regression tests.

## Test plan
- [x] Full clean build + `ctest` (24/24, ASan/UBSan active)
- [x] Confirmed every existing `CreateSubjectList`/`Serialize`/`SerializeUpdate` call site remains source-compatible
- [x] Dedicated Opus-tier adversarial review of `reorder_gate.h/.cpp`, findings fixed and regression-tested
- [ ] CI (checking now)

🤖 Generated as part of the June 2026 review follow-on planning.
