### PR TITLE
C0: predictor interface + classical baselines (Hold/Linear/Quadratic)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -108,6 +108,12 @@ set(pub_headers
 	o3ds/channel_model.h
 	o3ds/replay.h
 	o3ds/clock_offset.h
+	o3ds/predict/quat_math.h
+	o3ds/predict/pose_predictor.h
+	o3ds/predict/sample_ring.h
+	o3ds/predict/hold_predictor.h
+	o3ds/predict/linear_predictor.h
+	o3ds/predict/quadratic_predictor.h
 	o3ds/model.h
 	o3ds/base_connector.h
 	o3ds/nng_connector.h
@@ -149,6 +155,10 @@ set(SOURCES
 	o3ds/channel_model.cpp
 	o3ds/replay.cpp
 	o3ds/clock_offset.cpp
+	o3ds/predict/quat_math.cpp
+	o3ds/predict/hold_predictor.cpp
+	o3ds/predict/linear_predictor.cpp
+	o3ds/predict/quadratic_predictor.cpp
 	o3ds/model.cpp
 	o3ds/base_connector.cpp
 	o3ds/nng_connector.cpp

--- a/src/o3ds/predict/hold_predictor.cpp
+++ b/src/o3ds/predict/hold_predictor.cpp
@@ -1,0 +1,47 @@
+/*
+Open 3D Stream
+
+Copyright 2026 Alastair Macleod
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#include "hold_predictor.h"
+
+namespace O3DS
+{
+	void HoldPredictor::Observe(const PoseSample& sample)
+	{
+		mHistory.Push(sample);
+	}
+
+	bool HoldPredictor::Predict(double t, PoseSample& out) const
+	{
+		if (mHistory.Count() < 1) return false;
+
+		out = mHistory[0];
+		out.t = t;
+		return true;
+	}
+
+	void HoldPredictor::Reset()
+	{
+		mHistory.Clear();
+	}
+}

--- a/src/o3ds/predict/hold_predictor.h
+++ b/src/o3ds/predict/hold_predictor.h
@@ -1,0 +1,51 @@
+/*
+Open 3D Stream
+
+Copyright 2026 Alastair Macleod
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#ifndef O3DS_PREDICT_HOLD_PREDICTOR_H
+#define O3DS_PREDICT_HOLD_PREDICTOR_H
+
+#include "pose_predictor.h"
+#include "sample_ring.h"
+
+namespace O3DS
+{
+	//! Version 0. Predict() returns the last observed sample verbatim
+	//! (with t updated to the requested time) - today's "freeze on loss"
+	//! behavior, and the universal fallback every other predictor degrades
+	//! to when it lacks enough history. Needs 1 sample; Predict() returns
+	//! false before the first Observe().
+	class HoldPredictor : public IPosePredictor
+	{
+	public:
+		uint32_t Version() const override { return 0; }
+		void Observe(const PoseSample& sample) override;
+		bool Predict(double t, PoseSample& out) const override;
+		void Reset() override;
+
+	private:
+		SampleRing<1> mHistory;
+	};
+}
+
+#endif

--- a/src/o3ds/predict/linear_predictor.cpp
+++ b/src/o3ds/predict/linear_predictor.cpp
@@ -1,0 +1,128 @@
+/*
+Open 3D Stream
+
+Copyright 2026 Alastair Macleod
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#include "linear_predictor.h"
+
+#include <algorithm>
+
+namespace O3DS
+{
+	namespace
+	{
+		// Minimum dt (seconds) below which velocity is considered
+		// unreliable/degenerate; falls back to holding the newest sample
+		// rather than dividing by ~0.
+		constexpr double kMinDtSeconds = 1.0e-6;
+	}
+
+	void LinearPredictor::Observe(const PoseSample& sample)
+	{
+		mHistory.Push(sample);
+	}
+
+	bool LinearPredictor::Predict(double t, PoseSample& out) const
+	{
+		if (mHistory.Count() < 2) return false;
+
+		const PoseSample& s0 = mHistory[0];
+		const PoseSample& s1 = mHistory[1];
+
+		const double dt = s1.t - s0.t;
+		if (!(dt > kMinDtSeconds))
+		{
+			out = s1;
+			out.t = t;
+			return true;
+		}
+
+		const double factor = (t - s1.t) / dt;
+
+		out.t = t;
+		out.seq = s1.seq;
+
+		const size_t nTrans = std::min(s0.translations.size(), s1.translations.size());
+		out.translations.resize(nTrans);
+		for (size_t i = 0; i < nTrans; ++i)
+		{
+			for (int c = 0; c < 3; ++c)
+			{
+				const double v0 = s0.translations[i].v[c];
+				const double v1 = s1.translations[i].v[c];
+				out.translations[i].v[c] = v1 + (v1 - v0) * factor;
+			}
+		}
+
+		const size_t nScale = std::min(s0.scales.size(), s1.scales.size());
+		out.scales.resize(nScale);
+		for (size_t i = 0; i < nScale; ++i)
+		{
+			for (int c = 0; c < 3; ++c)
+			{
+				const double v0 = s0.scales[i].v[c];
+				const double v1 = s1.scales[i].v[c];
+				out.scales[i].v[c] = v1 + (v1 - v0) * factor;
+			}
+		}
+
+		const size_t nRot = std::min(s0.rotations.size(), s1.rotations.size());
+		out.rotations.resize(nRot);
+		for (size_t i = 0; i < nRot; ++i)
+		{
+			const Quat& q0 = s0.rotations[i];
+			const Quat& q1 = s1.rotations[i];
+
+			// Delta rotation such that dq * q0 == q1.
+			const Quat dq = QuatMultiply(q1, QuatConjugate(q0));
+
+			Vector3d axis;
+			double angle = 0.0;
+			if (QuatToAxisAngle(dq, axis, angle))
+			{
+				const Quat dqScaled = QuatFromAxisAngle(axis, angle * factor);
+				out.rotations[i] = QuatNormalize(QuatMultiply(dqScaled, q1));
+			}
+			else
+			{
+				// No meaningful rotation between samples - hold q1.
+				out.rotations[i] = q1;
+			}
+		}
+
+		const size_t nCurves = std::min(s0.curves.size(), s1.curves.size());
+		out.curves.resize(nCurves);
+		for (size_t i = 0; i < nCurves; ++i)
+		{
+			const float v0 = s0.curves[i];
+			const float v1 = s1.curves[i];
+			out.curves[i] = static_cast<float>(v1 + (v1 - v0) * factor);
+		}
+
+		return true;
+	}
+
+	void LinearPredictor::Reset()
+	{
+		mHistory.Clear();
+	}
+}

--- a/src/o3ds/predict/linear_predictor.cpp
+++ b/src/o3ds/predict/linear_predictor.cpp
@@ -61,6 +61,12 @@ namespace O3DS
 		out.t = t;
 		out.seq = s1.seq;
 
+		// PoseSample's channel counts are contractually stable within an
+		// epoch (see class doc comment on Reset()); std::min guards against
+		// a caller violating that contract (e.g. missing a Reset() on
+		// topology change) by truncating to the common count instead of
+		// reading out of bounds. A caller that hits this should treat it as
+		// a bug - it will not fail loudly here.
 		const size_t nTrans = std::min(s0.translations.size(), s1.translations.size());
 		out.translations.resize(nTrans);
 		for (size_t i = 0; i < nTrans; ++i)

--- a/src/o3ds/predict/linear_predictor.h
+++ b/src/o3ds/predict/linear_predictor.h
@@ -1,0 +1,52 @@
+/*
+Open 3D Stream
+
+Copyright 2026 Alastair Macleod
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#ifndef O3DS_PREDICT_LINEAR_PREDICTOR_H
+#define O3DS_PREDICT_LINEAR_PREDICTOR_H
+
+#include "pose_predictor.h"
+#include "sample_ring.h"
+
+namespace O3DS
+{
+	//! Version 1. Constant-velocity extrapolation from the two most recent
+	//! samples. Linear channels: x(t) = x1 + (x1-x0)/(t1-t0)*(t-t1).
+	//! Rotations: the angular velocity implied by q0->q1 is scaled to t and
+	//! applied to q1, then renormalized (roadmap doc §2.6). Needs 2 samples
+	//! with distinct timestamps; Predict() returns false otherwise (caller
+	//! should hold).
+	class LinearPredictor : public IPosePredictor
+	{
+	public:
+		uint32_t Version() const override { return 1; }
+		void Observe(const PoseSample& sample) override;
+		bool Predict(double t, PoseSample& out) const override;
+		void Reset() override;
+
+	private:
+		SampleRing<2> mHistory;
+	};
+}
+
+#endif

--- a/src/o3ds/predict/pose_predictor.h
+++ b/src/o3ds/predict/pose_predictor.h
@@ -1,0 +1,83 @@
+/*
+Open 3D Stream
+
+Copyright 2026 Alastair Macleod
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#ifndef O3DS_PREDICT_POSE_PREDICTOR_H
+#define O3DS_PREDICT_POSE_PREDICTOR_H
+
+#include <cstdint>
+#include <vector>
+
+#include "quat_math.h"
+
+namespace O3DS
+{
+	//! A flat, topology-stable snapshot of one subject's animatable values.
+	//! Channel counts/order are fixed for a subject "epoch" (until a
+	//! keyframe changes topology, at which point the caller must Reset()
+	//! the predictor); this keeps the predictor pure-math and decoupled
+	//! from the FlatBuffers/Subject types, so it unit-tests without the
+	//! model layer (roadmap doc, §5/C0). The caller owns the PoseSample <->
+	//! O3DS::Subject mapping.
+	struct PoseSample
+	{
+		double   t   = 0.0;   //!< sample time, seconds, in the SENDER clock domain
+		uint64_t seq = 0;     //!< tx_seq of the source frame (0 = unset)
+		std::vector<Vector3d> translations; //!< per node
+		std::vector<Quat>     rotations;    //!< per node (unit quaternion)
+		std::vector<Vector3d> scales;       //!< per node
+		std::vector<float>    curves;       //!< per curve
+	};
+
+	//! Pluggable pose predictor: feed confirmed frames via Observe(), ask
+	//! for a pose at an arbitrary time via Predict(). Implementations are
+	//! pure-math and allocation-light after warm-up (see each
+	//! implementation's own doc comment for its required history depth).
+	class IPosePredictor
+	{
+	public:
+		virtual ~IPosePredictor() = default;
+
+		//! A version tag carried in-stream for residual mode (C2) so a
+		//! receiver can detect a predictor mismatch and Reset(). Baselines:
+		//! HoldPredictor = 0, LinearPredictor = 1, QuadraticPredictor = 2.
+		virtual uint32_t Version() const = 0;
+
+		//! Feed one confirmed (real, applied) frame. Samples must arrive in
+		//! non-decreasing `t` order - implementations may assume this
+		//! rather than re-sorting.
+		virtual void Observe(const PoseSample& sample) = 0;
+
+		//! Predict the pose at time t. Returns false (out left untouched)
+		//! if there isn't enough history yet - the caller should hold the
+		//! last applied pose in that case, not treat false as an error.
+		virtual bool Predict(double t, PoseSample& out) const = 0;
+
+		//! Clears all history: call on keyframe/topology change, a version
+		//! mismatch, or a large sequence gap (ties to A1's restart
+		//! detection). The next Observe() starts a fresh history window.
+		virtual void Reset() = 0;
+	};
+}
+
+#endif

--- a/src/o3ds/predict/quadratic_predictor.cpp
+++ b/src/o3ds/predict/quadratic_predictor.cpp
@@ -71,6 +71,12 @@ namespace O3DS
 		out.t = t;
 		out.seq = s2.seq;
 
+		// PoseSample's channel counts are contractually stable within an
+		// epoch (see class doc comment on Reset()); std::min guards against
+		// a caller violating that contract (e.g. missing a Reset() on
+		// topology change) by truncating to the common count instead of
+		// reading out of bounds. A caller that hits this should treat it as
+		// a bug - it will not fail loudly here.
 		const size_t nTrans = std::min({ s0.translations.size(), s1.translations.size(), s2.translations.size() });
 		out.translations.resize(nTrans);
 		for (size_t i = 0; i < nTrans; ++i)

--- a/src/o3ds/predict/quadratic_predictor.cpp
+++ b/src/o3ds/predict/quadratic_predictor.cpp
@@ -1,0 +1,157 @@
+/*
+Open 3D Stream
+
+Copyright 2026 Alastair Macleod
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#include "quadratic_predictor.h"
+
+#include <algorithm>
+
+namespace O3DS
+{
+	namespace
+	{
+		constexpr double kMinDtSeconds = 1.0e-6;
+
+		// Newton divided-difference quadratic extrapolation through
+		// (t0,x0), (t1,x1), (t2,x2), evaluated at t. Correct for unevenly
+		// spaced samples (unlike assuming a fixed frame interval).
+		double QuadraticExtrapolate(double t0, double x0, double t1, double x1, double t2, double x2, double t)
+		{
+			const double d01 = (x1 - x0) / (t1 - t0);
+			const double d12 = (x2 - x1) / (t2 - t1);
+			const double d012 = (d12 - d01) / (t2 - t0);
+			return x0 + d01 * (t - t0) + d012 * (t - t0) * (t - t1);
+		}
+	}
+
+	void QuadraticPredictor::Observe(const PoseSample& sample)
+	{
+		mHistory.Push(sample);
+	}
+
+	bool QuadraticPredictor::Predict(double t, PoseSample& out) const
+	{
+		if (mHistory.Count() < 3) return false;
+
+		const PoseSample& s0 = mHistory[0];
+		const PoseSample& s1 = mHistory[1];
+		const PoseSample& s2 = mHistory[2];
+
+		const double dtA = s1.t - s0.t;
+		const double dtB = s2.t - s1.t;
+
+		if (!(dtA > kMinDtSeconds) || !(dtB > kMinDtSeconds))
+		{
+			// Degenerate spacing: fall back to holding the newest sample.
+			out = s2;
+			out.t = t;
+			return true;
+		}
+
+		out.t = t;
+		out.seq = s2.seq;
+
+		const size_t nTrans = std::min({ s0.translations.size(), s1.translations.size(), s2.translations.size() });
+		out.translations.resize(nTrans);
+		for (size_t i = 0; i < nTrans; ++i)
+		{
+			for (int c = 0; c < 3; ++c)
+			{
+				out.translations[i].v[c] = QuadraticExtrapolate(
+					s0.t, s0.translations[i].v[c],
+					s1.t, s1.translations[i].v[c],
+					s2.t, s2.translations[i].v[c], t);
+			}
+		}
+
+		const size_t nScale = std::min({ s0.scales.size(), s1.scales.size(), s2.scales.size() });
+		out.scales.resize(nScale);
+		for (size_t i = 0; i < nScale; ++i)
+		{
+			for (int c = 0; c < 3; ++c)
+			{
+				out.scales[i].v[c] = QuadraticExtrapolate(
+					s0.t, s0.scales[i].v[c],
+					s1.t, s1.scales[i].v[c],
+					s2.t, s2.scales[i].v[c], t);
+			}
+		}
+
+		const size_t nCurves = std::min({ s0.curves.size(), s1.curves.size(), s2.curves.size() });
+		out.curves.resize(nCurves);
+		for (size_t i = 0; i < nCurves; ++i)
+		{
+			out.curves[i] = static_cast<float>(QuadraticExtrapolate(
+				s0.t, s0.curves[i], s1.t, s1.curves[i], s2.t, s2.curves[i], t));
+		}
+
+		const size_t nRot = std::min({ s0.rotations.size(), s1.rotations.size(), s2.rotations.size() });
+		out.rotations.resize(nRot);
+		for (size_t i = 0; i < nRot; ++i)
+		{
+			const Quat& q0 = s0.rotations[i];
+			const Quat& q1 = s1.rotations[i];
+			const Quat& q2 = s2.rotations[i];
+
+			const Quat dqA = QuatMultiply(q1, QuatConjugate(q0)); // rotation from q0 to q1
+			const Quat dqB = QuatMultiply(q2, QuatConjugate(q1)); // rotation from q1 to q2
+
+			Vector3d axisA, axisB;
+			double angleA = 0.0, angleB = 0.0;
+			const bool hasA = QuatToAxisAngle(dqA, axisA, angleA);
+			const bool hasB = QuatToAxisAngle(dqB, axisB, angleB);
+
+			if (!hasB)
+			{
+				// No meaningful recent rotation - hold q2.
+				out.rotations[i] = q2;
+				continue;
+			}
+
+			const double omega2 = angleB / dtB; // angular speed between s1,s2, about axisB
+
+			double alpha = 0.0;
+			if (hasA)
+			{
+				// Only the *magnitude* of the older delta's angular speed
+				// feeds the acceleration estimate - see class doc comment
+				// on why axisA's direction isn't used.
+				const double omega1 = angleA / dtA;
+				alpha = (omega2 - omega1) / ((s2.t - s0.t) * 0.5);
+			}
+
+			const double dtExtrap = t - s2.t;
+			const double thetaExtrap = omega2 * dtExtrap + 0.5 * alpha * dtExtrap * dtExtrap;
+
+			const Quat dqExtrap = QuatFromAxisAngle(axisB, thetaExtrap);
+			out.rotations[i] = QuatNormalize(QuatMultiply(dqExtrap, q2));
+		}
+
+		return true;
+	}
+
+	void QuadraticPredictor::Reset()
+	{
+		mHistory.Clear();
+	}
+}

--- a/src/o3ds/predict/quadratic_predictor.cpp
+++ b/src/o3ds/predict/quadratic_predictor.cpp
@@ -128,7 +128,7 @@ namespace O3DS
 				continue;
 			}
 
-			const double omega2 = angleB / dtB; // angular speed between s1,s2, about axisB
+			const double omega2 = angleB / dtB; // mean angular speed over [t1,t2], about axisB
 
 			double alpha = 0.0;
 			if (hasA)
@@ -140,8 +140,14 @@ namespace O3DS
 				alpha = (omega2 - omega1) / ((s2.t - s0.t) * 0.5);
 			}
 
+			// omega2 is the mean speed over [t1,t2], i.e. the instantaneous
+			// speed at the interval midpoint (t1 + dtB/2), not at t2. Advance
+			// it by half the interval under the constant-alpha model to get
+			// the instantaneous speed at t2 before extrapolating further.
+			const double omegaAtT2 = omega2 + alpha * (dtB * 0.5);
+
 			const double dtExtrap = t - s2.t;
-			const double thetaExtrap = omega2 * dtExtrap + 0.5 * alpha * dtExtrap * dtExtrap;
+			const double thetaExtrap = omegaAtT2 * dtExtrap + 0.5 * alpha * dtExtrap * dtExtrap;
 
 			const Quat dqExtrap = QuatFromAxisAngle(axisB, thetaExtrap);
 			out.rotations[i] = QuatNormalize(QuatMultiply(dqExtrap, q2));

--- a/src/o3ds/predict/quadratic_predictor.h
+++ b/src/o3ds/predict/quadratic_predictor.h
@@ -42,6 +42,12 @@ namespace O3DS
 	//! direction) to the acceleration estimate. This is an approximation -
 	//! a fully general constant-angular-acceleration model in SO(3) is
 	//! materially more complex and not needed for a classical baseline.
+	//! A consequence: a rotation that reverses sense between the older and
+	//! newer delta is read as decelerating (magnitude only), not reversing
+	//! direction, and on long horizons the extrapolated angle can cross
+	//! zero and continue backward along the newer delta's axis rather than
+	//! actually reversing to a new axis - another reason callers must bound
+	//! the prediction horizon.
 	//!
 	//! Needs 3 samples with distinct timestamps; Predict() returns false
 	//! otherwise (caller should hold).

--- a/src/o3ds/predict/quadratic_predictor.h
+++ b/src/o3ds/predict/quadratic_predictor.h
@@ -1,0 +1,61 @@
+/*
+Open 3D Stream
+
+Copyright 2026 Alastair Macleod
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#ifndef O3DS_PREDICT_QUADRATIC_PREDICTOR_H
+#define O3DS_PREDICT_QUADRATIC_PREDICTOR_H
+
+#include "pose_predictor.h"
+#include "sample_ring.h"
+
+namespace O3DS
+{
+	//! Version 2. Constant-acceleration extrapolation from the three most
+	//! recent samples for linear/scalar channels (translations, scales,
+	//! curves), via Newton divided differences - correct for unevenly
+	//! spaced samples. More responsive than LinearPredictor but overshoots
+	//! on longer horizons; callers should bound the prediction horizon.
+	//!
+	//! Rotations use a simplified constant-angular-acceleration model about
+	//! the most recent delta rotation's axis (from the newest two
+	//! samples); the older delta only contributes its angular *speed* (not
+	//! direction) to the acceleration estimate. This is an approximation -
+	//! a fully general constant-angular-acceleration model in SO(3) is
+	//! materially more complex and not needed for a classical baseline.
+	//!
+	//! Needs 3 samples with distinct timestamps; Predict() returns false
+	//! otherwise (caller should hold).
+	class QuadraticPredictor : public IPosePredictor
+	{
+	public:
+		uint32_t Version() const override { return 2; }
+		void Observe(const PoseSample& sample) override;
+		bool Predict(double t, PoseSample& out) const override;
+		void Reset() override;
+
+	private:
+		SampleRing<3> mHistory;
+	};
+}
+
+#endif

--- a/src/o3ds/predict/quat_math.cpp
+++ b/src/o3ds/predict/quat_math.cpp
@@ -1,0 +1,97 @@
+/*
+Open 3D Stream
+
+Copyright 2026 Alastair Macleod
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#include "quat_math.h"
+
+#include <algorithm>
+#include <cmath>
+
+namespace O3DS
+{
+	Quat QuatMultiply(const Quat& a, const Quat& b)
+	{
+		const double ax = a.v[0], ay = a.v[1], az = a.v[2], aw = a.v[3];
+		const double bx = b.v[0], by = b.v[1], bz = b.v[2], bw = b.v[3];
+
+		return Quat(
+			aw * bx + ax * bw + ay * bz - az * by,
+			aw * by - ax * bz + ay * bw + az * bx,
+			aw * bz + ax * by - ay * bx + az * bw,
+			aw * bw - ax * bx - ay * by - az * bz);
+	}
+
+	Quat QuatConjugate(const Quat& q)
+	{
+		return Quat(-q.v[0], -q.v[1], -q.v[2], q.v[3]);
+	}
+
+	Quat QuatNormalize(const Quat& q)
+	{
+		const double lenSq = q.v[0] * q.v[0] + q.v[1] * q.v[1] + q.v[2] * q.v[2] + q.v[3] * q.v[3];
+		if (lenSq < 1.0e-18) return QuatIdentity();
+
+		const double invLen = 1.0 / std::sqrt(lenSq);
+		return Quat(q.v[0] * invLen, q.v[1] * invLen, q.v[2] * invLen, q.v[3] * invLen);
+	}
+
+	bool QuatToAxisAngle(const Quat& q, Vector3d& outAxis, double& outAngleRad)
+	{
+		// Pick the representative (q or -q, same rotation) with w >= 0 so
+		// the recovered angle is always the shortest-path magnitude in
+		// [0, pi], not "the long way around".
+		Quat qn = q;
+		if (qn.v[3] < 0.0)
+		{
+			qn = Quat(-qn.v[0], -qn.v[1], -qn.v[2], -qn.v[3]);
+		}
+
+		double w = qn.v[3];
+		w = std::max(-1.0, std::min(1.0, w));
+
+		const double angle = 2.0 * std::acos(w);
+		const double s = std::sqrt(std::max(0.0, 1.0 - w * w)); // sin(angle/2)
+
+		if (s < 1.0e-9)
+		{
+			// Near-identity rotation: axis is undefined.
+			return false;
+		}
+
+		outAxis = Vector3d(qn.v[0] / s, qn.v[1] / s, qn.v[2] / s);
+		outAngleRad = angle;
+		return true;
+	}
+
+	Quat QuatFromAxisAngle(const Vector3d& axis, double angleRad)
+	{
+		const double lenSq = axis.v[0] * axis.v[0] + axis.v[1] * axis.v[1] + axis.v[2] * axis.v[2];
+		if (lenSq < 1.0e-18) return QuatIdentity();
+
+		const double invLen = 1.0 / std::sqrt(lenSq);
+		const double half = angleRad * 0.5;
+		const double s = std::sin(half);
+
+		return Quat(axis.v[0] * invLen * s, axis.v[1] * invLen * s, axis.v[2] * invLen * s, std::cos(half));
+	}
+}

--- a/src/o3ds/predict/quat_math.h
+++ b/src/o3ds/predict/quat_math.h
@@ -1,0 +1,63 @@
+/*
+Open 3D Stream
+
+Copyright 2026 Alastair Macleod
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#ifndef O3DS_PREDICT_QUAT_MATH_H
+#define O3DS_PREDICT_QUAT_MATH_H
+
+#include "../math.h"
+
+namespace O3DS
+{
+	//! x,y,z,w unit-quaternion convention, matching Vector4d's existing use
+	//! for rotations elsewhere in this codebase (see Transform::rotation).
+	using Quat = Vector4d;
+
+	inline Quat QuatIdentity() { return Quat(0.0, 0.0, 0.0, 1.0); }
+
+	//! Hamilton product: applying (a*b) to a vector is equivalent to
+	//! applying b first, then a.
+	Quat QuatMultiply(const Quat& a, const Quat& b);
+
+	//! (x,y,z,w) -> (-x,-y,-z,w); the inverse of a unit quaternion.
+	Quat QuatConjugate(const Quat& q);
+
+	//! Returns q / |q|; falls back to the identity quaternion if |q| is
+	//! degenerate (near zero) rather than dividing by ~0.
+	Quat QuatNormalize(const Quat& q);
+
+	//! Decomposes a unit quaternion into an axis (unit vector) and angle
+	//! (radians, [0, pi] - always the shortest-path magnitude, since q and
+	//! -q represent the same rotation and this picks whichever has w >= 0
+	//! before decomposing). Returns false (axis/angle left untouched) if q
+	//! is within epsilon of the identity - there's no well-defined axis for
+	//! a near-zero rotation.
+	bool QuatToAxisAngle(const Quat& q, Vector3d& outAxis, double& outAngleRad);
+
+	//! Builds a unit quaternion representing a rotation of angleRad radians
+	//! about axis (which need not be pre-normalized). Returns the identity
+	//! quaternion if axis is near-zero-length.
+	Quat QuatFromAxisAngle(const Vector3d& axis, double angleRad);
+}
+
+#endif

--- a/src/o3ds/predict/sample_ring.h
+++ b/src/o3ds/predict/sample_ring.h
@@ -43,6 +43,8 @@ namespace O3DS
 	template <size_t N>
 	class SampleRing
 	{
+		static_assert(N > 0, "SampleRing requires N > 0");
+
 	public:
 		void Push(const PoseSample& sample)
 		{

--- a/src/o3ds/predict/sample_ring.h
+++ b/src/o3ds/predict/sample_ring.h
@@ -1,0 +1,76 @@
+/*
+Open 3D Stream
+
+Copyright 2026 Alastair Macleod
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#ifndef O3DS_PREDICT_SAMPLE_RING_H
+#define O3DS_PREDICT_SAMPLE_RING_H
+
+#include <array>
+#include <cstddef>
+
+#include "pose_predictor.h"
+
+namespace O3DS
+{
+	//! Fixed-capacity ring of the N most-recently Observe()'d samples,
+	//! oldest-to-newest ordered access via operator[]. All N slots are
+	//! preallocated up front, so steady-state Push() calls overwrite
+	//! existing PoseSample storage via assignment - typical std::vector
+	//! implementations reuse each member vector's already-allocated
+	//! capacity when the new sample's channel counts match rather than
+	//! reallocating, keeping this allocation-light after warm-up per the
+	//! roadmap's C0 requirement.
+	template <size_t N>
+	class SampleRing
+	{
+	public:
+		void Push(const PoseSample& sample)
+		{
+			mSlots[mNext] = sample;
+			mNext = (mNext + 1) % N;
+			if (mCount < N) ++mCount;
+		}
+
+		void Clear()
+		{
+			mCount = 0;
+			mNext = 0;
+		}
+
+		size_t Count() const { return mCount; }
+
+		//! index 0 = oldest retained sample, Count()-1 = newest.
+		const PoseSample& operator[](size_t index) const
+		{
+			const size_t start = (mNext + N - mCount) % N;
+			return mSlots[(start + index) % N];
+		}
+
+	private:
+		std::array<PoseSample, N> mSlots;
+		size_t mNext = 0;
+		size_t mCount = 0;
+	};
+}
+
+#endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -15,6 +15,7 @@ add_executable(o3ds_core_tests
 	channel_model_tests.cpp
 	replay_tests.cpp
 	clock_offset_tests.cpp
+	pose_predictor_tests.cpp
 )
 
 target_link_libraries(o3ds_core_tests PRIVATE open3dstreamstatic)

--- a/test/pose_predictor_tests.cpp
+++ b/test/pose_predictor_tests.cpp
@@ -1,0 +1,337 @@
+// Acceptance matrix for src/o3ds/predict/*, per the roadmap doc's C0 spec
+// (docs/roadmap/resilient-streaming-and-motion-prediction.md, §5/C0).
+#include "test_framework.h"
+
+#include "o3ds/predict/quat_math.h"
+#include "o3ds/predict/hold_predictor.h"
+#include "o3ds/predict/linear_predictor.h"
+#include "o3ds/predict/quadratic_predictor.h"
+#include "o3ds/predict/sample_ring.h"
+
+#include <cmath>
+
+using namespace O3DS;
+
+namespace
+{
+	constexpr double kPi = 3.14159265358979323846;
+
+	double QuatDot(const Quat& a, const Quat& b)
+	{
+		return a.v[0] * b.v[0] + a.v[1] * b.v[1] + a.v[2] * b.v[2] + a.v[3] * b.v[3];
+	}
+
+	// |1 - |q|^2| tolerance check that q is (numerically) a unit quaternion.
+	bool IsUnitNorm(const Quat& q, double tol = 1.0e-9)
+	{
+		const double lenSq = q.v[0] * q.v[0] + q.v[1] * q.v[1] + q.v[2] * q.v[2] + q.v[3] * q.v[3];
+		return std::abs(lenSq - 1.0) < tol;
+	}
+
+	// Quaternions q and -q represent the same rotation; compare via |dot|.
+	bool QuatsNearlyEqual(const Quat& a, const Quat& b, double tol = 1.0e-6)
+	{
+		return std::abs(std::abs(QuatDot(a, b)) - 1.0) < tol;
+	}
+
+	PoseSample MakeSample(double t, uint64_t seq, double x, double y, double z, const Quat& rot, float curve)
+	{
+		PoseSample s;
+		s.t = t;
+		s.seq = seq;
+		s.translations.push_back(Vector3d(x, y, z));
+		s.rotations.push_back(rot);
+		s.scales.push_back(Vector3d(1.0, 1.0, 1.0));
+		s.curves.push_back(curve);
+		return s;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// quat_math
+// ---------------------------------------------------------------------------
+
+O3DS_TEST(QuatMath_Multiply_WithIdentity_ReturnsOperand)
+{
+	Quat q = QuatFromAxisAngle(Vector3d(0.0, 1.0, 0.0), kPi / 3.0);
+	Quat r1 = QuatMultiply(QuatIdentity(), q);
+	Quat r2 = QuatMultiply(q, QuatIdentity());
+
+	O3DS_CHECK(QuatsNearlyEqual(r1, q));
+	O3DS_CHECK(QuatsNearlyEqual(r2, q));
+}
+
+O3DS_TEST(QuatMath_ConjugateOfUnitQuat_IsItsInverse)
+{
+	Quat q = QuatFromAxisAngle(Vector3d(1.0, 2.0, 3.0), 1.234);
+	Quat inv = QuatConjugate(q);
+	Quat product = QuatMultiply(q, inv);
+
+	O3DS_CHECK(QuatsNearlyEqual(product, QuatIdentity()));
+}
+
+O3DS_TEST(QuatMath_AxisAngleRoundTrip_RecoversRotation)
+{
+	Vector3d axis(0.267261, 0.534522, 0.801784); // normalized (1,2,3)
+	double angle = 0.789;
+
+	Quat q = QuatFromAxisAngle(axis, angle);
+	O3DS_CHECK(IsUnitNorm(q));
+
+	Vector3d outAxis;
+	double outAngle = 0.0;
+	O3DS_CHECK(QuatToAxisAngle(q, outAxis, outAngle));
+
+	Quat rebuilt = QuatFromAxisAngle(outAxis, outAngle);
+	O3DS_CHECK(QuatsNearlyEqual(q, rebuilt));
+}
+
+O3DS_TEST(QuatMath_ToAxisAngle_NearIdentity_ReturnsFalse)
+{
+	Vector3d axis;
+	double angle = 0.0;
+	O3DS_CHECK(!QuatToAxisAngle(QuatIdentity(), axis, angle));
+}
+
+O3DS_TEST(QuatMath_Normalize_ScaledQuat_RecoversUnitNorm)
+{
+	Quat q(2.0, 0.0, 0.0, 2.0); // unnormalized, direction (1,0,0,1)
+	Quat n = QuatNormalize(q);
+	O3DS_CHECK(IsUnitNorm(n));
+}
+
+// ---------------------------------------------------------------------------
+// SampleRing
+// ---------------------------------------------------------------------------
+
+O3DS_TEST(SampleRing_PushBeyondCapacity_KeepsNewestNInOrder)
+{
+	SampleRing<3> ring;
+	for (int i = 0; i < 5; ++i)
+	{
+		ring.Push(MakeSample((double)i, (uint64_t)i, (double)i, 0, 0, QuatIdentity(), 0.0f));
+	}
+
+	O3DS_CHECK_EQ(ring.Count(), (size_t)3);
+	O3DS_CHECK_EQ(ring[0].seq, (uint64_t)2);
+	O3DS_CHECK_EQ(ring[1].seq, (uint64_t)3);
+	O3DS_CHECK_EQ(ring[2].seq, (uint64_t)4);
+}
+
+O3DS_TEST(SampleRing_Clear_ResetsCount)
+{
+	SampleRing<2> ring;
+	ring.Push(MakeSample(0.0, 1, 0, 0, 0, QuatIdentity(), 0.0f));
+	ring.Clear();
+	O3DS_CHECK_EQ(ring.Count(), (size_t)0);
+}
+
+// ---------------------------------------------------------------------------
+// HoldPredictor
+// ---------------------------------------------------------------------------
+
+O3DS_TEST(HoldPredictor_NoObservations_PredictReturnsFalse)
+{
+	HoldPredictor pred;
+	PoseSample out;
+	O3DS_CHECK(!pred.Predict(1.0, out));
+}
+
+O3DS_TEST(HoldPredictor_OneObservation_HoldsLastValueAtRequestedTime)
+{
+	HoldPredictor pred;
+	pred.Observe(MakeSample(0.0, 5, 10.0, 20.0, 30.0, QuatIdentity(), 0.5f));
+
+	PoseSample out;
+	O3DS_CHECK(pred.Predict(2.5, out));
+	O3DS_CHECK_EQ(out.t, 2.5);
+	O3DS_CHECK_EQ(out.translations[0].v[0], 10.0);
+	O3DS_CHECK_EQ(out.curves[0], 0.5f);
+}
+
+O3DS_TEST(HoldPredictor_Reset_ClearsHistory)
+{
+	HoldPredictor pred;
+	pred.Observe(MakeSample(0.0, 1, 1, 1, 1, QuatIdentity(), 0.0f));
+	pred.Reset();
+
+	PoseSample out;
+	O3DS_CHECK(!pred.Predict(1.0, out));
+}
+
+// ---------------------------------------------------------------------------
+// LinearPredictor
+// ---------------------------------------------------------------------------
+
+O3DS_TEST(LinearPredictor_InsufficientHistory_ReturnsFalse)
+{
+	LinearPredictor pred;
+	PoseSample out;
+	O3DS_CHECK(!pred.Predict(1.0, out));
+
+	pred.Observe(MakeSample(0.0, 1, 0, 0, 0, QuatIdentity(), 0.0f));
+	O3DS_CHECK(!pred.Predict(1.0, out)); // only 1 sample so far
+}
+
+O3DS_TEST(LinearPredictor_ConstantVelocityTranslation_PredictsExactly)
+{
+	// x(t) = 5 + 2*t
+	LinearPredictor pred;
+	pred.Observe(MakeSample(0.0, 1, 5.0, 0.0, 0.0, QuatIdentity(), 0.0f));
+	pred.Observe(MakeSample(1.0, 2, 7.0, 0.0, 0.0, QuatIdentity(), 0.0f));
+
+	PoseSample out;
+	O3DS_CHECK(pred.Predict(2.0, out));
+	O3DS_CHECK(std::abs(out.translations[0].v[0] - 9.0) < 1.0e-9);
+}
+
+O3DS_TEST(LinearPredictor_ConstantAngularVelocity_PredictsExactlyAndStaysUnitNorm)
+{
+	// Constant rotation about Z at 0.4 rad per unit time.
+	Vector3d axisZ(0.0, 0.0, 1.0);
+	Quat q0 = QuatFromAxisAngle(axisZ, 0.0);
+	Quat q1 = QuatFromAxisAngle(axisZ, 0.4);
+	Quat qExpectedAt2 = QuatFromAxisAngle(axisZ, 0.8);
+
+	LinearPredictor pred;
+	pred.Observe(MakeSample(0.0, 1, 0, 0, 0, q0, 0.0f));
+	pred.Observe(MakeSample(1.0, 2, 0, 0, 0, q1, 0.0f));
+
+	PoseSample out;
+	O3DS_CHECK(pred.Predict(2.0, out));
+	O3DS_CHECK(IsUnitNorm(out.rotations[0]));
+	O3DS_CHECK(QuatsNearlyEqual(out.rotations[0], qExpectedAt2, 1.0e-6));
+}
+
+O3DS_TEST(LinearPredictor_ErrorMuchLessThanHold_AtOneFrameHorizon)
+{
+	// Ground truth: constant-velocity motion x(t) = 3*t. Compare LinearPredictor
+	// vs HoldPredictor error at a one-frame-ahead horizon (roadmap acceptance:
+	// "LinearPredictor error << HoldPredictor at horizon = 1 frame").
+	const double frameDt = 1.0 / 60.0;
+
+	LinearPredictor linear;
+	HoldPredictor hold;
+
+	double t0 = 0.0, t1 = frameDt;
+	double x0 = 3.0 * t0, x1 = 3.0 * t1;
+
+	linear.Observe(MakeSample(t0, 1, x0, 0, 0, QuatIdentity(), 0.0f));
+	linear.Observe(MakeSample(t1, 2, x1, 0, 0, QuatIdentity(), 0.0f));
+	hold.Observe(MakeSample(t1, 2, x1, 0, 0, QuatIdentity(), 0.0f));
+
+	double tHorizon = t1 + frameDt;
+	double trueX = 3.0 * tHorizon;
+
+	PoseSample linearOut, holdOut;
+	O3DS_CHECK(linear.Predict(tHorizon, linearOut));
+	O3DS_CHECK(hold.Predict(tHorizon, holdOut));
+
+	double linearError = std::abs(linearOut.translations[0].v[0] - trueX);
+	double holdError = std::abs(holdOut.translations[0].v[0] - trueX);
+
+	O3DS_CHECK(holdError > 1.0e-6); // sanity: hold actually has real error here
+	O3DS_CHECK(linearError < holdError * 0.01);
+}
+
+O3DS_TEST(LinearPredictor_DegenerateSpacing_HoldsRatherThanDividesByZero)
+{
+	LinearPredictor pred;
+	pred.Observe(MakeSample(1.0, 1, 5.0, 0, 0, QuatIdentity(), 0.0f));
+	pred.Observe(MakeSample(1.0, 2, 7.0, 0, 0, QuatIdentity(), 0.0f)); // same t as previous
+
+	PoseSample out;
+	O3DS_CHECK(pred.Predict(2.0, out));
+	O3DS_CHECK_EQ(out.translations[0].v[0], 7.0); // held, not NaN/inf
+}
+
+O3DS_TEST(LinearPredictor_Reset_ClearsHistory)
+{
+	LinearPredictor pred;
+	pred.Observe(MakeSample(0.0, 1, 0, 0, 0, QuatIdentity(), 0.0f));
+	pred.Observe(MakeSample(1.0, 2, 1, 0, 0, QuatIdentity(), 0.0f));
+	pred.Reset();
+
+	PoseSample out;
+	O3DS_CHECK(!pred.Predict(2.0, out));
+}
+
+// ---------------------------------------------------------------------------
+// QuadraticPredictor
+// ---------------------------------------------------------------------------
+
+O3DS_TEST(QuadraticPredictor_InsufficientHistory_ReturnsFalse)
+{
+	QuadraticPredictor pred;
+	PoseSample out;
+	O3DS_CHECK(!pred.Predict(1.0, out));
+
+	pred.Observe(MakeSample(0.0, 1, 0, 0, 0, QuatIdentity(), 0.0f));
+	pred.Observe(MakeSample(1.0, 2, 1, 0, 0, QuatIdentity(), 0.0f));
+	O3DS_CHECK(!pred.Predict(2.0, out)); // only 2 samples so far
+}
+
+O3DS_TEST(QuadraticPredictor_ConstantAccelerationTranslation_PredictsExactly)
+{
+	// x(t) = 1 + 2*t + 0.5*4*t^2 = 1 + 2t + 2t^2. Three points exactly
+	// determine a quadratic, so extrapolation should be exact (to fp
+	// precision) regardless of spacing.
+	auto x = [](double t) { return 1.0 + 2.0 * t + 2.0 * t * t; };
+
+	QuadraticPredictor pred;
+	pred.Observe(MakeSample(0.0, 1, x(0.0), 0, 0, QuatIdentity(), 0.0f));
+	pred.Observe(MakeSample(0.3, 2, x(0.3), 0, 0, QuatIdentity(), 0.0f));
+	pred.Observe(MakeSample(0.7, 3, x(0.7), 0, 0, QuatIdentity(), 0.0f));
+
+	PoseSample out;
+	O3DS_CHECK(pred.Predict(1.5, out));
+	O3DS_CHECK(std::abs(out.translations[0].v[0] - x(1.5)) < 1.0e-9);
+}
+
+O3DS_TEST(QuadraticPredictor_RotationStaysUnitNorm)
+{
+	Vector3d axisY(0.0, 1.0, 0.0);
+	QuadraticPredictor pred;
+	pred.Observe(MakeSample(0.0, 1, 0, 0, 0, QuatFromAxisAngle(axisY, 0.0), 0.0f));
+	pred.Observe(MakeSample(0.5, 2, 0, 0, 0, QuatFromAxisAngle(axisY, 0.2), 0.0f));
+	pred.Observe(MakeSample(1.0, 3, 0, 0, 0, QuatFromAxisAngle(axisY, 0.5), 0.0f));
+
+	PoseSample out;
+	O3DS_CHECK(pred.Predict(1.5, out));
+	O3DS_CHECK(IsUnitNorm(out.rotations[0]));
+}
+
+O3DS_TEST(QuadraticPredictor_DegenerateSpacing_HoldsRatherThanDividesByZero)
+{
+	QuadraticPredictor pred;
+	pred.Observe(MakeSample(0.0, 1, 1.0, 0, 0, QuatIdentity(), 0.0f));
+	pred.Observe(MakeSample(1.0, 2, 2.0, 0, 0, QuatIdentity(), 0.0f));
+	pred.Observe(MakeSample(1.0, 3, 3.0, 0, 0, QuatIdentity(), 0.0f)); // same t as previous
+
+	PoseSample out;
+	O3DS_CHECK(pred.Predict(2.0, out));
+	O3DS_CHECK_EQ(out.translations[0].v[0], 3.0); // held, not NaN/inf
+}
+
+O3DS_TEST(QuadraticPredictor_Reset_ClearsHistory)
+{
+	QuadraticPredictor pred;
+	pred.Observe(MakeSample(0.0, 1, 0, 0, 0, QuatIdentity(), 0.0f));
+	pred.Observe(MakeSample(1.0, 2, 1, 0, 0, QuatIdentity(), 0.0f));
+	pred.Observe(MakeSample(2.0, 3, 2, 0, 0, QuatIdentity(), 0.0f));
+	pred.Reset();
+
+	PoseSample out;
+	O3DS_CHECK(!pred.Predict(3.0, out));
+}
+
+O3DS_TEST(Predictors_VersionTags_MatchRoadmapNumbering)
+{
+	HoldPredictor hold;
+	LinearPredictor linear;
+	QuadraticPredictor quadratic;
+
+	O3DS_CHECK_EQ(hold.Version(), (uint32_t)0);
+	O3DS_CHECK_EQ(linear.Version(), (uint32_t)1);
+	O3DS_CHECK_EQ(quadratic.Version(), (uint32_t)2);
+}

--- a/test/pose_predictor_tests.cpp
+++ b/test/pose_predictor_tests.cpp
@@ -93,6 +93,23 @@ O3DS_TEST(QuatMath_ToAxisAngle_NearIdentity_ReturnsFalse)
 	O3DS_CHECK(!QuatToAxisAngle(QuatIdentity(), axis, angle));
 }
 
+O3DS_TEST(QuatMath_ToAxisAngle_NearHalfTurn_RecoversRotation)
+{
+	// w~=0, s~=1: well-conditioned, but exercises the opposite extreme from
+	// the near-identity guard.
+	Vector3d axis(0.267261, 0.534522, 0.801784); // normalized (1,2,3)
+	double angle = 179.94 * kPi / 180.0;
+
+	Quat q = QuatFromAxisAngle(axis, angle);
+	Vector3d outAxis;
+	double outAngle = 0.0;
+	O3DS_CHECK(QuatToAxisAngle(q, outAxis, outAngle));
+	O3DS_CHECK(IsUnitNorm(QuatFromAxisAngle(outAxis, outAngle)));
+
+	Quat rebuilt = QuatFromAxisAngle(outAxis, outAngle);
+	O3DS_CHECK(QuatsNearlyEqual(q, rebuilt));
+}
+
 O3DS_TEST(QuatMath_Normalize_ScaledQuat_RecoversUnitNorm)
 {
 	Quat q(2.0, 0.0, 0.0, 2.0); // unnormalized, direction (1,0,0,1)
@@ -234,6 +251,19 @@ O3DS_TEST(LinearPredictor_ErrorMuchLessThanHold_AtOneFrameHorizon)
 	O3DS_CHECK(linearError < holdError * 0.01);
 }
 
+O3DS_TEST(LinearPredictor_Interpolation_BetweenSamples_PredictsExactly)
+{
+	// x(t) = 5 + 2*t, requested t is between the two observed samples
+	// (interpolation) rather than past the newest (extrapolation).
+	LinearPredictor pred;
+	pred.Observe(MakeSample(0.0, 1, 5.0, 0.0, 0.0, QuatIdentity(), 0.0f));
+	pred.Observe(MakeSample(2.0, 2, 9.0, 0.0, 0.0, QuatIdentity(), 0.0f));
+
+	PoseSample out;
+	O3DS_CHECK(pred.Predict(1.0, out));
+	O3DS_CHECK(std::abs(out.translations[0].v[0] - 7.0) < 1.0e-9);
+}
+
 O3DS_TEST(LinearPredictor_DegenerateSpacing_HoldsRatherThanDividesByZero)
 {
 	LinearPredictor pred;
@@ -271,6 +301,18 @@ O3DS_TEST(QuadraticPredictor_InsufficientHistory_ReturnsFalse)
 	O3DS_CHECK(!pred.Predict(2.0, out)); // only 2 samples so far
 }
 
+O3DS_TEST(QuadraticPredictor_OutUntouched_OnInsufficientHistory)
+{
+	QuadraticPredictor pred;
+	pred.Observe(MakeSample(0.0, 1, 0, 0, 0, QuatIdentity(), 0.0f));
+
+	PoseSample out = MakeSample(42.0, 99, 1.0, 2.0, 3.0, QuatIdentity(), 0.75f);
+	O3DS_CHECK(!pred.Predict(1.0, out));
+	O3DS_CHECK_EQ(out.t, 42.0);
+	O3DS_CHECK_EQ(out.seq, (uint64_t)99);
+	O3DS_CHECK_EQ(out.translations[0].v[0], 1.0);
+}
+
 O3DS_TEST(QuadraticPredictor_ConstantAccelerationTranslation_PredictsExactly)
 {
 	// x(t) = 1 + 2*t + 0.5*4*t^2 = 1 + 2t + 2t^2. Three points exactly
@@ -299,6 +341,27 @@ O3DS_TEST(QuadraticPredictor_RotationStaysUnitNorm)
 	PoseSample out;
 	O3DS_CHECK(pred.Predict(1.5, out));
 	O3DS_CHECK(IsUnitNorm(out.rotations[0]));
+}
+
+O3DS_TEST(QuadraticPredictor_ConstantAngularAcceleration_PredictsRotationAngleExactly)
+{
+	// theta(t) = 0.2*t + 0.3*t^2 about a fixed axis: exercises the rotation
+	// channel's velocity/acceleration terms (not just unit-norm), catching
+	// the case where the base angular speed is evaluated at the [t1,t2]
+	// interval's mean instead of at t2 before extrapolating further.
+	Vector3d axis(0.3, -0.7, 0.65); // off-axis; QuatFromAxisAngle normalizes
+	auto theta = [](double t) { return 0.2 * t + 0.3 * t * t; };
+
+	QuadraticPredictor pred;
+	pred.Observe(MakeSample(0.0, 1, 0, 0, 0, QuatFromAxisAngle(axis, theta(0.0)), 0.0f));
+	pred.Observe(MakeSample(0.5, 2, 0, 0, 0, QuatFromAxisAngle(axis, theta(0.5)), 0.0f));
+	pred.Observe(MakeSample(1.0, 3, 0, 0, 0, QuatFromAxisAngle(axis, theta(1.0)), 0.0f));
+
+	PoseSample out;
+	O3DS_CHECK(pred.Predict(1.5, out));
+
+	Quat expected = QuatFromAxisAngle(axis, theta(1.5));
+	O3DS_CHECK(QuatsNearlyEqual(out.rotations[0], expected, 1.0e-6));
 }
 
 O3DS_TEST(QuadraticPredictor_DegenerateSpacing_HoldsRatherThanDividesByZero)


### PR DESCRIPTION
## Summary

Implements roadmap phase C0 (issue tracking TBD - see `docs/roadmap/resilient-streaming-and-motion-prediction.md` §5): a pluggable `IPosePredictor` abstraction plus three non-ML baseline implementations, entirely core-side and engine-agnostic (no UE dependency, fully Linux-testable).

- **`PoseSample`** - a flat, topology-stable snapshot (translations/rotations/scales/curves) decoupled from the FlatBuffers/`Subject` model layer, so predictors unit-test without it. The caller owns the `PoseSample` ↔ `O3DS::Subject` mapping.
- **`IPosePredictor`** - `Observe(sample)` feeds confirmed frames in non-decreasing time order; `Predict(t, out)` returns `false` (`out` left untouched) when there's insufficient history, so the caller falls back to holding the last real pose; `Reset()` clears history on keyframe/topology change, a version mismatch, or a large sequence gap.
- **`HoldPredictor`** (Version 0) - returns the last observed sample. Today's freeze-on-loss behavior, and the fallback every other predictor degrades to when it lacks history.
- **`LinearPredictor`** (Version 1) - constant-velocity extrapolation. Linear channels use the roadmap's exact formula (`x1 + (x1-x0)/(t1-t0)*(t-t1)`); rotations extrapolate the angular velocity implied by the delta between the two most recent samples and reapply it, renormalizing.
- **`QuadraticPredictor`** (Version 2) - constant-acceleration extrapolation for scalar channels via Newton divided differences (correct for unevenly-spaced samples, not just a fixed frame interval); rotations use a documented approximation (constant angular acceleration about the most recent delta's axis, borrowing only the older delta's angular *speed* for the acceleration estimate - a full constant-angular-acceleration model in SO(3) is materially more complex and not needed for a classical baseline).
- **`quat_math.h`/`.cpp`** - small quaternion helper library (multiply, conjugate, normalize, axis-angle ↔ quaternion), shared by the two non-Hold predictors.
- **`sample_ring.h`** - fixed-capacity ring of the N most recent samples (N=1/2/3 for Hold/Linear/Quadratic respectively), keeping `Observe()` allocation-light after warm-up.

## Test plan

- [x] 22 new CTest cases (now 26 after the review follow-up below): quaternion algebra sanity (multiply/conjugate/normalize/axis-angle round-trip, including a near-half-turn case), the ring buffer's wraparound indexing, each predictor's insufficient-history/degenerate-spacing/reset behavior, constant-velocity and constant-acceleration ground-truth recovery (exact to fp precision for the scalar channels), unit-norm preservation on all rotation predictions, an interpolation (not just extrapolation) case, an out-left-untouched-on-false check, and the roadmap's explicit acceptance criterion (`LinearPredictor` error `<<` `HoldPredictor` error at a one-frame horizon).
- [x] Full core suite 85/85 passes under ASan/UBSan.
- [x] Opus-tier adversarial review pass completed. Found one real accuracy bug in `QuadraticPredictor`'s rotation channel (base angular speed was evaluated at the `[t1,t2]` interval midpoint instead of at `t2`, causing systematic rotation under-prediction - ~4.3° error at a 0.5s horizon in the reviewer's probe). Fixed with a one-line velocity-advance correction (verified to bring the error to machine epsilon), added the regression/coverage-gap tests the review identified, and documented the predictor's direction-reversal limitation in its class doc comment. Everything else reviewed clean (quaternion algebra, `SampleRing` indexing, interface contract, numerical edge cases all held up under adversarial probing).

## Scope note

Per the roadmap, C0 is interface + classical baselines only - wiring into the send/receive paths (concealment in C1, residual compression in C2) is explicitly out of scope here. Shipping `HoldPredictor` changes nothing observable versus today; it's the safe first landing for the whole predictor line.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LHHqoB2uhpd7k7wSdbE4H6)_