### PR TITLE
Fix Shipping-build break in MoQSessionWrapperTests.cpp

### DIFF
--- a/ProjectSandbox/Plugins/Open3DBroadcast/Source/Open3DTransportMoQ/Private/Tests/MoQSessionWrapperTests.cpp
+++ b/ProjectSandbox/Plugins/Open3DBroadcast/Source/Open3DTransportMoQ/Private/Tests/MoQSessionWrapperTests.cpp
@@ -8,6 +8,8 @@
 
 #include <atomic>
 
+#if WITH_DEV_AUTOMATION_TESTS
+
 #if O3D_WITH_TRANSPORT_MOQ
 
 namespace
@@ -172,3 +174,5 @@ bool FMoQResultFromCodeFallbackTest::RunTest(const FString& Parameters)
 }
 
 #endif // O3D_WITH_TRANSPORT_MOQ
+
+#endif // WITH_DEV_AUTOMATION_TESTS

--- a/ProjectSandbox/Plugins/Open3DBroadcast/Source/Open3DTransportMoQ/Private/Tests/MoQSessionWrapperTests.cpp
+++ b/ProjectSandbox/Plugins/Open3DBroadcast/Source/Open3DTransportMoQ/Private/Tests/MoQSessionWrapperTests.cpp
@@ -1,3 +1,5 @@
+#if WITH_DEV_AUTOMATION_TESTS
+
 #include "Misc/AutomationTest.h"
 
 #include "HAL/PlatformProcess.h"
@@ -7,8 +9,6 @@
 #include "Shared/MoQTypes.h"
 
 #include <atomic>
-
-#if WITH_DEV_AUTOMATION_TESTS
 
 #if O3D_WITH_TRANSPORT_MOQ
 


### PR DESCRIPTION
## Summary

Fixes a Shipping-configuration compile break that surfaced when cutting the first "Open3DBroadcast Plugin Release" build after #207 merged (run [28693945956](https://github.com/lifelike-and-believable/Open3DBroadcast/actions/runs/28693945956)).

`MoQSessionWrapperTests.cpp` was the only MoQ automation-test file missing the `#if WITH_DEV_AUTOMATION_TESTS` wrapper that every sibling test file has (`MoQCloudflareRelayTests.cpp`, `MoQSenderTests.cpp`, `MoQReceiverTests.cpp`, `MoQTrackNamespaceTests.cpp`) - it was only guarded by `O3D_WITH_TRANSPORT_MOQ`. In a Shipping build, `WITH_DEV_AUTOMATION_TESTS` is 0, so `FMoQSessionWrapperTestHelper` (a friend class in `MoQSessionWrapper.h` declared under that same guard) doesn't exist - but this file's `IMPLEMENT_SIMPLE_AUTOMATION_TEST` bodies were still compiled and referenced it:

```
error C2653: 'FMoQSessionWrapperTestHelper': is not a class or namespace name
error C3861: 'InvokeConnectionState': identifier not found
```

This is a pre-existing bug, not introduced by #207 - it's just never been exercised by a real Shipping/Release build before now.

## Fix

Add the missing `#if WITH_DEV_AUTOMATION_TESTS` / `#endif` wrapper around the whole file, matching the pattern used by every other MoQ test file.

## Test plan

- [x] This is a UE-only test-file guard fix; core library (`src/o3ds/`) is untouched.
- [ ] Verify the next "Open3DBroadcast Plugin Release" workflow run compiles the Shipping target successfully.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LHHqoB2uhpd7k7wSdbE4H6)_