### PR TITLE
A2.b: clock-offset estimator for sender/receiver time mapping

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -107,6 +107,7 @@ set(pub_headers
 	o3ds/capture.h
 	o3ds/channel_model.h
 	o3ds/replay.h
+	o3ds/clock_offset.h
 	o3ds/model.h
 	o3ds/base_connector.h
 	o3ds/nng_connector.h
@@ -147,6 +148,7 @@ set(SOURCES
 	o3ds/capture.cpp
 	o3ds/channel_model.cpp
 	o3ds/replay.cpp
+	o3ds/clock_offset.cpp
 	o3ds/model.cpp
 	o3ds/base_connector.cpp
 	o3ds/nng_connector.cpp

--- a/src/o3ds/clock_offset.cpp
+++ b/src/o3ds/clock_offset.cpp
@@ -1,0 +1,118 @@
+/*
+Open 3D Stream
+
+Copyright 2026 Alastair Macleod
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#include "clock_offset.h"
+
+#include <algorithm>
+#include <cmath>
+
+namespace O3DS
+{
+	namespace
+	{
+		double ClampSlewRate(double rate)
+		{
+			if (!(rate > 0.0)) return 0.0;   // also catches NaN
+			if (rate >= 1.0) return 0.999999; // strictly < 1 preserves the monotonicity guarantee
+			return rate;
+		}
+
+		double ClampWindowSeconds(double s)
+		{
+			return (s > 0.0) ? s : 0.001;
+		}
+	}
+
+	ClockOffsetEstimator::ClockOffsetEstimator()
+		: ClockOffsetEstimator(Config())
+	{
+	}
+
+	ClockOffsetEstimator::ClockOffsetEstimator(const Config& config)
+		: mConfig(config)
+	{
+		mConfig.window_s = ClampWindowSeconds(mConfig.window_s);
+		mConfig.max_slew_rate = ClampSlewRate(mConfig.max_slew_rate);
+	}
+
+	ClockOffsetEstimator::Sample ClockOffsetEstimator::Observe(uint64_t tx_wallclock_us, uint64_t local_recv_us)
+	{
+		Sample result;
+
+		// Legacy/unset timestamp: fall back to local receive time and leave
+		// the estimator's state untouched (see class doc comment).
+		if (tx_wallclock_us == 0)
+		{
+			result.mapped_presentation_time_us = local_recv_us;
+			result.offset_estimate_us = 0;
+			result.excess_delay_us = 0;
+			return result;
+		}
+
+		const int64_t offset_us = (int64_t)local_recv_us - (int64_t)tx_wallclock_us;
+
+		// Sliding-window minimum: maintain a monotonic-increasing deque of
+		// offsets so the front is always the current window's minimum in
+		// O(1) amortized per sample.
+		while (!mWindow.empty() && mWindow.back().offset_us >= offset_us)
+			mWindow.pop_back();
+		mWindow.push_back({ tx_wallclock_us, offset_us });
+
+		const int64_t window_us = (int64_t)(mConfig.window_s * 1.0e6);
+		// Signed comparison: if tx_wallclock_us ever arrives out of the
+		// documented non-decreasing order, this simply skips eviction rather
+		// than wrapping around (which unsigned subtraction would do here).
+		while (!mWindow.empty() &&
+		       (int64_t)tx_wallclock_us - (int64_t)mWindow.front().tx_wallclock_us > window_us)
+			mWindow.pop_front();
+
+		const int64_t target_us = mWindow.front().offset_us;
+
+		if (!mInitialized)
+		{
+			mEstimateUs = (double)target_us;
+			mInitialized = true;
+		}
+		else
+		{
+			// dt_s bounds how far the estimate may move this call; a
+			// non-positive dt (out-of-order tx_wallclock_us) contributes no
+			// slew budget rather than a negative one.
+			double dt_s = 0.0;
+			if (tx_wallclock_us > mLastTxWallclockUs)
+				dt_s = (double)(tx_wallclock_us - mLastTxWallclockUs) / 1.0e6;
+
+			const double max_step = mConfig.max_slew_rate * dt_s * 1.0e6;
+			double delta = (double)target_us - mEstimateUs;
+			delta = std::max(-max_step, std::min(max_step, delta));
+			mEstimateUs += delta;
+		}
+		mLastTxWallclockUs = tx_wallclock_us;
+
+		result.offset_estimate_us = (int64_t)std::llround(mEstimateUs);
+		result.excess_delay_us = offset_us - target_us;
+		result.mapped_presentation_time_us = (uint64_t)((int64_t)tx_wallclock_us + result.offset_estimate_us);
+		return result;
+	}
+}

--- a/src/o3ds/clock_offset.h
+++ b/src/o3ds/clock_offset.h
@@ -1,0 +1,107 @@
+/*
+Open 3D Stream
+
+Copyright 2026 Alastair Macleod
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#ifndef OPEN3D_STREAM_CLOCK_OFFSET_H
+#define OPEN3D_STREAM_CLOCK_OFFSET_H
+
+#include <cstdint>
+#include <deque>
+
+namespace O3DS
+{
+	//! Maps a sender's tx_wallclock_us onto the receiver's local clock so a
+	//! presentation layer (LiveLink) can be driven consistently across the
+	//! network, without requiring the two machines' clocks to be NTP-synced
+	//! (see roadmap doc, section 2.5 / A2.b).
+	//!
+	//! For each observed frame, offset_i = local_recv_i - tx_wallclock_i =
+	//! skew + delay_i, where delay_i >= 0. The minimum offset over a bounded
+	//! window approximates `skew + min_delay` (the least-delayed frame is
+	//! closest to pure clock skew) - the classic NTP-style estimate. This
+	//! class tracks that rolling minimum, then *slews* the value it actually
+	//! hands back toward the rolling minimum at a bounded rate (rather than
+	//! snapping to it) so a discrete local-clock step (NTP adjustment) or a
+	//! sudden path-delay change doesn't show up as a presentation-time
+	//! discontinuity.
+	//!
+	//! Precondition: Observe() must be called with samples in non-decreasing
+	//! tx_wallclock_us order - i.e. fed from frames already delivered in
+	//! ascending tx_seq order (A1's ReorderGate does this before this
+	//! estimator ever sees a frame, per A2.a's wiring). This is what makes
+	//! the "mapped presentation time is monotonic" guarantee hold: as long as
+	//! Config::max_slew_rate < 1.0, the slewed offset can never fall faster
+	//! than tx_wallclock_us rises, so tx_wallclock_us + offset_estimate_us
+	//! never goes backward. Feeding it out-of-order samples doesn't corrupt
+	//! internal state (window pruning is safe either way), but the Sample
+	//! returned for that one out-of-order call may not honor monotonicity.
+	//!
+	//! tx_wallclock_us == 0 (legacy/unset, see SubjectList.tx_wallclock_us)
+	//! is treated as "no timestamp available": Observe() returns
+	//! local_recv_us as the mapped time and leaves all internal state
+	//! untouched, rather than feeding a huge phantom "offset" (now minus the
+	//! Unix epoch) into the window.
+	class ClockOffsetEstimator
+	{
+	public:
+		struct Config
+		{
+			double window_s = 5.0;        //!< rolling-min window width, in tx_wallclock_us time
+			double max_slew_rate = 0.2;   //!< max fraction of elapsed real time the used estimate
+			                               //!< may move toward the rolling-min target per second;
+			                               //!< clamped to [0, 1) to preserve the monotonicity guarantee
+		};
+
+		struct Sample
+		{
+			uint64_t mapped_presentation_time_us = 0; //!< tx_wallclock_us + slewed offset estimate
+			int64_t  offset_estimate_us = 0;          //!< current slewed offset (~ skew + min_delay)
+			int64_t  excess_delay_us = 0;              //!< this frame's offset above the rolling-min
+			                                            //!< floor (jitter indicator); always >= 0
+		};
+
+		ClockOffsetEstimator();
+		explicit ClockOffsetEstimator(const Config& config);
+
+		//! Observe one frame's send/receive timestamps (both UTC microseconds
+		//! since the Unix epoch) and return the mapped presentation time plus
+		//! diagnostics.
+		Sample Observe(uint64_t tx_wallclock_us, uint64_t local_recv_us);
+
+	private:
+		struct WindowEntry
+		{
+			uint64_t tx_wallclock_us;
+			int64_t offset_us;
+		};
+
+		Config mConfig;
+		bool mInitialized = false;
+		double mEstimateUs = 0.0; // kept as double for sub-microsecond slew precision
+		uint64_t mLastTxWallclockUs = 0;
+
+		std::deque<WindowEntry> mWindow; // monotonic increasing by offset_us; front = window minimum
+	};
+}
+
+#endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,6 +14,7 @@ add_executable(o3ds_core_tests
 	capture_tests.cpp
 	channel_model_tests.cpp
 	replay_tests.cpp
+	clock_offset_tests.cpp
 )
 
 target_link_libraries(o3ds_core_tests PRIVATE open3dstreamstatic)

--- a/test/clock_offset_tests.cpp
+++ b/test/clock_offset_tests.cpp
@@ -1,0 +1,176 @@
+// Acceptance matrix for src/o3ds/clock_offset.h, per the roadmap doc's A2.b
+// spec (docs/roadmap/resilient-streaming-and-motion-prediction.md, §3/A2.b).
+#include "test_framework.h"
+
+#include "o3ds/clock_offset.h"
+
+#include <cstdlib>
+#include <random>
+
+using namespace O3DS;
+
+namespace
+{
+	// Deterministic uniform draw in [0, 1), matching the convention already
+	// established in channel_model.cpp (avoids std::uniform_real_distribution,
+	// whose exact output is unspecified across standard library
+	// implementations).
+	double NextUniform01(std::mt19937_64& rng)
+	{
+		const double kTwoPow64 = 18446744073709551616.0;
+		return (double)rng() / kTwoPow64;
+	}
+}
+
+O3DS_TEST(ClockOffset_ConstantSkewNoJitter_ConvergesExactly)
+{
+	// tx_wallclock advances 16ms/frame (60fps-ish); local_recv = tx_wallclock
+	// + a fixed skew of 500ms and zero network jitter (delay_i == 0 for all
+	// frames). The rolling-min offset should converge to exactly that skew.
+	ClockOffsetEstimator est;
+	const int64_t kSkewUs = 500000;
+	uint64_t tx = 1000000000ull;
+
+	ClockOffsetEstimator::Sample last;
+	for (int i = 0; i < 200; i++)
+	{
+		uint64_t local_recv = (uint64_t)((int64_t)tx + kSkewUs);
+		last = est.Observe(tx, local_recv);
+		tx += 16000;
+	}
+
+	O3DS_CHECK_EQ(last.offset_estimate_us, kSkewUs);
+	O3DS_CHECK_EQ(last.excess_delay_us, (int64_t)0);
+}
+
+O3DS_TEST(ClockOffset_SkewPlusBoundedJitter_ConvergesToSkewPlusMinDelay)
+{
+	// offset_i = skew + delay_i, delay_i in [0, 20ms). The rolling minimum
+	// over a window long enough to see many samples should land at (or very
+	// near) skew + 0, since delay's infimum is 0 and enough samples are drawn
+	// to get arbitrarily close to it.
+	ClockOffsetEstimator::Config cfg;
+	cfg.window_s = 2.0;
+	ClockOffsetEstimator est(cfg);
+
+	const int64_t kSkewUs = -250000; // sender's clock ahead of the receiver's
+	const int64_t kMaxDelayUs = 20000;
+	uint64_t tx = 5000000000ull;
+	std::mt19937_64 rng(12345);
+
+	ClockOffsetEstimator::Sample last;
+	int64_t min_offset_seen = INT64_MAX;
+	for (int i = 0; i < 2000; i++)
+	{
+		int64_t delay = (int64_t)(NextUniform01(rng) * kMaxDelayUs);
+		int64_t offset = kSkewUs + delay;
+		min_offset_seen = std::min(min_offset_seen, offset);
+		uint64_t local_recv = (uint64_t)((int64_t)tx + offset);
+		last = est.Observe(tx, local_recv);
+		tx += 5000; // 5ms/frame, dense enough to fill the 2s window generously
+	}
+
+	// The estimator's target (rolling min) can never be below the true
+	// per-window minimum offset actually drawn, and by now (many samples,
+	// slew long since caught up) offset_estimate_us should sit close to it.
+	O3DS_CHECK(last.offset_estimate_us >= min_offset_seen - 1);
+	O3DS_CHECK(last.offset_estimate_us <= kSkewUs + 2000); // within 2ms of the true floor
+	O3DS_CHECK(last.excess_delay_us >= 0);
+}
+
+O3DS_TEST(ClockOffset_MappedPresentationTime_IsMonotonicUnderJitter)
+{
+	ClockOffsetEstimator::Config cfg;
+	cfg.window_s = 1.0;
+	cfg.max_slew_rate = 0.3;
+	ClockOffsetEstimator est(cfg);
+
+	uint64_t tx = 9000000000ull;
+	std::mt19937_64 rng(777);
+	uint64_t prevMapped = 0;
+	bool first = true;
+
+	for (int i = 0; i < 5000; i++)
+	{
+		int64_t delay = (int64_t)(NextUniform01(rng) * 30000); // up to 30ms jitter
+		uint64_t local_recv = tx + (uint64_t)delay;
+		auto s = est.Observe(tx, local_recv);
+
+		if (!first)
+			O3DS_CHECK(s.mapped_presentation_time_us >= prevMapped);
+		prevMapped = s.mapped_presentation_time_us;
+		first = false;
+
+		tx += 4000; // 4ms/frame
+	}
+}
+
+O3DS_TEST(ClockOffset_ClockStep_IsSlewedNotJumped)
+{
+	// Simulate a discrete local-clock step: after a long stretch of steady
+	// zero-jitter samples, local_recv suddenly jumps forward by 300ms for one
+	// step (as if NTP stepped the local clock), then continues steady at the
+	// new level. The *reported* estimate must not jump by anywhere near the
+	// full step in a single Observe() call - it should move gradually.
+	ClockOffsetEstimator::Config cfg;
+	cfg.window_s = 5.0;
+	cfg.max_slew_rate = 0.1; // slow, deliberately, so the step is easy to observe mid-slew
+	ClockOffsetEstimator est(cfg);
+
+	uint64_t tx = 20000000000ull;
+	const int64_t kSkewUs = 100000;
+
+	ClockOffsetEstimator::Sample beforeStep;
+	for (int i = 0; i < 50; i++)
+	{
+		beforeStep = est.Observe(tx, (uint64_t)((int64_t)tx + kSkewUs));
+		tx += 16000;
+	}
+	O3DS_CHECK_EQ(beforeStep.offset_estimate_us, kSkewUs);
+
+	// Step: local clock jumps forward 300ms for every subsequent sample.
+	const int64_t kStepUs = 300000;
+	tx += 16000;
+	auto justAfterStep = est.Observe(tx, (uint64_t)((int64_t)tx + kSkewUs + kStepUs));
+
+	// A single 16ms tick at max_slew_rate=0.1 bounds movement to ~1.6us -
+	// nowhere close to the 300ms step. Allow generous headroom (10ms) while
+	// still proving it did not jump to the new level immediately.
+	int64_t movedBy = justAfterStep.offset_estimate_us - beforeStep.offset_estimate_us;
+	O3DS_CHECK(movedBy >= 0);
+	O3DS_CHECK(movedBy < 10000);
+
+	// Given enough subsequent samples at the new steady level, the estimate
+	// must eventually converge there.
+	ClockOffsetEstimator::Sample last = justAfterStep;
+	for (int i = 0; i < 5000; i++)
+	{
+		tx += 16000;
+		last = est.Observe(tx, (uint64_t)((int64_t)tx + kSkewUs + kStepUs));
+	}
+	O3DS_CHECK_EQ(last.offset_estimate_us, kSkewUs + kStepUs);
+}
+
+O3DS_TEST(ClockOffset_LegacyZeroTimestamp_PassesThroughLocalRecvAndLeavesStateUntouched)
+{
+	ClockOffsetEstimator est;
+
+	// Establish real state first.
+	uint64_t tx = 42000000000ull;
+	auto warm = est.Observe(tx, tx + 1000);
+	O3DS_CHECK(warm.offset_estimate_us != 0);
+
+	// A legacy/unset frame must not poison the estimator: it should pass
+	// through local_recv_us untouched...
+	auto legacy = est.Observe(0, 999999999999ull);
+	O3DS_CHECK_EQ(legacy.mapped_presentation_time_us, (uint64_t)999999999999ull);
+	O3DS_CHECK_EQ(legacy.offset_estimate_us, (int64_t)0);
+	O3DS_CHECK_EQ(legacy.excess_delay_us, (int64_t)0);
+
+	// ...and the next real frame should behave exactly as if the legacy
+	// frame had never been observed (same offset as before, no discontinuity
+	// from a phantom huge sample).
+	tx += 16000;
+	auto after = est.Observe(tx, tx + 1000);
+	O3DS_CHECK_EQ(after.offset_estimate_us, warm.offset_estimate_us);
+}


### PR DESCRIPTION
## Summary

Implements the core, engine-agnostic piece of roadmap phase A2 (issue #217): `ClockOffsetEstimator` (`src/o3ds/clock_offset.h`/`.cpp`) maps a sender's `tx_wallclock_us` onto the receiver's local clock without requiring NTP-synced machines.

- Rolling-minimum offset estimate (`skew + min_delay`, the classic NTP-style approach) tracked via an O(1) sliding-window-minimum deque.
- The estimate actually handed back is **slewed** toward that rolling-min target rather than snapped to it, so a discrete local clock step (NTP adjustment) or a sudden path-delay change doesn't show up as a presentation-time discontinuity.
- Bounding `max_slew_rate < 1.0` guarantees the mapped presentation time (`tx_wallclock_us + offset_estimate`) stays monotonic as long as samples arrive in non-decreasing `tx_wallclock_us` order — the order A1's `ReorderGate` already guarantees, which is how A2.a will feed this.
- `tx_wallclock_us == 0` (legacy/unset) passes through local receive time and leaves internal estimator state untouched, so a stray legacy frame can't poison the window or neuter the slew-rate limiting for the next real sample.

## Test plan

- [x] 5 new CTest cases in `test/clock_offset_tests.cpp`: constant-skew convergence, skew+jitter convergence to `skew + min_delay`, monotonicity of mapped presentation time under jitter, slewed (not jumped) response to a simulated clock step, legacy-timestamp pass-through leaves state untouched.
- [x] Full core suite (58/58) passes under ASan/UBSan, built against the existing `core-tests.yml` Linux CI harness.

## Scope note

A2.a/A2.c/A2.d (wiring the `ReorderGate` + this estimator into `Open3DReceiver/O3DReceiverSource.cpp`, LiveLink `WorldTime` mapping, and HUD metrics) is a separate follow-on PR. That work restructures the receiver's live frame-processing path and needs the self-hosted UE runner to build/verify, whereas this piece is fully Linux-testable in isolation — same split rationale as A1/B1/B2.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LHHqoB2uhpd7k7wSdbE4H6)_