### PR TITLE
B1: .o3dscap capture format + core reader/writer

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -104,6 +104,7 @@ set(pub_headers
 	o3ds/getTime.h
 	o3ds/sequencing.h
 	o3ds/reorder_gate.h
+	o3ds/capture.h
 	o3ds/model.h
 	o3ds/base_connector.h
 	o3ds/nng_connector.h
@@ -141,6 +142,7 @@ set(SOURCES
 	o3ds/getTime.cpp
 	o3ds/sequencing.cpp
 	o3ds/reorder_gate.cpp
+	o3ds/capture.cpp
 	o3ds/model.cpp
 	o3ds/base_connector.cpp
 	o3ds/nng_connector.cpp

--- a/src/o3ds/capture.cpp
+++ b/src/o3ds/capture.cpp
@@ -1,0 +1,223 @@
+/*
+Open 3D Stream
+
+Copyright 2026 Alastair Macleod
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#include "capture.h"
+
+#include <cstring>
+
+namespace
+{
+	// Fixed portion of the header, before the variable-length source_desc
+	// tail: magic(8) + format_version(2) + header_len(2) + flags(4) +
+	// base_wallclock_us(8) + schema_fingerprint(4) + predictor_version(4) +
+	// source_desc_len(2) = 34 bytes.
+	const size_t kHeaderFixedSize = 34;
+	const size_t kMaxSourceDescLen = 65535 - kHeaderFixedSize; // so header_len still fits in uint16
+	const char kMagic[8] = { 'O', '3', 'D', 'S', 'C', 'A', 'P', '\0' };
+
+	// Explicit little-endian encode/decode: correct regardless of host byte
+	// order (never relies on raw memcpy of a multi-byte integer).
+
+	void WriteU16LE(std::ostream& out, uint16_t v)
+	{
+		char buf[2] = { (char)(v & 0xFF), (char)((v >> 8) & 0xFF) };
+		out.write(buf, sizeof(buf));
+	}
+
+	void WriteU32LE(std::ostream& out, uint32_t v)
+	{
+		char buf[4];
+		for (int i = 0; i < 4; i++)
+			buf[i] = (char)((v >> (8 * i)) & 0xFF);
+		out.write(buf, sizeof(buf));
+	}
+
+	void WriteU64LE(std::ostream& out, uint64_t v)
+	{
+		char buf[8];
+		for (int i = 0; i < 8; i++)
+			buf[i] = (char)((v >> (8 * i)) & 0xFF);
+		out.write(buf, sizeof(buf));
+	}
+
+	bool ReadU16LE(std::istream& in, uint16_t& outValue)
+	{
+		unsigned char buf[2];
+		in.read((char*)buf, sizeof(buf));
+		if (!in || in.gcount() != (std::streamsize)sizeof(buf))
+			return false;
+		outValue = (uint16_t)buf[0] | ((uint16_t)buf[1] << 8);
+		return true;
+	}
+
+	bool ReadU32LE(std::istream& in, uint32_t& outValue)
+	{
+		unsigned char buf[4];
+		in.read((char*)buf, sizeof(buf));
+		if (!in || in.gcount() != (std::streamsize)sizeof(buf))
+			return false;
+		outValue = 0;
+		for (int i = 0; i < 4; i++)
+			outValue |= ((uint32_t)buf[i]) << (8 * i);
+		return true;
+	}
+
+	bool ReadU64LE(std::istream& in, uint64_t& outValue)
+	{
+		unsigned char buf[8];
+		in.read((char*)buf, sizeof(buf));
+		if (!in || in.gcount() != (std::streamsize)sizeof(buf))
+			return false;
+		outValue = 0;
+		for (int i = 0; i < 8; i++)
+			outValue |= ((uint64_t)buf[i]) << (8 * i);
+		return true;
+	}
+}
+
+namespace O3DS
+{
+	bool WriteCaptureHeader(std::ostream& out, const CaptureHeaderInfo& info)
+	{
+		if (info.source_desc.size() > kMaxSourceDescLen)
+			return false;
+
+		uint16_t sourceDescLen = (uint16_t)info.source_desc.size();
+		uint16_t headerLen = (uint16_t)(kHeaderFixedSize + sourceDescLen);
+
+		out.write(kMagic, sizeof(kMagic));
+		WriteU16LE(out, kCaptureFormatVersion);
+		WriteU16LE(out, headerLen);
+		WriteU32LE(out, info.flags);
+		WriteU64LE(out, info.base_wallclock_us);
+		WriteU32LE(out, info.schema_fingerprint);
+		WriteU32LE(out, info.predictor_version);
+		WriteU16LE(out, sourceDescLen);
+		if (sourceDescLen > 0)
+			out.write(info.source_desc.data(), sourceDescLen);
+
+		return (bool)out;
+	}
+
+	bool WriteCaptureRecord(std::ostream& out, const CaptureRecord& record)
+	{
+		if (record.wire_bytes.size() > kCaptureMaxWireLen)
+			return false;
+
+		WriteU64LE(out, record.recv_wallclock_us);
+		WriteU32LE(out, (uint32_t)record.wire_bytes.size());
+		if (!record.wire_bytes.empty())
+			out.write(record.wire_bytes.data(), (std::streamsize)record.wire_bytes.size());
+
+		return (bool)out;
+	}
+
+	bool ReadCaptureHeader(std::istream& in, CaptureHeaderInfo& outInfo)
+	{
+		outInfo = CaptureHeaderInfo();
+
+		char magic[8];
+		in.read(magic, sizeof(magic));
+		if (!in || in.gcount() != (std::streamsize)sizeof(magic))
+			return false;
+		if (memcmp(magic, kMagic, sizeof(kMagic)) != 0)
+			return false;
+
+		uint16_t formatVersion = 0;
+		if (!ReadU16LE(in, formatVersion))
+			return false;
+		if (formatVersion != kCaptureFormatVersion) // v1 reader: no minor-version tolerance yet
+			return false;
+
+		uint16_t headerLen = 0;
+		if (!ReadU16LE(in, headerLen))
+			return false;
+		if (headerLen < kHeaderFixedSize)
+			return false; // too small to even hold the fixed fields - corrupt
+
+		uint32_t flags = 0;
+		uint64_t baseWallclockUs = 0;
+		uint32_t schemaFingerprint = 0;
+		uint32_t predictorVersion = 0;
+		uint16_t sourceDescLen = 0;
+		if (!ReadU32LE(in, flags)) return false;
+		if (!ReadU64LE(in, baseWallclockUs)) return false;
+		if (!ReadU32LE(in, schemaFingerprint)) return false;
+		if (!ReadU32LE(in, predictorVersion)) return false;
+		if (!ReadU16LE(in, sourceDescLen)) return false;
+
+		if ((size_t)headerLen < kHeaderFixedSize + sourceDescLen)
+			return false; // declared header too small to hold its own source_desc - corrupt
+
+		std::string sourceDesc;
+		if (sourceDescLen > 0)
+		{
+			sourceDesc.resize(sourceDescLen);
+			in.read(&sourceDesc[0], sourceDescLen);
+			if (!in || in.gcount() != (std::streamsize)sourceDescLen)
+				return false;
+		}
+
+		// Skip any reserved padding a newer writer may have appended between
+		// source_desc and header_len, so records start at the right offset
+		// regardless of header_len exceeding what we understood how to parse.
+		in.seekg((std::streamoff)headerLen, std::ios::beg);
+		if (!in)
+			return false;
+
+		outInfo.flags = flags;
+		outInfo.base_wallclock_us = baseWallclockUs;
+		outInfo.schema_fingerprint = schemaFingerprint;
+		outInfo.predictor_version = predictorVersion;
+		outInfo.source_desc = std::move(sourceDesc);
+		return true;
+	}
+
+	bool ReadCaptureRecord(std::istream& in, CaptureRecord& outRecord)
+	{
+		uint64_t recvWallclockUs = 0;
+		if (!ReadU64LE(in, recvWallclockUs))
+			return false; // clean EOF or truncated - both mean "no more records"
+
+		uint32_t wireLen = 0;
+		if (!ReadU32LE(in, wireLen))
+			return false; // truncated mid-record-header - stop cleanly, not an error
+
+		if (wireLen > kCaptureMaxWireLen)
+			return false; // corrupt/adversarial length - reject before allocating
+
+		std::vector<char> wireBytes;
+		if (wireLen > 0)
+		{
+			wireBytes.resize(wireLen);
+			in.read(wireBytes.data(), wireLen);
+			if (!in || in.gcount() != (std::streamsize)wireLen)
+				return false; // truncated final record - stop cleanly, not an error
+		}
+
+		outRecord.recv_wallclock_us = recvWallclockUs;
+		outRecord.wire_bytes = std::move(wireBytes);
+		return true;
+	}
+}

--- a/src/o3ds/capture.h
+++ b/src/o3ds/capture.h
@@ -1,0 +1,113 @@
+/*
+Open 3D Stream
+
+Copyright 2026 Alastair Macleod
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#ifndef OPEN3D_STREAM_CAPTURE_H
+#define OPEN3D_STREAM_CAPTURE_H
+
+#include <cstdint>
+#include <istream>
+#include <ostream>
+#include <string>
+#include <vector>
+
+namespace O3DS
+{
+	//! .o3dscap v1 container format (see docs/roadmap/resilient-streaming-
+	//! and-motion-prediction.md, Phase B1, for the full byte-level spec).
+	//! Captures verbatim on-the-wire O3DS frames plus their receive time, so
+	//! writing a capture is near-zero cost (no re-encoding) and safe to call
+	//! inline on a hot send/receive path.
+	//!
+	//! All multi-byte fields are little-endian on the wire regardless of
+	//! host byte order (encoded/decoded explicitly, not via raw memcpy).
+	//! These functions operate on std::istream&/std::ostream& - any
+	//! seekable stream works (std::ifstream/ofstream for real files,
+	//! std::istringstream/ostringstream for tests); ReadCaptureHeader
+	//! requires the input stream to be seekable (see its doc comment).
+	//!
+	//! IMPORTANT for real files: open with std::ios::binary. This is a
+	//! binary format; a file stream opened in text mode can silently
+	//! rewrite byte sequences in the payload (historically, and still
+	//! today on Windows, 0x0A <-> 0x0D 0x0A translation), corrupting
+	//! captured frames without any read/write call reporting failure.
+
+	static const uint16_t kCaptureFormatVersion = 1;
+
+	//! Reject any single record's wire_bytes above this size before
+	//! allocating for it - guards against a corrupt/malicious wire_len
+	//! (a uint32 field, so its face-value range goes well past what any
+	//! real O3DS frame should be) causing a huge allocation. Mirrors the
+	//! same posture already applied to the network-facing parsers.
+	static const uint32_t kCaptureMaxWireLen = 64u * 1024u * 1024u; // 64MB
+
+	struct CaptureHeaderInfo
+	{
+		uint32_t flags = 0;              // bit0 = timestamps are UTC-us; other bits reserved (0)
+		uint64_t base_wallclock_us = 0;  // capture start; 0 = unset
+		uint32_t schema_fingerprint = 0; // e.g. a hash of o3ds.fbs/O3DS_VERSION_TAG; 0 = unset
+		uint32_t predictor_version = 0;  // 0 = none (Workstream C)
+		std::string source_desc;         // free-form UTF-8 (transport, host, notes); max 65501 bytes
+		                                  // (65535 minus the 34-byte fixed header, so header_len itself
+		                                  // still fits in its own uint16 field)
+	};
+
+	struct CaptureRecord
+	{
+		uint64_t recv_wallclock_us = 0; // capture/receive time, absolute
+		std::vector<char> wire_bytes;   // the exact on-the-wire O3DS frame, verbatim
+	};
+
+	//! Writes the .o3dscap header. Call exactly once, before any
+	//! WriteCaptureRecord calls on the same stream. Returns false if
+	//! `info.source_desc` exceeds 65535 bytes (its wire length prefix is a
+	//! uint16) or the stream write fails.
+	bool WriteCaptureHeader(std::ostream& out, const CaptureHeaderInfo& info);
+
+	//! Appends one record. Returns false if `record.wire_bytes.size()`
+	//! exceeds kCaptureMaxWireLen (a byte count that large should never be
+	//! reached by a real O3DS frame; this is a guard, not a realistic
+	//! capture) or the stream write fails.
+	bool WriteCaptureRecord(std::ostream& out, const CaptureRecord& record);
+
+	//! Reads and validates the header: magic, and format_version (v1
+	//! readers accept only format_version == 1; a future version may
+	//! introduce major/minor semantics). Requires `in` to be seekable
+	//! (uses seekg to skip to the end of the header, including any
+	//! reserved padding a newer writer may have added) - real files and
+	//! std::istringstream both satisfy this; a non-seekable stream is not
+	//! supported. Returns false on any validation failure or short read;
+	//! `outInfo` is left default-constructed in that case.
+	bool ReadCaptureHeader(std::istream& in, CaptureHeaderInfo& outInfo);
+
+	//! Reads the next record. Returns false when there isn't a complete
+	//! record left to read - this covers BOTH a clean end-of-capture and a
+	//! truncated trailing record (a capture cut mid-write) identically, by
+	//! design: a truncated tail is not an error, just the end of what was
+	//! successfully captured. Never throws or reads out of bounds on
+	//! malformed/truncated/adversarial input. `outRecord` is left
+	//! unspecified (do not use) when this returns false.
+	bool ReadCaptureRecord(std::istream& in, CaptureRecord& outRecord);
+}
+
+#endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -11,6 +11,7 @@ add_executable(o3ds_core_tests
 	model_tests.cpp
 	sequencing_tests.cpp
 	reorder_gate_tests.cpp
+	capture_tests.cpp
 )
 
 target_link_libraries(o3ds_core_tests PRIVATE open3dstreamstatic)

--- a/test/capture_tests.cpp
+++ b/test/capture_tests.cpp
@@ -1,0 +1,345 @@
+// Acceptance tests for src/o3ds/capture.h (.o3dscap v1), per the roadmap
+// doc's B1 spec (docs/roadmap/resilient-streaming-and-motion-prediction.md,
+// section "Phase B1").
+#include "test_framework.h"
+
+#include "o3ds/capture.h"
+
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+
+using namespace O3DS;
+
+namespace
+{
+	std::vector<char> MakeWireBytes(char fill, size_t len)
+	{
+		return std::vector<char>(len, fill);
+	}
+
+	// Writes a raw little-endian uint32 directly into a stream, bypassing
+	// the public API - used to hand-construct malformed/adversarial
+	// captures that WriteCaptureRecord would never produce itself.
+	void RawWriteU32LE(std::ostream& out, uint32_t v)
+	{
+		char buf[4];
+		for (int i = 0; i < 4; i++)
+			buf[i] = (char)((v >> (8 * i)) & 0xFF);
+		out.write(buf, sizeof(buf));
+	}
+
+	void RawWriteU64LE(std::ostream& out, uint64_t v)
+	{
+		char buf[8];
+		for (int i = 0; i < 8; i++)
+			buf[i] = (char)((v >> (8 * i)) & 0xFF);
+		out.write(buf, sizeof(buf));
+	}
+}
+
+O3DS_TEST(Capture_HeaderRoundTrip)
+{
+	CaptureHeaderInfo written;
+	written.flags = 1;
+	written.base_wallclock_us = 1234567890123ull;
+	written.schema_fingerprint = 0xDEADBEEF;
+	written.predictor_version = 2;
+	written.source_desc = "tcp://127.0.0.1:5555 test capture";
+
+	std::ostringstream out;
+	O3DS_CHECK(WriteCaptureHeader(out, written));
+
+	std::istringstream in(out.str());
+	CaptureHeaderInfo read;
+	O3DS_CHECK(ReadCaptureHeader(in, read));
+
+	O3DS_CHECK_EQ(read.flags, written.flags);
+	O3DS_CHECK_EQ(read.base_wallclock_us, written.base_wallclock_us);
+	O3DS_CHECK_EQ(read.schema_fingerprint, written.schema_fingerprint);
+	O3DS_CHECK_EQ(read.predictor_version, written.predictor_version);
+	O3DS_CHECK_EQ(read.source_desc, written.source_desc);
+}
+
+O3DS_TEST(Capture_HeaderRoundTrip_EmptySourceDesc)
+{
+	CaptureHeaderInfo written; // all defaults, empty source_desc
+	std::ostringstream out;
+	O3DS_CHECK(WriteCaptureHeader(out, written));
+
+	std::istringstream in(out.str());
+	CaptureHeaderInfo read;
+	O3DS_CHECK(ReadCaptureHeader(in, read));
+	O3DS_CHECK(read.source_desc.empty());
+	O3DS_CHECK_EQ(read.base_wallclock_us, (uint64_t)0);
+}
+
+O3DS_TEST(Capture_WriteNFramesReadBackIdentical)
+{
+	std::ostringstream out;
+	O3DS_CHECK(WriteCaptureHeader(out, CaptureHeaderInfo()));
+
+	const int kFrameCount = 25;
+	std::vector<CaptureRecord> written;
+	for (int i = 0; i < kFrameCount; i++)
+	{
+		CaptureRecord r;
+		r.recv_wallclock_us = 1000000ull + (uint64_t)i * 16667ull; // ~60fps spacing
+		r.wire_bytes = MakeWireBytes((char)('A' + (i % 26)), (size_t)(i * 3 + 1)); // varying, non-trivial size
+		O3DS_CHECK(WriteCaptureRecord(out, r));
+		written.push_back(r);
+	}
+
+	std::istringstream in(out.str());
+	CaptureHeaderInfo header;
+	O3DS_CHECK(ReadCaptureHeader(in, header));
+
+	int readCount = 0;
+	CaptureRecord r;
+	while (ReadCaptureRecord(in, r))
+	{
+		O3DS_CHECK(readCount < kFrameCount);
+		O3DS_CHECK_EQ(r.recv_wallclock_us, written[readCount].recv_wallclock_us);
+		O3DS_CHECK(r.wire_bytes == written[readCount].wire_bytes);
+		readCount++;
+	}
+
+	O3DS_CHECK_EQ(readCount, kFrameCount); // exactly all of them, no more, no fewer
+}
+
+O3DS_TEST(Capture_EmptyWireBytesRecord_RoundTrips)
+{
+	std::ostringstream out;
+	O3DS_CHECK(WriteCaptureHeader(out, CaptureHeaderInfo()));
+
+	CaptureRecord written;
+	written.recv_wallclock_us = 42;
+	written.wire_bytes.clear();
+	O3DS_CHECK(WriteCaptureRecord(out, written));
+
+	std::istringstream in(out.str());
+	CaptureHeaderInfo header;
+	O3DS_CHECK(ReadCaptureHeader(in, header));
+
+	CaptureRecord read;
+	O3DS_CHECK(ReadCaptureRecord(in, read));
+	O3DS_CHECK_EQ(read.recv_wallclock_us, (uint64_t)42);
+	O3DS_CHECK(read.wire_bytes.empty());
+
+	CaptureRecord none;
+	O3DS_CHECK(ReadCaptureRecord(in, none) == false); // exactly one record, then clean end
+}
+
+O3DS_TEST(Capture_RejectsBadMagic)
+{
+	std::ostringstream out;
+	out.write("NOTACAP\0", 8);
+	// Rest of a well-formed-looking header, so only magic is wrong.
+	std::string blob = out.str();
+	blob.resize(64, '\0');
+
+	std::istringstream in(blob);
+	CaptureHeaderInfo header;
+	O3DS_CHECK(ReadCaptureHeader(in, header) == false);
+}
+
+O3DS_TEST(Capture_RejectsUnknownFormatVersion)
+{
+	std::ostringstream out;
+	CaptureHeaderInfo info;
+	O3DS_CHECK(WriteCaptureHeader(out, info));
+	std::string blob = out.str();
+
+	// Overwrite the format_version field (offset 8, 2 bytes LE) with an
+	// unsupported value.
+	blob[8] = (char)0xFF;
+	blob[9] = (char)0xFF;
+
+	std::istringstream in(blob);
+	CaptureHeaderInfo header;
+	O3DS_CHECK(ReadCaptureHeader(in, header) == false);
+}
+
+O3DS_TEST(Capture_TruncatedHeader_RejectedAtEveryCutPoint)
+{
+	std::ostringstream out;
+	CaptureHeaderInfo info;
+	info.source_desc = "some source description";
+	O3DS_CHECK(WriteCaptureHeader(out, info));
+	std::string full = out.str();
+
+	// A well-formed header must never partially parse: truncating at ANY
+	// byte offset before the end must fail cleanly (no crash, ASan/UBSan
+	// clean), not succeed with garbage/partial data.
+	for (size_t cut = 0; cut < full.size(); cut++)
+	{
+		std::istringstream in(full.substr(0, cut));
+		CaptureHeaderInfo header;
+		bool ok = ReadCaptureHeader(in, header);
+		O3DS_CHECK(ok == false);
+	}
+}
+
+O3DS_TEST(Capture_TruncatedFinalRecord_StopsCleanlyNotError)
+{
+	// This is the core B1 guarantee: a capture cut mid-write (process
+	// killed, disk full, etc.) must yield everything successfully written
+	// before the cut, then stop without error - never crash, never throw.
+	std::ostringstream out;
+	O3DS_CHECK(WriteCaptureHeader(out, CaptureHeaderInfo()));
+
+	CaptureRecord complete;
+	complete.recv_wallclock_us = 100;
+	complete.wire_bytes = MakeWireBytes('X', 10);
+	O3DS_CHECK(WriteCaptureRecord(out, complete));
+
+	CaptureRecord truncated;
+	truncated.recv_wallclock_us = 200;
+	truncated.wire_bytes = MakeWireBytes('Y', 50);
+	O3DS_CHECK(WriteCaptureRecord(out, truncated));
+
+	std::string full = out.str();
+
+	// Cut off partway through the second record's wire_bytes.
+	std::string cutBlob = full.substr(0, full.size() - 20);
+
+	std::istringstream in(cutBlob);
+	CaptureHeaderInfo header;
+	O3DS_CHECK(ReadCaptureHeader(in, header));
+
+	CaptureRecord r1;
+	O3DS_CHECK(ReadCaptureRecord(in, r1));
+	O3DS_CHECK_EQ(r1.recv_wallclock_us, (uint64_t)100);
+	O3DS_CHECK(r1.wire_bytes == complete.wire_bytes);
+
+	CaptureRecord r2;
+	O3DS_CHECK(ReadCaptureRecord(in, r2) == false); // truncated - stop cleanly, no crash
+}
+
+O3DS_TEST(Capture_TruncatedRecordHeader_StopsCleanly)
+{
+	// Cut off mid-way through even the fixed 12-byte record header (before
+	// wire_len is fully readable).
+	std::ostringstream out;
+	O3DS_CHECK(WriteCaptureHeader(out, CaptureHeaderInfo()));
+	RawWriteU64LE(out, 999); // recv_wallclock_us, complete
+	// wire_len (4 bytes) cut short after 2.
+	out.put((char)0x01);
+	out.put((char)0x02);
+
+	std::istringstream in(out.str());
+	CaptureHeaderInfo header;
+	O3DS_CHECK(ReadCaptureHeader(in, header));
+
+	CaptureRecord r;
+	O3DS_CHECK(ReadCaptureRecord(in, r) == false);
+}
+
+O3DS_TEST(Capture_OversizedWireLen_RejectedWithoutHugeAllocation)
+{
+	// Hand-construct a record claiming a wire_len far beyond
+	// kCaptureMaxWireLen, with no actual payload bytes following. A correct
+	// reader must reject based on the length field alone, before attempting
+	// to allocate/read - if it tried to honor this, it would attempt a
+	// multi-gigabyte allocation for a payload that doesn't exist.
+	std::ostringstream out;
+	O3DS_CHECK(WriteCaptureHeader(out, CaptureHeaderInfo()));
+	RawWriteU64LE(out, 1); // recv_wallclock_us
+	RawWriteU32LE(out, 0xFFFFFFFFu); // wire_len: ~4GB, no data follows
+
+	std::istringstream in(out.str());
+	CaptureHeaderInfo header;
+	O3DS_CHECK(ReadCaptureHeader(in, header));
+
+	CaptureRecord r;
+	O3DS_CHECK(ReadCaptureRecord(in, r) == false);
+}
+
+O3DS_TEST(Capture_WriterRejectsOversizedRecord)
+{
+	CaptureRecord huge;
+	huge.wire_bytes.resize((size_t)kCaptureMaxWireLen + 1);
+
+	std::ostringstream out;
+	O3DS_CHECK(WriteCaptureRecord(out, huge) == false);
+}
+
+O3DS_TEST(Capture_ReaderTolerates_HeaderLenPadding)
+{
+	// A future/newer writer could add reserved padding between source_desc
+	// and header_len (e.g. for forward-compatible extension fields). A v1
+	// reader must skip straight to header_len, not assume records start
+	// immediately after source_desc.
+	std::ostringstream out;
+	CaptureHeaderInfo info;
+	info.source_desc = "x";
+	O3DS_CHECK(WriteCaptureHeader(out, info));
+	std::string blob = out.str();
+
+	// header_len is at offset 10 (2 bytes LE). Bump it by 8 to simulate 8
+	// bytes of reserved padding, and insert 8 zero bytes at that point.
+	uint16_t originalHeaderLen = (uint16_t)((unsigned char)blob[10] | ((unsigned char)blob[11] << 8));
+	uint16_t paddedHeaderLen = originalHeaderLen + 8;
+	blob[10] = (char)(paddedHeaderLen & 0xFF);
+	blob[11] = (char)((paddedHeaderLen >> 8) & 0xFF);
+	blob.insert(originalHeaderLen, 8, '\0');
+
+	CaptureRecord written;
+	written.recv_wallclock_us = 7;
+	written.wire_bytes = MakeWireBytes('Z', 3);
+	std::ostringstream recordStream;
+	O3DS_CHECK(WriteCaptureRecord(recordStream, written));
+	blob += recordStream.str();
+
+	std::istringstream in(blob);
+	CaptureHeaderInfo header;
+	O3DS_CHECK(ReadCaptureHeader(in, header));
+	O3DS_CHECK_EQ(header.source_desc, std::string("x"));
+
+	CaptureRecord read;
+	O3DS_CHECK(ReadCaptureRecord(in, read));
+	O3DS_CHECK_EQ(read.recv_wallclock_us, (uint64_t)7);
+	O3DS_CHECK(read.wire_bytes == written.wire_bytes);
+}
+
+O3DS_TEST(Capture_RealFileRoundTrip)
+{
+	// Stringstream-based tests above prove the encoding logic; this proves
+	// the actual file I/O path (open/write/flush/close/reopen/seek) works,
+	// and that binary payload bytes (including 0x0A, the byte a text-mode
+	// stream would be most likely to mangle) survive a real round trip.
+	std::filesystem::path path = std::filesystem::temp_directory_path() / "o3ds_capture_test.o3dscap";
+
+	CaptureRecord written;
+	written.recv_wallclock_us = 555;
+	written.wire_bytes = { (char)0x00, (char)0x0A, (char)0x0D, (char)0x0A, (char)0xFF, 'h', 'i' };
+
+	{
+		std::ofstream out(path, std::ios::binary | std::ios::trunc);
+		O3DS_CHECK(out.is_open());
+		CaptureHeaderInfo header;
+		header.source_desc = "real file test";
+		O3DS_CHECK(WriteCaptureHeader(out, header));
+		O3DS_CHECK(WriteCaptureRecord(out, written));
+	}
+
+	{
+		std::ifstream in(path, std::ios::binary);
+		O3DS_CHECK(in.is_open());
+
+		CaptureHeaderInfo header;
+		O3DS_CHECK(ReadCaptureHeader(in, header));
+		O3DS_CHECK_EQ(header.source_desc, std::string("real file test"));
+
+		CaptureRecord read;
+		O3DS_CHECK(ReadCaptureRecord(in, read));
+		O3DS_CHECK_EQ(read.recv_wallclock_us, (uint64_t)555);
+		O3DS_CHECK(read.wire_bytes == written.wire_bytes);
+
+		CaptureRecord none;
+		O3DS_CHECK(ReadCaptureRecord(in, none) == false);
+	}
+
+	std::filesystem::remove(path);
+}


### PR DESCRIPTION
## Summary
Implements roadmap phase B1 (docs/roadmap/resilient-streaming-and-motion-prediction.md §4, issue #218): an append-only, streamable, truncation-tolerant `.o3dscap` container for recording wire frames, plus the reader/writer. Entirely `src/o3ds/capture.h/.cpp`, no dependency on A1 (the container is agnostic to what's inside `wire_bytes`) — though captures are more useful now that A1's `tx_seq`/`tx_wallclock_us` exist to be captured.

### Format
v1, exactly per the roadmap's byte-level spec: 8-byte magic + `format_version` + `header_len` + `flags` + `base_wallclock_us` + `schema_fingerprint` + `predictor_version` + a length-prefixed `source_desc` string, then records of `[recv_wallclock_us][wire_len][wire_bytes]` repeated to EOF. All multi-byte fields are explicit little-endian — encoded/decoded by hand, never via raw `memcpy` of a multi-byte integer, so it's correct regardless of host byte order.

### API
Four free functions (`WriteCaptureHeader`/`WriteCaptureRecord`/`ReadCaptureHeader`/`ReadCaptureRecord`) on `std::istream&`/`std::ostream&`, not stateful wrapper classes — the stream already tracks position, wrapping it added nothing. One implementation works identically against `std::ifstream`/`ofstream` (real files — what B2's replay CLI and B3's repeater capture will use) and `std::istringstream`/`ostringstream` (fast, filesystem-free tests).

**Documented explicitly:** real file streams must be opened with `std::ios::binary`. A text-mode stream (still relevant on Windows) can silently rewrite `0x0A`/`0x0D` bytes in a captured payload with zero read/write failure — this is exactly the kind of gap that passes every in-memory test and only shows up on a real file on a specific platform, so I documented it prominently and wrote a real (non-stringstream) file test carrying those exact bytes to prove it round-trips.

### Hardening (consistent with the rest of the core library)
- `ReadCaptureRecord` rejects `wire_len > 64MB` **before** attempting to allocate — a corrupt/adversarial capture can claim any `wire_len` a `uint32` can hold.
- A truncated trailing record (capture cut mid-write) is a clean end, not an error — this is the spec's explicit truncation-tolerance requirement, not incidental defensive coding.
- `ReadCaptureHeader` always seeks to the declared `header_len` (not just past what it understood how to parse), so a future writer can add reserved padding/fields after `source_desc` without breaking a v1 reader.

## Verified, not just written
**37/37 tests pass under ASan/UBSan** (12 new), run against a fully clean from-scratch configure/build/`ctest`:
- Header and N-record round-trip, byte-identical
- **A truncation fuzz test** that rejects a well-formed header at *every single* possible byte-cut point (~59 offsets)
- Truncated final record → clean stop, not error (the core B1 guarantee)
- Oversized `wire_len` (hand-constructed, no real payload) → rejected without attempting the multi-GB allocation
- Bad magic / unsupported `format_version` → rejected
- Header-padding forward-compatibility (a hypothetical newer writer's reserved bytes are correctly skipped)
- **Real temp-file round-trip** with bytes chosen to be maximally CRLF-hostile

No dedicated Opus review for this one — per the model-tiering approach from A1, this is a straightforward binary format reader/writer, not a state machine with interacting concerns, so routine ASan/UBSan + exhaustive-truncation testing is the right level of scrutiny.

## Test plan
- [x] Full clean build + `ctest` (37/37, ASan/UBSan active)
- [x] Real file I/O path exercised, not just in-memory streams
- [ ] CI (checking now)

🤖 Generated as part of the June 2026 review follow-on planning.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LHHqoB2uhpd7k7wSdbE4H6)_