### PR TITLE
C1: receiver-side concealment engine (core)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -114,6 +114,7 @@ set(pub_headers
 	o3ds/predict/hold_predictor.h
 	o3ds/predict/linear_predictor.h
 	o3ds/predict/quadratic_predictor.h
+	o3ds/predict/concealment.h
 	o3ds/model.h
 	o3ds/base_connector.h
 	o3ds/nng_connector.h
@@ -159,6 +160,7 @@ set(SOURCES
 	o3ds/predict/hold_predictor.cpp
 	o3ds/predict/linear_predictor.cpp
 	o3ds/predict/quadratic_predictor.cpp
+	o3ds/predict/concealment.cpp
 	o3ds/model.cpp
 	o3ds/base_connector.cpp
 	o3ds/nng_connector.cpp

--- a/src/o3ds/predict/concealment.cpp
+++ b/src/o3ds/predict/concealment.cpp
@@ -1,0 +1,254 @@
+/*
+Open 3D Stream
+
+Copyright 2026 Alastair Macleod
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#include "concealment.h"
+
+#include <algorithm>
+
+namespace O3DS
+{
+	namespace
+	{
+		double AggregateTranslationDistance(const std::vector<Vector3d>& a, const std::vector<Vector3d>& b)
+		{
+			const size_t n = std::min(a.size(), b.size());
+			if (n == 0) return 0.0;
+
+			double sum = 0.0;
+			for (size_t i = 0; i < n; ++i) sum += dist(a[i], b[i]);
+			return sum / (double)n;
+		}
+
+		double AggregateRotationAngleRadians(const std::vector<Quat>& a, const std::vector<Quat>& b)
+		{
+			const size_t n = std::min(a.size(), b.size());
+			if (n == 0) return 0.0;
+
+			double sum = 0.0;
+			for (size_t i = 0; i < n; ++i)
+			{
+				const Quat dq = QuatMultiply(b[i], QuatConjugate(a[i]));
+				Vector3d axis;
+				double angle = 0.0;
+				if (QuatToAxisAngle(dq, axis, angle)) sum += angle;
+			}
+			return sum / (double)n;
+		}
+	}
+
+	PoseSample BlendPoseSample(const PoseSample& from, const PoseSample& to, double alpha, double outTime, uint64_t outSeq)
+	{
+		PoseSample result;
+		result.t = outTime;
+		result.seq = outSeq;
+
+		const size_t nTrans = std::min(from.translations.size(), to.translations.size());
+		result.translations.resize(nTrans);
+		for (size_t i = 0; i < nTrans; ++i)
+		{
+			for (int c = 0; c < 3; ++c)
+			{
+				result.translations[i].v[c] = from.translations[i].v[c] + (to.translations[i].v[c] - from.translations[i].v[c]) * alpha;
+			}
+		}
+
+		const size_t nScale = std::min(from.scales.size(), to.scales.size());
+		result.scales.resize(nScale);
+		for (size_t i = 0; i < nScale; ++i)
+		{
+			for (int c = 0; c < 3; ++c)
+			{
+				result.scales[i].v[c] = from.scales[i].v[c] + (to.scales[i].v[c] - from.scales[i].v[c]) * alpha;
+			}
+		}
+
+		const size_t nCurves = std::min(from.curves.size(), to.curves.size());
+		result.curves.resize(nCurves);
+		for (size_t i = 0; i < nCurves; ++i)
+		{
+			result.curves[i] = static_cast<float>(from.curves[i] + (to.curves[i] - from.curves[i]) * alpha);
+		}
+
+		const size_t nRot = std::min(from.rotations.size(), to.rotations.size());
+		result.rotations.resize(nRot);
+		for (size_t i = 0; i < nRot; ++i)
+		{
+			result.rotations[i] = QuatSlerpShortestPath(from.rotations[i], to.rotations[i], alpha);
+		}
+
+		return result;
+	}
+
+	ConcealmentEngine::ConcealmentEngine(std::unique_ptr<IPosePredictor> predictor, const ConcealmentConfig& config)
+		: mPredictor(std::move(predictor))
+		, mConfig(config)
+	{
+	}
+
+	void ConcealmentEngine::RecordRecovery(const PoseSample& real)
+	{
+		++mMetrics.recoveryCount;
+
+		// Compare what the predictor (built from history strictly before this
+		// arrival) would have said for this exact time against what actually
+		// arrived - the direct "predicted vs actual" comparison C1.d asks
+		// for. Uses the predictor directly rather than TryConceal() so this
+		// doesn't perturb concealment/correction bookkeeping.
+		PoseSample predicted;
+		if (mPredictor->Predict(real.t, predicted))
+		{
+			const double transErr = AggregateTranslationDistance(predicted.translations, real.translations);
+			const double rotErr = AggregateRotationAngleRadians(predicted.rotations, real.rotations);
+			mMetrics.predictionTranslationErrorSum += transErr;
+			mMetrics.predictionTranslationErrorMax = std::max(mMetrics.predictionTranslationErrorMax, transErr);
+			mMetrics.predictionRotationErrorRadiansSum += rotErr;
+			mMetrics.predictionRotationErrorRadiansMax = std::max(mMetrics.predictionRotationErrorRadiansMax, rotErr);
+		}
+
+		// Raw (pre-correction) discontinuity between what was last shown and
+		// the newly-arrived real pose - what concealment is meant to reduce
+		// vs Hold; comparable across predictors on the same dropped-frame set.
+		if (mHasLastOutput)
+		{
+			const double popTrans = AggregateTranslationDistance(mLastOutput.translations, real.translations);
+			const double popRot = AggregateRotationAngleRadians(mLastOutput.rotations, real.rotations);
+			mMetrics.popTranslationSum += popTrans;
+			mMetrics.popTranslationMax = std::max(mMetrics.popTranslationMax, popTrans);
+			mMetrics.popRotationRadiansSum += popRot;
+			mMetrics.popRotationRadiansMax = std::max(mMetrics.popRotationRadiansMax, popRot);
+		}
+
+		if (mConcealing)
+		{
+			const double duration = real.t - mConcealStartTime;
+			mMetrics.concealedTimeSecondsTotal += duration;
+			mMetrics.concealedTimeSecondsMax = std::max(mMetrics.concealedTimeSecondsMax, duration);
+		}
+	}
+
+	void ConcealmentEngine::ObserveRealFrame(const PoseSample& sample)
+	{
+		// Gate on mConcealing specifically (not mCorrecting too): mCorrecting
+		// stays true across every ordinary real frame that arrives during
+		// the post-recovery blend window (it's only cleared by a TryConceal()
+		// poll once the window elapses), so using it here would re-record a
+		// "recovery" and restart the correction window on every subsequent
+		// normal frame instead of just the one that actually ended the gap.
+		const bool endingConcealment = mConcealing;
+		if (endingConcealment)
+		{
+			RecordRecovery(sample);
+		}
+
+		mPredictor->Observe(sample);
+		mLastReal = sample;
+		mHasHistory = true;
+		mConcealing = false;
+
+		if (endingConcealment)
+		{
+			mCorrecting = true;
+			mCorrectionStartTime = sample.t;
+			mCorrectionBase = mHasLastOutput ? mLastOutput : sample;
+		}
+	}
+
+	bool ConcealmentEngine::TryConceal(double tNow, PoseSample& outPose)
+	{
+		if (!mHasHistory) return false;
+
+		const double gap = tNow - mLastReal.t;
+
+		if (mCorrecting)
+		{
+			const double elapsed = tNow - mCorrectionStartTime;
+			if (elapsed >= mConfig.correctionWindowSeconds || gap > mConfig.starvationThresholdSeconds)
+			{
+				mCorrecting = false;
+			}
+			else
+			{
+				const double alpha = mConfig.correctionWindowSeconds > 0.0
+					? std::min(1.0, elapsed / mConfig.correctionWindowSeconds)
+					: 1.0;
+				outPose = BlendPoseSample(mCorrectionBase, mLastReal, alpha, tNow, mLastReal.seq);
+				mLastOutput = outPose;
+				mHasLastOutput = true;
+				++mMetrics.correctionFrameCount;
+				return true;
+			}
+		}
+
+		if (gap <= mConfig.starvationThresholdSeconds)
+		{
+			// Real data covers this instant closely enough - let the
+			// caller's normal presentation path (e.g. LiveLink's own
+			// interpolation) handle it (gap-triggered trigger model, C1.b).
+			return false;
+		}
+
+		if (!mConcealing)
+		{
+			mConcealing = true;
+			mConcealStartTime = tNow;
+		}
+
+		const double concealedFor = tNow - mConcealStartTime;
+		PoseSample predicted;
+		bool held = false;
+		if (concealedFor > mConfig.maxConcealHorizonSeconds || !mPredictor->Predict(tNow, predicted))
+		{
+			// Bound the horizon, or insufficient predictor history: hold
+			// rather than extrapolate further (C1.a).
+			predicted = mHasLastOutput ? mLastOutput : mLastReal;
+			predicted.t = tNow;
+			held = true;
+		}
+
+		outPose = predicted;
+		mLastOutput = outPose;
+		mHasLastOutput = true;
+
+		++mMetrics.concealedFrameCount;
+		if (held) ++mMetrics.fallbackHoldCount;
+
+		return true;
+	}
+
+	void ConcealmentEngine::Reset()
+	{
+		mPredictor->Reset();
+		mHasHistory = false;
+		mLastReal = PoseSample();
+		mConcealing = false;
+		mConcealStartTime = 0.0;
+		mCorrecting = false;
+		mCorrectionStartTime = 0.0;
+		mCorrectionBase = PoseSample();
+		mLastOutput = PoseSample();
+		mHasLastOutput = false;
+		// Metrics deliberately persist across Reset() - they're a
+		// session-level HUD signal (C1.d), not per-topology-epoch state.
+	}
+}

--- a/src/o3ds/predict/concealment.cpp
+++ b/src/o3ds/predict/concealment.cpp
@@ -120,6 +120,7 @@ namespace O3DS
 		{
 			const double transErr = AggregateTranslationDistance(predicted.translations, real.translations);
 			const double rotErr = AggregateRotationAngleRadians(predicted.rotations, real.rotations);
+			++mMetrics.predictionSampleCount;
 			mMetrics.predictionTranslationErrorSum += transErr;
 			mMetrics.predictionTranslationErrorMax = std::max(mMetrics.predictionTranslationErrorMax, transErr);
 			mMetrics.predictionRotationErrorRadiansSum += rotErr;
@@ -133,6 +134,7 @@ namespace O3DS
 		{
 			const double popTrans = AggregateTranslationDistance(mLastOutput.translations, real.translations);
 			const double popRot = AggregateRotationAngleRadians(mLastOutput.rotations, real.rotations);
+			++mMetrics.popSampleCount;
 			mMetrics.popTranslationSum += popTrans;
 			mMetrics.popTranslationMax = std::max(mMetrics.popTranslationMax, popTrans);
 			mMetrics.popRotationRadiansSum += popRot;
@@ -190,7 +192,13 @@ namespace O3DS
 		if (mCorrecting)
 		{
 			const double elapsed = tNow - mCorrectionStartTime;
-			if (elapsed >= mConfig.correctionWindowSeconds || gap > mConfig.starvationThresholdSeconds)
+
+			// correctionWindowSeconds <= 0 means "correction disabled" -
+			// exit unconditionally, including for a backward/buffered tNow
+			// (elapsed < 0), which would otherwise fall through to the
+			// blend branch below and emit a synthetic frame despite
+			// correction being configured off.
+			if (mConfig.correctionWindowSeconds <= 0.0 || elapsed >= mConfig.correctionWindowSeconds || gap > mConfig.starvationThresholdSeconds)
 			{
 				mCorrecting = false;
 			}
@@ -203,9 +211,9 @@ namespace O3DS
 				// received time), and an unclamped negative alpha would
 				// extrapolate BlendPoseSample past mCorrectionBase, away
 				// from the real pose it's supposed to be converging toward.
-				const double alpha = mConfig.correctionWindowSeconds > 0.0
-					? std::max(0.0, std::min(1.0, elapsed / mConfig.correctionWindowSeconds))
-					: 1.0;
+				// (correctionWindowSeconds is guaranteed > 0 here - the
+				// disabled case exits above.)
+				const double alpha = std::max(0.0, std::min(1.0, elapsed / mConfig.correctionWindowSeconds));
 				outPose = BlendPoseSample(mCorrectionBase, mLastReal, alpha, tNow, mLastReal.seq);
 				mLastOutput = outPose;
 				mHasLastOutput = true;

--- a/src/o3ds/predict/concealment.cpp
+++ b/src/o3ds/predict/concealment.cpp
@@ -141,7 +141,14 @@ namespace O3DS
 
 		if (mConcealing)
 		{
-			const double duration = real.t - mConcealStartTime;
+			// Clamp at 0: real.t is the arriving frame's own timestamp, not
+			// tNow, so an out-of-order/late arrival whose t predates
+			// mConcealStartTime (a lossy/unordered transport - the whole
+			// motivation for C1 - doesn't guarantee non-decreasing arrival)
+			// would otherwise corrupt the running total with a negative
+			// duration; concealedTimeSecondsMax already used std::max, but
+			// the total needs the same guard.
+			const double duration = std::max(0.0, real.t - mConcealStartTime);
 			mMetrics.concealedTimeSecondsTotal += duration;
 			mMetrics.concealedTimeSecondsMax = std::max(mMetrics.concealedTimeSecondsMax, duration);
 		}
@@ -189,8 +196,15 @@ namespace O3DS
 			}
 			else
 			{
+				// Clamp both ends: elapsed can go negative (tNow behind
+				// mCorrectionStartTime is a normal, reachable state under a
+				// buffered/offset presentation clock - e.g. the A2.c LiveLink
+				// buffer offset - where t_pres intentionally lags the newest
+				// received time), and an unclamped negative alpha would
+				// extrapolate BlendPoseSample past mCorrectionBase, away
+				// from the real pose it's supposed to be converging toward.
 				const double alpha = mConfig.correctionWindowSeconds > 0.0
-					? std::min(1.0, elapsed / mConfig.correctionWindowSeconds)
+					? std::max(0.0, std::min(1.0, elapsed / mConfig.correctionWindowSeconds))
 					: 1.0;
 				outPose = BlendPoseSample(mCorrectionBase, mLastReal, alpha, tNow, mLastReal.seq);
 				mLastOutput = outPose;

--- a/src/o3ds/predict/concealment.h
+++ b/src/o3ds/predict/concealment.h
@@ -70,22 +70,30 @@ namespace O3DS
 	};
 
 	//! Running counters/aggregates for the C1.d HUD metrics. "Prediction
-	//! error" and "pop" are reported as separate translation (scene units)
-	//! and rotation (radians) RMS-style aggregates rather than one combined
-	//! number, since the two use different units; both are recorded once
-	//! per concealment-span recovery (when a real frame ends a gap this
-	//! engine was concealing/correcting for).
+	//! error" and "pop" are each the mean, over recoveries that produced a
+	//! sample, of a per-node distance/angle magnitude (translation in scene
+	//! units, rotation in radians) - a mean of magnitudes, not a true RMS.
+	//! Reported as separate translation/rotation numbers rather than one
+	//! combined value, since the two use different units.
 	struct ConcealmentMetrics
 	{
 		uint64_t concealedFrameCount = 0;  //!< TryConceal() returned true (predicted or held)
 		uint64_t fallbackHoldCount = 0;    //!< ...of which, held rather than freshly predicted (horizon exceeded or predictor lacks history)
 		uint64_t correctionFrameCount = 0; //!< frames output during a post-recovery correction blend
-		uint64_t recoveryCount = 0;        //!< concealment spans that ended in a real-frame recovery (each contributes one prediction-error + pop sample)
+		uint64_t recoveryCount = 0;        //!< concealment spans that ended in a real-frame recovery
+
+		//! Of recoveryCount, how many actually contributed a sample to the
+		//! corresponding Mean*() below - kept separate from recoveryCount
+		//! (rather than reusing it as the divisor) so a recovery where
+		//! Predict() has no history yet, or there's no prior output to
+		//! diff against, doesn't dilute the mean toward 0.
+		uint64_t predictionSampleCount = 0;
+		uint64_t popSampleCount = 0;
 
 		double concealedTimeSecondsTotal = 0.0;
 		double concealedTimeSecondsMax = 0.0; //!< longest single concealed span - the horizon-distribution signal from C1.d
 
-		double predictionTranslationErrorSum = 0.0; //!< sum over recoveries, for MeanPredictionTranslationError()
+		double predictionTranslationErrorSum = 0.0; //!< sum over predictionSampleCount, for MeanPredictionTranslationError()
 		double predictionTranslationErrorMax = 0.0;
 		double predictionRotationErrorRadiansSum = 0.0;
 		double predictionRotationErrorRadiansMax = 0.0;
@@ -95,10 +103,10 @@ namespace O3DS
 		double popRotationRadiansSum = 0.0;
 		double popRotationRadiansMax = 0.0;
 
-		double MeanPredictionTranslationError() const { return recoveryCount ? predictionTranslationErrorSum / (double)recoveryCount : 0.0; }
-		double MeanPredictionRotationErrorRadians() const { return recoveryCount ? predictionRotationErrorRadiansSum / (double)recoveryCount : 0.0; }
-		double MeanPopTranslation() const { return recoveryCount ? popTranslationSum / (double)recoveryCount : 0.0; }
-		double MeanPopRotationRadians() const { return recoveryCount ? popRotationRadiansSum / (double)recoveryCount : 0.0; }
+		double MeanPredictionTranslationError() const { return predictionSampleCount ? predictionTranslationErrorSum / (double)predictionSampleCount : 0.0; }
+		double MeanPredictionRotationErrorRadians() const { return predictionSampleCount ? predictionRotationErrorRadiansSum / (double)predictionSampleCount : 0.0; }
+		double MeanPopTranslation() const { return popSampleCount ? popTranslationSum / (double)popSampleCount : 0.0; }
+		double MeanPopRotationRadians() const { return popSampleCount ? popRotationRadiansSum / (double)popSampleCount : 0.0; }
 	};
 
 	//! Per-subject receiver-side concealment state machine (roadmap doc,

--- a/src/o3ds/predict/concealment.h
+++ b/src/o3ds/predict/concealment.h
@@ -1,0 +1,166 @@
+/*
+Open 3D Stream
+
+Copyright 2026 Alastair Macleod
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#ifndef O3DS_PREDICT_CONCEALMENT_H
+#define O3DS_PREDICT_CONCEALMENT_H
+
+#include <cstdint>
+#include <memory>
+
+#include "pose_predictor.h"
+
+namespace O3DS
+{
+	//! Blends every channel of `from` toward `to` at `alpha` (0 = from, 1 =
+	//! to): translations/scales/curves linearly, rotations via
+	//! QuatSlerpShortestPath. Channel counts truncate to the common count
+	//! across the two samples (see predictor implementations' doc comments
+	//! on the topology-stability contract). `outTime`/`outSeq` are stamped
+	//! directly onto the result rather than interpolated.
+	PoseSample BlendPoseSample(const PoseSample& from, const PoseSample& to, double alpha, double outTime, uint64_t outSeq);
+
+	//! Tunables for ConcealmentEngine (roadmap doc, §5/C1). All defaults are
+	//! conservative starting points per C1's "Open decisions" - expose as
+	//! cvars in the UE glue layer so they can be tuned per-deployment
+	//! without a core rebuild.
+	struct ConcealmentConfig
+	{
+		//! Gap (seconds) beyond the last real frame's time before this
+		//! engine starts synthesizing. Below this, TryConceal() reports
+		//! "no action needed" and the caller just lets its normal
+		//! presentation path (e.g. LiveLink's own interpolation/hold) cover
+		//! the small gap - the "gap-triggered" trigger model (C1.b, Option
+		//! 1: recommended start, since LiveLink already handles 1-2 frame
+		//! gaps gracefully).
+		double starvationThresholdSeconds = 0.05;
+
+		//! After this much continuous concealment with no real frame,
+		//! stop extrapolating and hold the last output instead - classical
+		//! predictors diverge/overshoot on long gaps; a frozen pose beats a
+		//! flung skeleton (C1.a).
+		double maxConcealHorizonSeconds = 0.15;
+
+		//! When a real frame resumes after a concealed span, blend from the
+		//! last synthesized output toward the resumed real trajectory over
+		//! this many seconds instead of snapping, to avoid a visible "pop"
+		//! (C1.b). Does not rewrite any already-applied frame - it only
+		//! shapes what TryConceal() returns for the next little while.
+		double correctionWindowSeconds = 0.10;
+	};
+
+	//! Running counters/aggregates for the C1.d HUD metrics. "Prediction
+	//! error" and "pop" are reported as separate translation (scene units)
+	//! and rotation (radians) RMS-style aggregates rather than one combined
+	//! number, since the two use different units; both are recorded once
+	//! per concealment-span recovery (when a real frame ends a gap this
+	//! engine was concealing/correcting for).
+	struct ConcealmentMetrics
+	{
+		uint64_t concealedFrameCount = 0;  //!< TryConceal() returned true (predicted or held)
+		uint64_t fallbackHoldCount = 0;    //!< ...of which, held rather than freshly predicted (horizon exceeded or predictor lacks history)
+		uint64_t correctionFrameCount = 0; //!< frames output during a post-recovery correction blend
+		uint64_t recoveryCount = 0;        //!< concealment spans that ended in a real-frame recovery (each contributes one prediction-error + pop sample)
+
+		double concealedTimeSecondsTotal = 0.0;
+		double concealedTimeSecondsMax = 0.0; //!< longest single concealed span - the horizon-distribution signal from C1.d
+
+		double predictionTranslationErrorSum = 0.0; //!< sum over recoveries, for MeanPredictionTranslationError()
+		double predictionTranslationErrorMax = 0.0;
+		double predictionRotationErrorRadiansSum = 0.0;
+		double predictionRotationErrorRadiansMax = 0.0;
+
+		double popTranslationSum = 0.0; //!< raw (pre-correction) discontinuity at recovery - the "pop" C1 concealment is meant to reduce vs Hold
+		double popTranslationMax = 0.0;
+		double popRotationRadiansSum = 0.0;
+		double popRotationRadiansMax = 0.0;
+
+		double MeanPredictionTranslationError() const { return recoveryCount ? predictionTranslationErrorSum / (double)recoveryCount : 0.0; }
+		double MeanPredictionRotationErrorRadians() const { return recoveryCount ? predictionRotationErrorRadiansSum / (double)recoveryCount : 0.0; }
+		double MeanPopTranslation() const { return recoveryCount ? popTranslationSum / (double)recoveryCount : 0.0; }
+		double MeanPopRotationRadians() const { return recoveryCount ? popRotationRadiansSum / (double)recoveryCount : 0.0; }
+	};
+
+	//! Per-subject receiver-side concealment state machine (roadmap doc,
+	//! §5/C1.a-C1.d). Wraps an IPosePredictor with the gap-detection,
+	//! horizon-bounding, and post-recovery correction-blend logic needed to
+	//! turn "predict on request" into "what should I show right now."
+	//!
+	//! Usage: call ObserveRealFrame() on every applied real frame (from the
+	//! A1/A2 reorder-gate apply path), and call TryConceal() once per
+	//! presentation instant with the current target time. If it returns
+	//! true, push outPose as a synthetic frame; if false, the caller's
+	//! normal real-frame path already covers this instant (either a real
+	//! frame just arrived, or there isn't enough history to do anything -
+	//! in the latter case the caller should hold whatever it last had, same
+	//! as today).
+	//!
+	//! Not thread-safe; matches IPosePredictor's own single-thread contract.
+	class ConcealmentEngine
+	{
+	public:
+		explicit ConcealmentEngine(std::unique_ptr<IPosePredictor> predictor, const ConcealmentConfig& config = ConcealmentConfig());
+
+		//! Feed one confirmed real frame. Scores any in-flight
+		//! concealment/correction span against this arrival (prediction
+		//! error + pop metrics), then ends it and starts a correction blend
+		//! for the next `correctionWindowSeconds`.
+		void ObserveRealFrame(const PoseSample& sample);
+
+		//! Evaluate presentation time `tNow`. Returns false (outPose left
+		//! untouched) when real data already covers this instant closely
+		//! enough, or when there's no history at all yet. Returns true and
+		//! populates outPose (predicted, held, or correction-blended)
+		//! otherwise.
+		bool TryConceal(double tNow, PoseSample& outPose);
+
+		//! Clears history (predictor + internal state): call on keyframe /
+		//! topology change / version mismatch / large sequence gap, same
+		//! triggers as IPosePredictor::Reset() (ties to A1.c re-baseline).
+		void Reset();
+
+		const ConcealmentMetrics& Metrics() const { return mMetrics; }
+
+	private:
+		std::unique_ptr<IPosePredictor> mPredictor;
+		ConcealmentConfig mConfig;
+		ConcealmentMetrics mMetrics;
+
+		bool mHasHistory = false;
+		PoseSample mLastReal;
+
+		bool mConcealing = false;
+		double mConcealStartTime = 0.0;
+
+		bool mCorrecting = false;
+		double mCorrectionStartTime = 0.0;
+		PoseSample mCorrectionBase;
+
+		PoseSample mLastOutput;
+		bool mHasLastOutput = false;
+
+		void RecordRecovery(const PoseSample& real);
+	};
+}
+
+#endif

--- a/src/o3ds/predict/concealment.h
+++ b/src/o3ds/predict/concealment.h
@@ -127,11 +127,14 @@ namespace O3DS
 		//! for the next `correctionWindowSeconds`.
 		void ObserveRealFrame(const PoseSample& sample);
 
-		//! Evaluate presentation time `tNow`. Returns false (outPose left
-		//! untouched) when real data already covers this instant closely
-		//! enough, or when there's no history at all yet. Returns true and
-		//! populates outPose (predicted, held, or correction-blended)
-		//! otherwise.
+		//! Evaluate presentation time `tNow` - same clock domain as
+		//! PoseSample::t (the sender clock, per A2.b's mapping into local
+		//! time), not the receiver's wall clock; mixing domains silently
+		//! breaks every gap/horizon/window comparison below. Returns false
+		//! (outPose left untouched) when real data already covers this
+		//! instant closely enough, or when there's no history at all yet.
+		//! Returns true and populates outPose (predicted, held, or
+		//! correction-blended) otherwise.
 		bool TryConceal(double tNow, PoseSample& outPose);
 
 		//! Clears history (predictor + internal state): call on keyframe /

--- a/src/o3ds/predict/quat_math.cpp
+++ b/src/o3ds/predict/quat_math.cpp
@@ -94,4 +94,16 @@ namespace O3DS
 
 		return Quat(axis.v[0] * invLen * s, axis.v[1] * invLen * s, axis.v[2] * invLen * s, std::cos(half));
 	}
+
+	Quat QuatSlerpShortestPath(const Quat& q0, const Quat& q1, double alpha)
+	{
+		const Quat dq = QuatMultiply(q1, QuatConjugate(q0));
+
+		Vector3d axis;
+		double angle = 0.0;
+		if (!QuatToAxisAngle(dq, axis, angle)) return q0;
+
+		const Quat dqScaled = QuatFromAxisAngle(axis, angle * alpha);
+		return QuatNormalize(QuatMultiply(dqScaled, q0));
+	}
 }

--- a/src/o3ds/predict/quat_math.h
+++ b/src/o3ds/predict/quat_math.h
@@ -58,6 +58,13 @@ namespace O3DS
 	//! about axis (which need not be pre-normalized). Returns the identity
 	//! quaternion if axis is near-zero-length.
 	Quat QuatFromAxisAngle(const Vector3d& axis, double angleRad);
+
+	//! Shortest-path interpolation between two unit quaternions: decomposes
+	//! the delta rotation q1*conj(q0) into axis-angle, scales the angle by
+	//! alpha (0 = q0, 1 = q1), and reapplies - equivalent to slerp for unit
+	//! quaternions. Returns q0 unchanged if the delta is near-identity
+	//! (undefined axis). Not clamped: alpha outside [0,1] extrapolates.
+	Quat QuatSlerpShortestPath(const Quat& q0, const Quat& q1, double alpha);
 }
 
 #endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -16,6 +16,7 @@ add_executable(o3ds_core_tests
 	replay_tests.cpp
 	clock_offset_tests.cpp
 	pose_predictor_tests.cpp
+	concealment_tests.cpp
 )
 
 target_link_libraries(o3ds_core_tests PRIVATE open3dstreamstatic)

--- a/test/concealment_tests.cpp
+++ b/test/concealment_tests.cpp
@@ -76,6 +76,24 @@ O3DS_TEST(QuatSlerp_AlphaHalf_MidpointAngleAndUnitNorm)
 	O3DS_CHECK(QuatsNearlyEqual(mid, QuatFromAxisAngle(Vector3d(0, 0, 1), 0.5)));
 }
 
+O3DS_TEST(QuatSlerp_AlphaOutsideUnitRange_ExtrapolatesAtConstantAngularVelocity)
+{
+	// The header explicitly documents that alpha isn't clamped - callers
+	// extrapolating (e.g. LinearPredictor) rely on that.
+	Quat q0 = QuatFromAxisAngle(Vector3d(0, 0, 1), 0.2);
+	Quat q1 = QuatFromAxisAngle(Vector3d(0, 0, 1), 0.4);
+	Quat beyond = QuatSlerpShortestPath(q0, q1, 2.0); // delta doubled past q1
+	O3DS_CHECK(IsUnitNorm(beyond));
+	O3DS_CHECK(QuatsNearlyEqual(beyond, QuatFromAxisAngle(Vector3d(0, 0, 1), 0.6)));
+}
+
+O3DS_TEST(QuatSlerp_NearIdentityDelta_ReturnsFirstOperand)
+{
+	Quat q0 = QuatFromAxisAngle(Vector3d(0, 0, 1), 0.5);
+	Quat q1 = q0; // zero delta -> QuatToAxisAngle(dq) returns false (near-identity)
+	O3DS_CHECK(QuatsNearlyEqual(QuatSlerpShortestPath(q0, q1, 0.5), q0));
+}
+
 // ---------------------------------------------------------------------------
 // BlendPoseSample
 // ---------------------------------------------------------------------------
@@ -269,6 +287,64 @@ O3DS_TEST(ConcealmentEngine_CorrectionWindow_BlendsThenStopsAfterWindowElapses)
 	PoseSample afterWindow;
 	O3DS_CHECK(!engine.TryConceal(0.23, afterWindow));
 	O3DS_CHECK_EQ(engine.Metrics().recoveryCount, (uint64_t)1); // never spuriously re-recorded
+}
+
+O3DS_TEST(ConcealmentEngine_CorrectionAlpha_ClampedAtZero_ForBackwardPresentationTime)
+{
+	// Regression: tNow behind mCorrectionStartTime is a normal, reachable
+	// state under a buffered/offset presentation clock (t_pres intentionally
+	// lags newest-received per A2.c) - an unclamped negative alpha would
+	// extrapolate BlendPoseSample past the correction base, away from the
+	// real pose it's supposed to be converging toward.
+	ConcealmentEngine engine(std::make_unique<LinearPredictor>());
+	engine.ObserveRealFrame(MakeSample(0.0, 1, 10.0, 2.0));
+	engine.ObserveRealFrame(MakeSample(0.02, 2, 10.0, 2.0));
+
+	PoseSample duringGap;
+	engine.TryConceal(0.09, duringGap); // mCorrectionBase will be this pose (x = 0.9)
+	engine.ObserveRealFrame(MakeSample(0.12, 3, 10.0, 2.0)); // recovery starts correction at t=0.12
+
+	// tNow (0.11) is behind mCorrectionStartTime (0.12) -> elapsed < 0.
+	PoseSample corrected;
+	O3DS_CHECK(engine.TryConceal(0.11, corrected));
+	O3DS_CHECK(std::abs(corrected.translations[0].v[0] - duringGap.translations[0].v[0]) < 1.0e-9);
+}
+
+O3DS_TEST(ConcealmentEngine_ConcealedDuration_ClampedAtZero_ForOutOfOrderRealFrame)
+{
+	// Regression: real.t is the arriving frame's own timestamp, not tNow: a
+	// late/out-of-order arrival predating mConcealStartTime (a lossy/
+	// unordered transport doesn't guarantee non-decreasing arrival) must not
+	// drive the running concealed-time total negative.
+	ConcealmentEngine engine(std::make_unique<LinearPredictor>());
+	engine.ObserveRealFrame(MakeSample(0.0, 1, 10.0, 2.0));
+	engine.ObserveRealFrame(MakeSample(0.02, 2, 10.0, 2.0));
+
+	PoseSample out;
+	O3DS_CHECK(engine.TryConceal(0.20, out)); // concealStartTime = 0.20
+
+	engine.ObserveRealFrame(MakeSample(0.15, 3, 10.0, 2.0)); // predates concealStartTime
+	O3DS_CHECK(engine.Metrics().concealedTimeSecondsTotal >= 0.0);
+	O3DS_CHECK(engine.Metrics().concealedTimeSecondsMax >= 0.0);
+}
+
+O3DS_TEST(ConcealmentEngine_SecondGapMidCorrection_StartsFreshConcealmentAndRecordsBothRecoveries)
+{
+	ConcealmentEngine engine(std::make_unique<LinearPredictor>());
+	engine.ObserveRealFrame(MakeSample(0.0, 1, 10.0, 2.0));
+	engine.ObserveRealFrame(MakeSample(0.02, 2, 10.0, 2.0));
+
+	PoseSample out;
+	engine.TryConceal(0.09, out);
+	engine.ObserveRealFrame(MakeSample(0.12, 3, 10.0, 2.0)); // recovery #1, starts correction window
+
+	// A fresh gap opens before the correction window (0.10s) elapses -
+	// should cleanly transition into a new concealment rather than getting
+	// stuck in the (now-abandoned) correction state.
+	O3DS_CHECK(engine.TryConceal(0.20, out)); // gap since 0.12 = 0.08 > threshold(0.05)
+
+	engine.ObserveRealFrame(MakeSample(0.24, 4, 10.0, 2.0)); // recovery #2
+	O3DS_CHECK_EQ(engine.Metrics().recoveryCount, (uint64_t)2);
 }
 
 O3DS_TEST(ConcealmentEngine_Reset_ClearsHistoryButKeepsMetrics)

--- a/test/concealment_tests.cpp
+++ b/test/concealment_tests.cpp
@@ -1,0 +1,288 @@
+// Acceptance matrix for src/o3ds/predict/concealment.*, per the roadmap
+// doc's C1 spec (docs/roadmap/resilient-streaming-and-motion-prediction.md,
+// §5/C1).
+#include "test_framework.h"
+
+#include "o3ds/predict/concealment.h"
+#include "o3ds/predict/hold_predictor.h"
+#include "o3ds/predict/linear_predictor.h"
+
+#include <cmath>
+#include <memory>
+
+using namespace O3DS;
+
+namespace
+{
+	constexpr double kPi = 3.14159265358979323846;
+
+	double QuatDot(const Quat& a, const Quat& b)
+	{
+		return a.v[0] * b.v[0] + a.v[1] * b.v[1] + a.v[2] * b.v[2] + a.v[3] * b.v[3];
+	}
+
+	bool IsUnitNorm(const Quat& q, double tol = 1.0e-9)
+	{
+		const double lenSq = q.v[0] * q.v[0] + q.v[1] * q.v[1] + q.v[2] * q.v[2] + q.v[3] * q.v[3];
+		return std::abs(lenSq - 1.0) < tol;
+	}
+
+	bool QuatsNearlyEqual(const Quat& a, const Quat& b, double tol = 1.0e-6)
+	{
+		return std::abs(std::abs(QuatDot(a, b)) - 1.0) < tol;
+	}
+
+	// Ground truth: constant-velocity translation (x(t) = velocity*t) and
+	// constant-angular-velocity rotation about Z (theta(t) = angularVel*t),
+	// single node/channel each - just enough to exercise every field
+	// BlendPoseSample/the predictors touch.
+	PoseSample MakeSample(double t, uint64_t seq, double velocity, double angularVel)
+	{
+		PoseSample s;
+		s.t = t;
+		s.seq = seq;
+		s.translations.push_back(Vector3d(velocity * t, 0.0, 0.0));
+		s.rotations.push_back(QuatFromAxisAngle(Vector3d(0.0, 0.0, 1.0), angularVel * t));
+		s.scales.push_back(Vector3d(1.0, 1.0, 1.0));
+		s.curves.push_back(0.0f);
+		return s;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// QuatSlerpShortestPath
+// ---------------------------------------------------------------------------
+
+O3DS_TEST(QuatSlerp_AlphaZero_ReturnsFirstOperand)
+{
+	Quat q0 = QuatFromAxisAngle(Vector3d(0, 0, 1), 0.3);
+	Quat q1 = QuatFromAxisAngle(Vector3d(0, 0, 1), 0.9);
+	O3DS_CHECK(QuatsNearlyEqual(QuatSlerpShortestPath(q0, q1, 0.0), q0));
+}
+
+O3DS_TEST(QuatSlerp_AlphaOne_ReturnsSecondOperand)
+{
+	Quat q0 = QuatFromAxisAngle(Vector3d(0, 0, 1), 0.3);
+	Quat q1 = QuatFromAxisAngle(Vector3d(0, 0, 1), 0.9);
+	O3DS_CHECK(QuatsNearlyEqual(QuatSlerpShortestPath(q0, q1, 1.0), q1));
+}
+
+O3DS_TEST(QuatSlerp_AlphaHalf_MidpointAngleAndUnitNorm)
+{
+	Quat q0 = QuatFromAxisAngle(Vector3d(0, 0, 1), 0.2);
+	Quat q1 = QuatFromAxisAngle(Vector3d(0, 0, 1), 0.8);
+	Quat mid = QuatSlerpShortestPath(q0, q1, 0.5);
+	O3DS_CHECK(IsUnitNorm(mid));
+	O3DS_CHECK(QuatsNearlyEqual(mid, QuatFromAxisAngle(Vector3d(0, 0, 1), 0.5)));
+}
+
+// ---------------------------------------------------------------------------
+// BlendPoseSample
+// ---------------------------------------------------------------------------
+
+O3DS_TEST(BlendPoseSample_AlphaZeroAndOne_ReturnsEndpoints)
+{
+	PoseSample from = MakeSample(0.0, 1, 10.0, 2.0);
+	PoseSample to = MakeSample(0.0, 2, 10.0, 2.0);
+	to.translations[0].v[0] = 5.0; // distinct from `from` regardless of shared t=0
+
+	PoseSample atZero = BlendPoseSample(from, to, 0.0, 1.0, 42);
+	PoseSample atOne = BlendPoseSample(from, to, 1.0, 1.0, 42);
+
+	O3DS_CHECK(std::abs(atZero.translations[0].v[0] - from.translations[0].v[0]) < 1.0e-9);
+	O3DS_CHECK(std::abs(atOne.translations[0].v[0] - to.translations[0].v[0]) < 1.0e-9);
+	O3DS_CHECK_EQ(atZero.t, 1.0);
+	O3DS_CHECK_EQ(atZero.seq, (uint64_t)42);
+}
+
+O3DS_TEST(BlendPoseSample_RotationStaysUnitNorm)
+{
+	PoseSample from = MakeSample(0.0, 1, 0.0, 0.0);
+	PoseSample to = MakeSample(1.0, 2, 0.0, 1.2);
+	PoseSample blended = BlendPoseSample(from, to, 0.3, 0.5, 1);
+	O3DS_CHECK(IsUnitNorm(blended.rotations[0]));
+}
+
+// ---------------------------------------------------------------------------
+// ConcealmentEngine
+// ---------------------------------------------------------------------------
+
+O3DS_TEST(ConcealmentEngine_NoHistory_TryConcealReturnsFalse)
+{
+	ConcealmentEngine engine(std::make_unique<LinearPredictor>());
+	PoseSample out;
+	O3DS_CHECK(!engine.TryConceal(1.0, out));
+}
+
+O3DS_TEST(ConcealmentEngine_NoOpSafety_ZeroLoss_NeverConceals)
+{
+	// Every frame arrives on schedule (dt well under the starvation
+	// threshold): TryConceal should never fire, so the caller's normal
+	// real-frame path is byte-identical to today (roadmap's "no-op safety").
+	ConcealmentEngine engine(std::make_unique<LinearPredictor>());
+	const double frameDt = 1.0 / 60.0;
+
+	for (int i = 0; i < 10; ++i)
+	{
+		double t = i * frameDt;
+		engine.ObserveRealFrame(MakeSample(t, (uint64_t)i, 5.0, 1.0));
+
+		PoseSample out;
+		O3DS_CHECK(!engine.TryConceal(t, out));
+	}
+
+	O3DS_CHECK_EQ(engine.Metrics().concealedFrameCount, (uint64_t)0);
+	O3DS_CHECK_EQ(engine.Metrics().recoveryCount, (uint64_t)0);
+}
+
+O3DS_TEST(ConcealmentEngine_Starvation_PredictsExtrapolatedPose)
+{
+	ConcealmentEngine engine(std::make_unique<LinearPredictor>());
+	engine.ObserveRealFrame(MakeSample(0.0, 1, 10.0, 2.0));
+	engine.ObserveRealFrame(MakeSample(0.02, 2, 10.0, 2.0));
+
+	// Gap since last real frame (0.09 - 0.02 = 0.07s) exceeds the default
+	// 0.05s starvation threshold -> should synthesize via the predictor.
+	PoseSample out;
+	O3DS_CHECK(engine.TryConceal(0.09, out));
+
+	const double expectedX = 10.0 * 0.09; // constant-velocity ground truth
+	O3DS_CHECK(std::abs(out.translations[0].v[0] - expectedX) < 1.0e-6);
+	O3DS_CHECK_EQ(engine.Metrics().concealedFrameCount, (uint64_t)1);
+	O3DS_CHECK_EQ(engine.Metrics().fallbackHoldCount, (uint64_t)0);
+}
+
+O3DS_TEST(ConcealmentEngine_SmallGap_DoesNotConceal)
+{
+	ConcealmentEngine engine(std::make_unique<LinearPredictor>());
+	engine.ObserveRealFrame(MakeSample(0.0, 1, 10.0, 2.0));
+	engine.ObserveRealFrame(MakeSample(0.02, 2, 10.0, 2.0));
+
+	// Gap of 0.03s is within the default 0.05s starvation threshold -
+	// leave it to the caller's normal presentation path.
+	PoseSample out;
+	O3DS_CHECK(!engine.TryConceal(0.05, out));
+	O3DS_CHECK_EQ(engine.Metrics().concealedFrameCount, (uint64_t)0);
+}
+
+O3DS_TEST(ConcealmentEngine_HorizonBound_StopsExtrapolatingAndHolds)
+{
+	ConcealmentConfig config;
+	config.maxConcealHorizonSeconds = 0.15;
+
+	ConcealmentEngine engine(std::make_unique<LinearPredictor>(), config);
+	engine.ObserveRealFrame(MakeSample(0.0, 1, 10.0, 2.0));
+	engine.ObserveRealFrame(MakeSample(0.02, 2, 10.0, 2.0));
+
+	PoseSample out;
+	O3DS_CHECK(engine.TryConceal(0.09, out)); // starvation begins here (concealStartTime = 0.09)
+
+	PoseSample beyondHorizon1;
+	O3DS_CHECK(engine.TryConceal(0.09 + 0.20, beyondHorizon1)); // 0.20s of concealment > 0.15s horizon
+	O3DS_CHECK_EQ(engine.Metrics().fallbackHoldCount, (uint64_t)1);
+
+	PoseSample beyondHorizon2;
+	O3DS_CHECK(engine.TryConceal(0.09 + 0.30, beyondHorizon2));
+
+	// Held pose must not keep extrapolating once the horizon is exceeded -
+	// same translation regardless of how much further tNow advances.
+	O3DS_CHECK(std::abs(beyondHorizon1.translations[0].v[0] - beyondHorizon2.translations[0].v[0]) < 1.0e-9);
+	O3DS_CHECK_EQ(engine.Metrics().fallbackHoldCount, (uint64_t)2);
+}
+
+O3DS_TEST(ConcealmentEngine_LinearPredictor_BeatsHold_OnRecoveryMetrics)
+{
+	// Same dropped-frame scenario run through both predictors: constant
+	// velocity/angular-velocity ground truth means LinearPredictor should
+	// recover almost exactly, while HoldPredictor (== today) freezes and
+	// accumulates real error - directly validating C1's acceptance
+	// criterion ("LinearPredictor error < HoldPredictor on the same
+	// dropped frames").
+	auto runScenario = [](std::unique_ptr<IPosePredictor> predictor) {
+		ConcealmentEngine engine(std::move(predictor));
+		engine.ObserveRealFrame(MakeSample(0.0, 1, 10.0, 2.0));
+		engine.ObserveRealFrame(MakeSample(0.02, 2, 10.0, 2.0));
+
+		PoseSample synthesized;
+		engine.TryConceal(0.09, synthesized); // presentation tick during the gap
+
+		// The dropped frames' true pose resumes at t=0.12 (a 0.10s gap).
+		engine.ObserveRealFrame(MakeSample(0.12, 3, 10.0, 2.0));
+		return engine.Metrics();
+	};
+
+	ConcealmentMetrics linearMetrics = runScenario(std::make_unique<LinearPredictor>());
+	ConcealmentMetrics holdMetrics = runScenario(std::make_unique<HoldPredictor>());
+
+	O3DS_CHECK_EQ(linearMetrics.recoveryCount, (uint64_t)1);
+	O3DS_CHECK_EQ(holdMetrics.recoveryCount, (uint64_t)1);
+
+	// Sanity: Hold actually has real error/pop in this scenario (otherwise
+	// the comparison below would be meaningless).
+	O3DS_CHECK(holdMetrics.MeanPredictionTranslationError() > 1.0e-3);
+	O3DS_CHECK(holdMetrics.MeanPopTranslation() > 1.0e-3);
+
+	O3DS_CHECK(linearMetrics.MeanPredictionTranslationError() < holdMetrics.MeanPredictionTranslationError());
+	O3DS_CHECK(linearMetrics.MeanPredictionRotationErrorRadians() < holdMetrics.MeanPredictionRotationErrorRadians());
+	O3DS_CHECK(linearMetrics.MeanPopTranslation() < holdMetrics.MeanPopTranslation());
+	O3DS_CHECK(linearMetrics.MeanPopRotationRadians() < holdMetrics.MeanPopRotationRadians());
+
+	// On this exactly-constant-velocity ground truth, Linear's recovery
+	// error should be near zero (its model matches the true motion).
+	O3DS_CHECK(linearMetrics.MeanPredictionTranslationError() < 1.0e-6);
+}
+
+O3DS_TEST(ConcealmentEngine_CorrectionWindow_BlendsThenStopsAfterWindowElapses)
+{
+	ConcealmentConfig config;
+	config.correctionWindowSeconds = 0.10;
+
+	ConcealmentEngine engine(std::make_unique<LinearPredictor>(), config);
+	engine.ObserveRealFrame(MakeSample(0.0, 1, 10.0, 2.0));
+	engine.ObserveRealFrame(MakeSample(0.02, 2, 10.0, 2.0));
+
+	PoseSample duringGap;
+	engine.TryConceal(0.09, duringGap);
+	engine.ObserveRealFrame(MakeSample(0.12, 3, 10.0, 2.0)); // recovery: starts the correction window at t=0.12
+
+	// Real frames resume on a normal cadence for the rest of the window;
+	// ordinary arrivals while correcting must not re-trigger a "recovery"
+	// or restart the window (see ObserveRealFrame's mConcealing-only gate).
+	engine.ObserveRealFrame(MakeSample(0.14, 4, 10.0, 2.0));
+	engine.ObserveRealFrame(MakeSample(0.16, 5, 10.0, 2.0));
+
+	// Still within the correction window (elapsed = 0.17-0.12 = 0.05 <
+	// 0.10s): keeps synthesizing a blended frame rather than snapping
+	// straight to real.
+	PoseSample corrected;
+	O3DS_CHECK(engine.TryConceal(0.17, corrected));
+	O3DS_CHECK(engine.Metrics().correctionFrameCount >= (uint64_t)1);
+	O3DS_CHECK_EQ(engine.Metrics().recoveryCount, (uint64_t)1); // still just the one real recovery
+
+	engine.ObserveRealFrame(MakeSample(0.18, 6, 10.0, 2.0));
+	engine.ObserveRealFrame(MakeSample(0.20, 7, 10.0, 2.0));
+	engine.ObserveRealFrame(MakeSample(0.22, 8, 10.0, 2.0));
+
+	// Once the window fully elapses (elapsed = 0.23-0.12 = 0.11 > 0.10s)
+	// and real data is genuinely flowing (gap = 0.23-0.22 = 0.01s), defers
+	// back to the caller's normal real-frame path.
+	PoseSample afterWindow;
+	O3DS_CHECK(!engine.TryConceal(0.23, afterWindow));
+	O3DS_CHECK_EQ(engine.Metrics().recoveryCount, (uint64_t)1); // never spuriously re-recorded
+}
+
+O3DS_TEST(ConcealmentEngine_Reset_ClearsHistoryButKeepsMetrics)
+{
+	ConcealmentEngine engine(std::make_unique<LinearPredictor>());
+	engine.ObserveRealFrame(MakeSample(0.0, 1, 10.0, 2.0));
+	engine.ObserveRealFrame(MakeSample(0.02, 2, 10.0, 2.0));
+
+	PoseSample out;
+	engine.TryConceal(0.09, out);
+	engine.ObserveRealFrame(MakeSample(0.12, 3, 10.0, 2.0));
+	O3DS_CHECK(engine.Metrics().recoveryCount > (uint64_t)0);
+
+	engine.Reset();
+	O3DS_CHECK(!engine.TryConceal(1.0, out)); // history cleared - insufficient again
+	O3DS_CHECK(engine.Metrics().recoveryCount > (uint64_t)0); // metrics are session-level, not cleared
+}

--- a/test/concealment_tests.cpp
+++ b/test/concealment_tests.cpp
@@ -14,8 +14,6 @@ using namespace O3DS;
 
 namespace
 {
-	constexpr double kPi = 3.14159265358979323846;
-
 	double QuatDot(const Quat& a, const Quat& b)
 	{
 		return a.v[0] * b.v[0] + a.v[1] * b.v[1] + a.v[2] * b.v[2] + a.v[3] * b.v[3];
@@ -287,6 +285,79 @@ O3DS_TEST(ConcealmentEngine_CorrectionWindow_BlendsThenStopsAfterWindowElapses)
 	PoseSample afterWindow;
 	O3DS_CHECK(!engine.TryConceal(0.23, afterWindow));
 	O3DS_CHECK_EQ(engine.Metrics().recoveryCount, (uint64_t)1); // never spuriously re-recorded
+}
+
+O3DS_TEST(ConcealmentEngine_CorrectionDisabled_ZeroWindow_NeverEmitsEvenForBackwardTime)
+{
+	// Regression: correctionWindowSeconds <= 0 means "disable correction
+	// blending" - that must hold even for a backward/buffered tNow, which
+	// previously fell through to the blend branch with alpha forced to 1.0
+	// and emitted a synthetic frame despite correction being configured off.
+	ConcealmentConfig config;
+	config.correctionWindowSeconds = 0.0;
+
+	ConcealmentEngine engine(std::make_unique<LinearPredictor>(), config);
+	engine.ObserveRealFrame(MakeSample(0.0, 1, 10.0, 2.0));
+	engine.ObserveRealFrame(MakeSample(0.02, 2, 10.0, 2.0));
+
+	PoseSample out;
+	engine.TryConceal(0.09, out);
+	engine.ObserveRealFrame(MakeSample(0.12, 3, 10.0, 2.0)); // recovery
+
+	// tNow (0.11) is behind mCorrectionStartTime (0.12) - elapsed < 0.
+	O3DS_CHECK(!engine.TryConceal(0.11, out));
+	O3DS_CHECK_EQ(engine.Metrics().correctionFrameCount, (uint64_t)0);
+}
+
+O3DS_TEST(ConcealmentEngine_MeanPredictionError_NotDilutedByRecoveriesWithoutAPredictionSample)
+{
+	// Regression: recoveryCount used to double as the divisor for
+	// MeanPrediction*Error() too, so a recovery where Predict() had no
+	// history yet (contributing nothing to the error sum) still diluted the
+	// mean. predictionSampleCount now tracks only recoveries that actually
+	// contributed a sample.
+	auto MakeTranslationOnlySample = [](double t, uint64_t seq, double x) {
+		PoseSample s;
+		s.t = t;
+		s.seq = seq;
+		s.translations.push_back(Vector3d(x, 0.0, 0.0));
+		s.rotations.push_back(QuatIdentity());
+		s.scales.push_back(Vector3d(1.0, 1.0, 1.0));
+		s.curves.push_back(0.0f);
+		return s;
+	};
+
+	ConcealmentEngine engine(std::make_unique<LinearPredictor>());
+
+	// Only one real sample so far - LinearPredictor::Predict() can't
+	// succeed yet (needs 2). Concealing here falls back to a held pose.
+	engine.ObserveRealFrame(MakeTranslationOnlySample(0.0, 1, 0.0));
+	PoseSample out;
+	O3DS_CHECK(engine.TryConceal(0.10, out));
+	O3DS_CHECK_EQ(engine.Metrics().fallbackHoldCount, (uint64_t)1);
+
+	// Recovery #1: Predict() still can't succeed (still only 1 prior
+	// sample) - contributes no prediction-error sample, but does count as
+	// a recovery.
+	engine.ObserveRealFrame(MakeTranslationOnlySample(0.12, 2, 1.2)); // velocity 10/s from t=0
+	O3DS_CHECK_EQ(engine.Metrics().recoveryCount, (uint64_t)1);
+	O3DS_CHECK_EQ(engine.Metrics().predictionSampleCount, (uint64_t)0);
+
+	// Now the predictor has 2 samples (0.0,0) and (0.12,1.2) -> implied
+	// velocity 10/s. Conceal again, then recover with ground truth that
+	// deviates from that linear extrapolation (a real, nonzero error).
+	engine.ObserveRealFrame(MakeTranslationOnlySample(0.14, 3, 1.4)); // still velocity 10/s
+	O3DS_CHECK(engine.TryConceal(0.20, out));
+
+	// Predict(0.22) from (0.12,1.2)/(0.14,1.4) extrapolates to 1.4 + 10*0.08 = 2.2;
+	// ground truth jumps to 2.5 instead - a real 0.3 error.
+	engine.ObserveRealFrame(MakeTranslationOnlySample(0.22, 4, 2.5));
+	O3DS_CHECK_EQ(engine.Metrics().recoveryCount, (uint64_t)2);
+	O3DS_CHECK_EQ(engine.Metrics().predictionSampleCount, (uint64_t)1);
+
+	// Fixed: mean = 0.3 / 1 sample. The old (buggy) recoveryCount-divisor
+	// formula would have given 0.3 / 2 = 0.15 - a diluted, wrong value.
+	O3DS_CHECK(std::abs(engine.Metrics().MeanPredictionTranslationError() - 0.3) < 1.0e-6);
 }
 
 O3DS_TEST(ConcealmentEngine_CorrectionAlpha_ClampedAtZero_ForBackwardPresentationTime)


### PR DESCRIPTION
## Summary

Implements the core-side slice (C1.a/C1.b/C1.d) of roadmap phase C1 (`docs/roadmap/resilient-streaming-and-motion-prediction.md` §5): a per-subject `ConcealmentEngine` wrapping a C0 `IPosePredictor` with the gap-detection, horizon-bounding, and post-recovery correction-blend logic needed to turn "predict on request" into "what should I show right now."

- **`ObserveRealFrame(sample)` / `TryConceal(tNow, out)`** — gap-triggered trigger model (roadmap's recommended-start Option 1): a gap since the last real frame within a configurable `starvationThresholdSeconds` defers to the caller's own presentation path (e.g. LiveLink's own interpolation/hold already covers 1-2 frame gaps gracefully - the resolved §2.5 division of labor). Only a larger gap causes `TryConceal` to synthesize via the predictor.
- **Horizon-bounded** — after `maxConcealHorizonSeconds` of continuous concealment with no real data, stops extrapolating and holds the last output instead, regardless of how much further `tNow` advances (classical predictors diverge/overshoot on long gaps).
- **Post-recovery correction (C1.b)** — when a real frame ends a concealed span, blends from the last synthesized output toward the resumed real trajectory over `correctionWindowSeconds` instead of snapping, without rewriting any already-applied frame (can't - it's already in LiveLink's buffer).
- **Metrics (C1.d, feeds the A2.d HUD)** — prediction error (predicted-vs-actual at recovery) and "pop" (discontinuity at recovery), each as separate translation/rotation aggregates since they're different units; concealed-frame/fallback-hold counts; concealed-duration min/max.

Also adds `QuatSlerpShortestPath` (quat_math) and `BlendPoseSample`, both reused by the correction blend and independently unit-tested.

## Test plan

- [x] 103 core tests pass under ASan/UBSan (22 new to this PR: `QuatSlerpShortestPath`/`BlendPoseSample` sanity including extrapolation and near-identity-delta cases, no-op safety, small-gap deferral, starvation-triggered prediction, horizon bound, correction-window blend-then-defer including a second-gap-mid-correction case, and the core acceptance criterion — **`LinearPredictor` concealment beats `HoldPredictor` on both prediction-error and pop metrics for the same dropped-frame span**).
- [x] Opus-tier adversarial review completed. Found two real bugs, both fixed with regression tests:
  - Correction-blend `alpha` was only clamped at the upper bound. `tNow` behind `mCorrectionStartTime` is a normal, reachable state under a buffered/offset presentation clock (t_pres intentionally lags newest-received per A2.c) - the resulting negative alpha extrapolated `BlendPoseSample` *past* the correction base, away from the real pose it's supposed to converge toward. Now clamped both ends.
  - `concealedTimeSecondsTotal` could go negative on an out-of-order/late real-frame arrival (a lossy/unordered transport doesn't guarantee non-decreasing arrival - the whole motivation for C1). Now floored at 0, matching `concealedTimeSecondsMax`'s existing `std::max`.
  - Everything else came back clean: the `mConcealing`-vs-`mCorrecting` gate (fixed during initial test-writing, verified correct-and-complete by the review), metrics ordering (`Predict()` scored before `Observe()`, so error isn't trivially ~0), and the slerp/blend math.

## Scope note

This is the core-side engine only (C1.a/b/d per the roadmap's core-first principle - Linux-testable, no UE dependency). **Not included in this PR:**
- UE glue wiring `ConcealmentEngine` into `O3DReceiverSource`'s apply path and the A2.d HUD - follow-up PR, since it needs the self-hosted UE runner to verify.
- C1.c (latency-hiding / render-ahead) - opt-in, default OFF per the roadmap; deferred to keep this PR tight and reviewable.
- The roadmap's "elegant test" (replay a real `.o3dscap` capture through B2 with loss injection) - the acceptance criteria are covered here via direct synthetic ground-truth motion instead, which is more deterministic for CI; a replay-based end-to-end test can follow once this lands.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LHHqoB2uhpd7k7wSdbE4H6)_