### PR TITLE
D1: adaptive/variable-bit channel quantization (core)

### DIFF
--- a/Build/o3ds-core/CMakeLists.txt
+++ b/Build/o3ds-core/CMakeLists.txt
@@ -79,6 +79,19 @@ set(O3DS_SOURCES
     ${SRC_DIR}/o3ds/async_pair.cpp
     ${SRC_DIR}/o3ds/async_request.cpp
     ${SRC_DIR}/o3ds/async_pipeline.cpp
+    # predict/ and quant/ (roadmap doc §5/C0-C2, §6/D1): model.cpp has
+    # depended on the predict/ subsystem (predictors, concealment, residual
+    # coding) since C0-C2 landed, but this list was never updated to
+    # include it - this build target has been unable to link since then.
+    # channel_quant.cpp is D1's own addition and itself depends on
+    # predict/quat_math.cpp (QuatNormalize).
+    ${SRC_DIR}/o3ds/predict/quat_math.cpp
+    ${SRC_DIR}/o3ds/predict/hold_predictor.cpp
+    ${SRC_DIR}/o3ds/predict/linear_predictor.cpp
+    ${SRC_DIR}/o3ds/predict/quadratic_predictor.cpp
+    ${SRC_DIR}/o3ds/predict/concealment.cpp
+    ${SRC_DIR}/o3ds/predict/residual_codec.cpp
+    ${SRC_DIR}/o3ds/quant/channel_quant.cpp
 )
 
 # Optional WebSocket support (not needed for Unreal)
@@ -124,6 +137,15 @@ set(O3DS_HEADERS
     ${SRC_DIR}/o3ds/binary_stream.h
     ${SRC_DIR}/o3ds/xsens_parser.h
     ${SRC_DIR}/o3ds/o3ds_version.h
+    ${SRC_DIR}/o3ds/predict/quat_math.h
+    ${SRC_DIR}/o3ds/predict/pose_predictor.h
+    ${SRC_DIR}/o3ds/predict/sample_ring.h
+    ${SRC_DIR}/o3ds/predict/hold_predictor.h
+    ${SRC_DIR}/o3ds/predict/linear_predictor.h
+    ${SRC_DIR}/o3ds/predict/quadratic_predictor.h
+    ${SRC_DIR}/o3ds/predict/concealment.h
+    ${SRC_DIR}/o3ds/predict/residual_codec.h
+    ${SRC_DIR}/o3ds/quant/channel_quant.h
 )
 
 if(O3DS_WITH_WEBSOCKET)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -116,6 +116,7 @@ set(pub_headers
 	o3ds/predict/quadratic_predictor.h
 	o3ds/predict/concealment.h
 	o3ds/predict/residual_codec.h
+	o3ds/quant/channel_quant.h
 	o3ds/model.h
 	o3ds/base_connector.h
 	o3ds/nng_connector.h
@@ -163,6 +164,7 @@ set(SOURCES
 	o3ds/predict/quadratic_predictor.cpp
 	o3ds/predict/concealment.cpp
 	o3ds/predict/residual_codec.cpp
+	o3ds/quant/channel_quant.cpp
 	o3ds/model.cpp
 	o3ds/base_connector.cpp
 	o3ds/nng_connector.cpp

--- a/src/o3ds.fbs
+++ b/src/o3ds.fbs
@@ -62,6 +62,61 @@ struct ScaleUpdate {
   i:int;
 }
 
+// Appended (D1, roadmap doc §6/D1): fixed-size, per-tier quantized variants
+// of the *Update structs above - kept as structs (not tables) deliberately,
+// to preserve the zero-vtable/zero-offset compactness that makes the plain
+// *Update structs cheap in a vector; a table-based "optional precision
+// field" would reintroduce per-instance overhead and could erase D1's own
+// byte savings. Each carries a signed fixed-point code (see
+// quant/channel_quant.h's QuantizeByte/QuantizeHalf) for a DELTA already
+// known to be bounded within the update's own quant_byte_range/
+// quant_half_range (below) - never an absolute world-space value, which is
+// not bounded.
+struct TranslationUpdateQ8 {
+  dx:byte;
+  dy:byte;
+  dz:byte;
+  i:int;
+}
+
+struct TranslationUpdateQ16 {
+  dx:short;
+  dy:short;
+  dz:short;
+  i:int;
+}
+
+struct CurveUpdateQ8 {
+  dv:byte;
+  i:int;
+}
+
+struct CurveUpdateQ16 {
+  dv:short;
+  i:int;
+}
+
+// Smallest-three quantized rotation (see quant/channel_quant.h's
+// QuantizeRotationByte/QuantizeRotationHalf): quantizes the ABSOLUTE
+// rotation, not a delta - unit-quaternion components are already bounded
+// to [-1,1], so no caller-supplied range is needed (unlike translation/
+// curve above). `dropped` is which of x/y/z/w (0-3) was omitted and must
+// be reconstructed from the unit-length constraint on decode.
+struct RotationUpdateQ8 {
+  dropped:ubyte;
+  a:byte;
+  b:byte;
+  c:byte;
+  i:int;
+}
+
+struct RotationUpdateQ16 {
+  dropped:ubyte;
+  a:short;
+  b:short;
+  c:short;
+  i:int;
+}
 
 enum Component : byte { Translation, Rotation, Scale, Matrix }
 
@@ -103,6 +158,28 @@ table SubjectUpdate {
   // that collision (0 meaning two different things) would be dangerous.
   predictor_id:uint = 0;
   is_keyframe:bool = false;
+
+  // Appended (D1, roadmap doc §6/D1): adaptive/variable-bit channel
+  // quantization - orthogonal to (and stacks with) the residual-coding
+  // fields above; quantizes whatever value would otherwise be sent (a
+  // legacy last-sent delta OR a C2 residual) into a smaller wire
+  // representation when its magnitude is small enough. A channel appears
+  // in at most ONE of {translations, translations_q8, translations_q16}
+  // (same rule for rotation/curves) - never sent at all means "unchanged,
+  // below deltaThreshold", exactly as today. quant_byte_range/
+  // quant_half_range default to 0 ("quantization not used this update"),
+  // so an old reader (or a new reader talking to a sender with
+  // quantization disabled) simply never sees the *_q8/*_q16 vectors
+  // populated, preserving today's behavior exactly. Rotation needs no
+  // range field: quantized absolute, not delta - see RotationUpdateQ8/16.
+  quant_byte_range:float = 0.0;
+  quant_half_range:float = 0.0;
+  translations_q8:[TranslationUpdateQ8];
+  translations_q16:[TranslationUpdateQ16];
+  rotations_q8:[RotationUpdateQ8];
+  rotations_q16:[RotationUpdateQ16];
+  curves_q8:[CurveUpdateQ8];
+  curves_q16:[CurveUpdateQ16];
 }
 
 table SubjectList {

--- a/src/o3ds.fbs
+++ b/src/o3ds.fbs
@@ -166,17 +166,25 @@ table SubjectUpdate {
   // despite the schema fields living alongside predictor_id/is_keyframe
   // above; wiring D1 into the residual path (using ResidualEncoder/
   // Decoder's own Reference() as the anchor instead of the rest-pose one
-  // below) is a natural follow-on, not yet done. Quantizes whatever value
-  // the legacy path would otherwise send (a last-sent delta) into a
-  // smaller wire representation when its magnitude is small enough. A
-  // channel appears in at most ONE of {translations, translations_q8, translations_q16}
+  // below) is a natural follow-on, not yet done. Translation quantizes a
+  // DELTA FROM A FIXED REST-POSE ANCHOR (Transform::mQuantAnchorTranslation,
+  // captured once at the first full sync and held for the transform's
+  // lifetime) - NOT the legacy path's own absolute-float translation
+  // values, and NOT a last-sent delta (a moving reference would desync
+  // permanently the first time a periodic full "keyframe" resync was
+  // dropped - see the anchor's own doc comment in model.h). A channel
+  // appears in at most ONE of {translations, translations_q8, translations_q16}
   // (same rule for rotation/curves) - never sent at all means "unchanged,
   // below deltaThreshold", exactly as today. quant_byte_range/
-  // quant_half_range default to 0 ("quantization not used this update"),
-  // so an old reader (or a new reader talking to a sender with
-  // quantization disabled) simply never sees the *_q8/*_q16 vectors
-  // populated, preserving today's behavior exactly. Rotation needs no
-  // range field: quantized absolute, not delta - see RotationUpdateQ8/16.
+  // quant_half_range each default to 0, meaning there is no
+  // translations_q8/translations_q16 vector (respectively) present in this
+  // update to decode - NOT "quantization is off overall": rotation's
+  // smallest-three encoding (RotationUpdateQ8/16) never uses either range
+  // field, quantizing the absolute value directly (bounded to [-1,1]
+  // already, no reference needed), so a rotations_q8/q16 vector can be
+  // present even when both ranges are 0. An old reader (or a new reader
+  // talking to a sender with quantization disabled) simply never sees any
+  // *_q8/*_q16 vectors populated, preserving today's behavior exactly.
   quant_byte_range:float = 0.0;
   quant_half_range:float = 0.0;
   translations_q8:[TranslationUpdateQ8];

--- a/src/o3ds.fbs
+++ b/src/o3ds.fbs
@@ -160,11 +160,16 @@ table SubjectUpdate {
   is_keyframe:bool = false;
 
   // Appended (D1, roadmap doc §6/D1): adaptive/variable-bit channel
-  // quantization - orthogonal to (and stacks with) the residual-coding
-  // fields above; quantizes whatever value would otherwise be sent (a
-  // legacy last-sent delta OR a C2 residual) into a smaller wire
-  // representation when its magnitude is small enough. A channel appears
-  // in at most ONE of {translations, translations_q8, translations_q16}
+  // quantization for the LEGACY (predictor_id==0) path only in this first
+  // pass - Subject::SerializeUpdateResidual (C2) does not yet consult
+  // mQuantRanges, so a residual-coded update is never quantized today
+  // despite the schema fields living alongside predictor_id/is_keyframe
+  // above; wiring D1 into the residual path (using ResidualEncoder/
+  // Decoder's own Reference() as the anchor instead of the rest-pose one
+  // below) is a natural follow-on, not yet done. Quantizes whatever value
+  // the legacy path would otherwise send (a last-sent delta) into a
+  // smaller wire representation when its magnitude is small enough. A
+  // channel appears in at most ONE of {translations, translations_q8, translations_q16}
   // (same rule for rotation/curves) - never sent at all means "unchanged,
   // below deltaThreshold", exactly as today. quant_byte_range/
   // quant_half_range default to 0 ("quantization not used this update"),

--- a/src/o3ds/model.cpp
+++ b/src/o3ds/model.cpp
@@ -27,6 +27,7 @@ SOFTWARE.
 #include "CRC.h"
 #include <algorithm>
 #include <iterator>
+#include <map>
 #include <sstream>
 
 using namespace O3DS::Data;
@@ -335,17 +336,28 @@ namespace O3DS
 			t->rotation >> rotation;
 			t->scale >> scale;
 
-			// D1 (roadmap doc §6/D1): (re)anchor this transform's
-			// quantization reference to whatever value is being sent in
-			// THIS full sync - see Transform::mQuantAnchorTranslation's own
-			// doc comment for why a fixed, sync-time anchor (not a moving
-			// last-sent value) is required for D1's quantized deltas to
-			// stay loss-safe. Unconditional, not just first-time: every
-			// full resync re-establishes a fresh anchor, matching
-			// ParseSubject's receive-side capture below exactly, so both
-			// sides always agree on the same anchor.
-			t->mQuantAnchorTranslation = t->translation.value;
-			t->mQuantAnchorSet = true;
+			// D1 (roadmap doc §6/D1): anchor this transform's quantization
+			// reference ONCE, the first time it's ever sent - see Transform::
+			// mQuantAnchorTranslation's own doc comment for why a fixed
+			// anchor (not a moving last-sent value) is required for D1's
+			// quantized deltas to stay loss-safe. Deliberately NOT
+			// re-captured on every subsequent full sync: real senders in
+			// this codebase periodically re-send a full snapshot as a
+			// "keyframe" over the same best-effort connector as delta
+			// updates, with no ACK. If re-anchoring happened on every one of
+			// those and a single such packet were dropped, the sender would
+			// silently move on to a new anchor the receiver never saw,
+			// corrupting every quantized delta after it - exactly the
+			// history-divergence-under-loss failure D1 exists to avoid.
+			// Anchoring once and holding it for the Transform's entire
+			// logical lifetime (see ParseSubject's matching receive-side
+			// preservation-across-resync logic below) means a lost keyframe
+			// has no effect on anchor correctness at all.
+			if (!t->mQuantAnchorSet)
+			{
+				t->mQuantAnchorTranslation = t->translation.value;
+				t->mQuantAnchorSet = true;
+			}
 
 			for (const auto component : t->transformOrder) {
 				if (component == O3DS::TTranslation) {
@@ -559,10 +571,19 @@ flatbuffers::Offset<flatbuffers::Vector<const O3DS::Data::CurveUpdate *>> Subjec
 		auto ro = builder.CreateVectorOfStructs(rotations);
 		auto sc = builder.CreateVectorOfStructs(scales);
 		auto cu = SerializeCurveUpdates(builder, count);
-		auto trQ8 = builder.CreateVectorOfStructs(translationsQ8);
-		auto trQ16 = builder.CreateVectorOfStructs(translationsQ16);
-		auto roQ8 = builder.CreateVectorOfStructs(rotationsQ8);
-		auto roQ16 = builder.CreateVectorOfStructs(rotationsQ16);
+		// CreateVectorOfStructs() always writes a (non-null-offset) vector,
+		// even an empty one - it is NOT equivalent to passing 0. Since these
+		// four are only ever populated when quantization is enabled AND a
+		// channel actually chose that tier, an unconditional call here would
+		// add real wire bytes for all four EVERY update regardless of
+		// whether quantization is used at all - directly contradicting the
+		// "byte-for-byte identical when disabled" guarantee this feature is
+		// supposed to have (confirmed empirically: ~48 bytes of pure
+		// overhead per update with quantization off before this guard).
+		auto trQ8 = translationsQ8.empty() ? 0 : builder.CreateVectorOfStructs(translationsQ8);
+		auto trQ16 = translationsQ16.empty() ? 0 : builder.CreateVectorOfStructs(translationsQ16);
+		auto roQ8 = rotationsQ8.empty() ? 0 : builder.CreateVectorOfStructs(rotationsQ8);
+		auto roQ16 = rotationsQ16.empty() ? 0 : builder.CreateVectorOfStructs(rotationsQ16);
 
 		const float byteRangeOut = (quantRanges != nullptr) ? (float)quantRanges->byteRange : 0.0f;
 		const float halfRangeOut = (quantRanges != nullptr) ? (float)quantRanges->halfRange : 0.0f;
@@ -1055,6 +1076,30 @@ flatbuffers::Offset<flatbuffers::Vector<const O3DS::Data::CurveUpdate *>> Subjec
 		// Get the nodes (transforms) for this subject
 		auto ovNodes = inSubject->nodes();
 
+		// D1 (roadmap doc §6/D1): outSubject->clear() below unconditionally
+		// deletes every existing Transform and rebuilds fresh ones - even
+		// when the topology hasn't actually changed, since a full resync
+		// happens periodically as a "keyframe" over the same connector as
+		// delta updates (see real senders in apps/, plugins/mobu, and the UE
+		// glue). A brand-new Transform object always starts with no
+		// quantization anchor, but re-capturing one here on every resync
+		// would defeat the whole point of the anchor being a FIXED
+		// reference (see Subject::Serialize's matching comment on the
+		// sender side) - a single dropped resync packet would silently
+		// desync sender/receiver anchors forever after. Snapshot the old
+		// anchors by name before clearing, and restore them onto the new
+		// Transform objects below instead of recapturing, for any
+		// transform whose identity (name) is unchanged across this resync.
+		// A genuinely new transform name (real topology change) has no
+		// entry here and gets a fresh anchor captured for the first time,
+		// same as before.
+		std::map<std::string, std::pair<Vector3d, bool>> preservedAnchors;
+		for (Transform* oldTransform : outSubject->mTransforms.mItems)
+		{
+			preservedAnchors[oldTransform->mName] =
+				std::make_pair(oldTransform->mQuantAnchorTranslation, oldTransform->mQuantAnchorSet);
+		}
+
 		// Clear the subject and add the transforms
 		outSubject->clear();
 
@@ -1103,14 +1148,24 @@ flatbuffers::Offset<flatbuffers::Vector<const O3DS::Data::CurveUpdate *>> Subjec
 						*inTranslation >> outTransform->translation;
 						outTransform->transformOrder.push_back(O3DS::TTranslation);
 
-						// D1 (roadmap doc §6/D1): mirrors the sender-side
-						// anchor capture in Subject::Serialize() above -
-						// both sides (re)anchor to the same full-sync value,
-						// so a later quantized delta update decodes
-						// correctly regardless of which side's clock it's
-						// measured against.
-						outTransform->mQuantAnchorTranslation = outTransform->translation.value;
-						outTransform->mQuantAnchorSet = true;
+						// D1 (roadmap doc §6/D1): restore this transform's
+						// preserved anchor (same name, prior resync) rather
+						// than recapturing - see the preservedAnchors doc
+						// comment above for why. Only a transform with no
+						// preserved entry (or whose anchor was never set)
+						// gets a fresh one captured now, mirroring the
+						// sender's own "once" semantics in Serialize().
+						auto preserved = preservedAnchors.find(transformName);
+						if (preserved != preservedAnchors.end() && preserved->second.second)
+						{
+							outTransform->mQuantAnchorTranslation = preserved->second.first;
+							outTransform->mQuantAnchorSet = true;
+						}
+						else
+						{
+							outTransform->mQuantAnchorTranslation = outTransform->translation.value;
+							outTransform->mQuantAnchorSet = true;
+						}
 					}
 					if (componentId == O3DS::Data::Component::Component_Rotation && inRotation != nullptr)
 					{

--- a/src/o3ds/model.cpp
+++ b/src/o3ds/model.cpp
@@ -335,6 +335,18 @@ namespace O3DS
 			t->rotation >> rotation;
 			t->scale >> scale;
 
+			// D1 (roadmap doc §6/D1): (re)anchor this transform's
+			// quantization reference to whatever value is being sent in
+			// THIS full sync - see Transform::mQuantAnchorTranslation's own
+			// doc comment for why a fixed, sync-time anchor (not a moving
+			// last-sent value) is required for D1's quantized deltas to
+			// stay loss-safe. Unconditional, not just first-time: every
+			// full resync re-establishes a fresh anchor, matching
+			// ParseSubject's receive-side capture below exactly, so both
+			// sides always agree on the same anchor.
+			t->mQuantAnchorTranslation = t->translation.value;
+			t->mQuantAnchorSet = true;
+
 			for (const auto component : t->transformOrder) {
 				if (component == O3DS::TTranslation) {
 					components.push_back(O3DS::Data::Component::Component_Translation);
@@ -423,12 +435,16 @@ flatbuffers::Offset<flatbuffers::Vector<const O3DS::Data::CurveUpdate *>> Subjec
 		return s;
 	}
 
-	flatbuffers::Offset<O3DS::Data::SubjectUpdate> Subject::SerializeUpdate(flatbuffers::FlatBufferBuilder& builder, size_t &count, double deltaThreshold)
+	flatbuffers::Offset<O3DS::Data::SubjectUpdate> Subject::SerializeUpdate(flatbuffers::FlatBufferBuilder& builder, size_t &count, double deltaThreshold, const QuantRanges* quantRanges)
 	{
 		auto oSubjectName = builder.CreateString(this->mName);
 
 		std::vector<O3DS::Data::TranslationUpdate> translations;
+		std::vector<O3DS::Data::TranslationUpdateQ8> translationsQ8;
+		std::vector<O3DS::Data::TranslationUpdateQ16> translationsQ16;
 		std::vector<O3DS::Data::RotationUpdate> rotations;
+		std::vector<O3DS::Data::RotationUpdateQ8> rotationsQ8;
+		std::vector<O3DS::Data::RotationUpdateQ16> rotationsQ16;
 		std::vector<O3DS::Data::ScaleUpdate> scales;
 		std::vector<flatbuffers::Offset<O3DS::Data::CurveUpdate>> curveUpdates;
 
@@ -442,21 +458,86 @@ flatbuffers::Offset<flatbuffers::Vector<const O3DS::Data::CurveUpdate *>> Subjec
 			}
 			if (t->translation.delta() > deltaThreshold)
 			{
-				translations.push_back(O3DS::Data::TranslationUpdate(
-					(float)t->translation.value.v[0],
-					(float)t->translation.value.v[1],
-					(float)t->translation.value.v[2], transformId));
+				bool quantized = false;
+				// D1 (roadmap doc §6/D1): quantize a delta from this
+				// Transform's fixed rest-pose anchor, never from
+				// lastSentValue - see Transform::mQuantAnchorTranslation's
+				// doc comment for why a moving reference would reintroduce
+				// loss-sensitivity D1 is meant to avoid. No anchor yet
+				// (never seen a full Serialize()) means no safe delta to
+				// quantize - fall back to Full for this call only.
+				if (quantRanges != nullptr && t->mQuantAnchorSet)
+				{
+					double dx = t->translation.value.v[0] - t->mQuantAnchorTranslation.v[0];
+					double dy = t->translation.value.v[1] - t->mQuantAnchorTranslation.v[1];
+					double dz = t->translation.value.v[2] - t->mQuantAnchorTranslation.v[2];
+					double maxAbs = std::max(std::fabs(dx), std::max(std::fabs(dy), std::fabs(dz)));
+					QuantTier tier = ChooseScalarTier(maxAbs, *quantRanges);
+					if (tier == QuantTier::Byte)
+					{
+						translationsQ8.push_back(O3DS::Data::TranslationUpdateQ8(
+							QuantizeByte(dx, quantRanges->byteRange),
+							QuantizeByte(dy, quantRanges->byteRange),
+							QuantizeByte(dz, quantRanges->byteRange),
+							transformId));
+						quantized = true;
+					}
+					else if (tier == QuantTier::Half)
+					{
+						translationsQ16.push_back(O3DS::Data::TranslationUpdateQ16(
+							QuantizeHalf(dx, quantRanges->halfRange),
+							QuantizeHalf(dy, quantRanges->halfRange),
+							QuantizeHalf(dz, quantRanges->halfRange),
+							transformId));
+						quantized = true;
+					}
+				}
+				if (!quantized)
+				{
+					translations.push_back(O3DS::Data::TranslationUpdate(
+						(float)t->translation.value.v[0],
+						(float)t->translation.value.v[1],
+						(float)t->translation.value.v[2], transformId));
+				}
 				t->translation.sent();
 				count++;
 			}
 
 			if (t->rotation.delta() > deltaThreshold)
 			{
-				rotations.push_back(O3DS::Data::RotationUpdate(
-					(float)t->rotation.value.v[0],
-					(float)t->rotation.value.v[1],
-					(float)t->rotation.value.v[2],
-					(float)t->rotation.value.v[3], transformId));
+				bool quantized = false;
+				// Rotation quantizes the ABSOLUTE value (smallest-three) -
+				// unlike translation, unit-quaternion components are
+				// already bounded, so no anchor is needed. Reuses
+				// quantRanges' byteRange/halfRange as a generic "how much
+				// did this channel move" threshold against the same
+				// quaternion-space delta() already computed above - a
+				// classical fixed-threshold choice, not dimensionally tied
+				// to translation's own linear units.
+				if (quantRanges != nullptr)
+				{
+					QuantTier tier = ChooseScalarTier(t->rotation.delta(), *quantRanges);
+					if (tier == QuantTier::Byte)
+					{
+						SmallestThreeQ8 q = QuantizeRotationByte(t->rotation.value);
+						rotationsQ8.push_back(O3DS::Data::RotationUpdateQ8(q.droppedIndex, q.a, q.b, q.c, transformId));
+						quantized = true;
+					}
+					else if (tier == QuantTier::Half)
+					{
+						SmallestThreeQ16 q = QuantizeRotationHalf(t->rotation.value);
+						rotationsQ16.push_back(O3DS::Data::RotationUpdateQ16(q.droppedIndex, q.a, q.b, q.c, transformId));
+						quantized = true;
+					}
+				}
+				if (!quantized)
+				{
+					rotations.push_back(O3DS::Data::RotationUpdate(
+						(float)t->rotation.value.v[0],
+						(float)t->rotation.value.v[1],
+						(float)t->rotation.value.v[2],
+						(float)t->rotation.value.v[3], transformId));
+				}
 				t->rotation.sent();
 				count++;
 			}
@@ -478,7 +559,18 @@ flatbuffers::Offset<flatbuffers::Vector<const O3DS::Data::CurveUpdate *>> Subjec
 		auto ro = builder.CreateVectorOfStructs(rotations);
 		auto sc = builder.CreateVectorOfStructs(scales);
 		auto cu = SerializeCurveUpdates(builder, count);
-		return CreateSubjectUpdate(builder, oSubjectName, tr, ro, sc, cu);
+		auto trQ8 = builder.CreateVectorOfStructs(translationsQ8);
+		auto trQ16 = builder.CreateVectorOfStructs(translationsQ16);
+		auto roQ8 = builder.CreateVectorOfStructs(rotationsQ8);
+		auto roQ16 = builder.CreateVectorOfStructs(rotationsQ16);
+
+		const float byteRangeOut = (quantRanges != nullptr) ? (float)quantRanges->byteRange : 0.0f;
+		const float halfRangeOut = (quantRanges != nullptr) ? (float)quantRanges->halfRange : 0.0f;
+
+		return CreateSubjectUpdate(builder, oSubjectName, tr, ro, sc, cu,
+			/*predictor_id*/0, /*is_keyframe*/false,
+			byteRangeOut, halfRangeOut,
+			trQ8, trQ16, roQ8, roQ16, /*curves_q8*/0, /*curves_q16*/0);
 	}
 
 	flatbuffers::Offset<O3DS::Data::SubjectUpdate> Subject::SerializeUpdateResidual(flatbuffers::FlatBufferBuilder& builder, size_t& count, double deltaThreshold, double t, uint64_t seq)
@@ -638,7 +730,7 @@ flatbuffers::Offset<flatbuffers::Vector<const O3DS::Data::CurveUpdate *>> Subjec
 		return static_cast<int>(outbuf.size());
 	}
 
-	int Subject::SerializeUpdate(std::vector<char>& outbuf, size_t& count, double deltaThreshold, double timestamp)
+	int Subject::SerializeUpdate(std::vector<char>& outbuf, size_t& count, double deltaThreshold, double timestamp, const QuantRanges* quantRanges)
 	{
 		if (timestamp == 0.0)
 		{
@@ -648,7 +740,7 @@ flatbuffers::Offset<flatbuffers::Vector<const O3DS::Data::CurveUpdate *>> Subjec
 		flatbuffers::FlatBufferBuilder builder;
 
 		std::vector<flatbuffers::Offset<O3DS::Data::SubjectUpdate>> outSubjectUpdates;
-		outSubjectUpdates.push_back(this->SerializeUpdate(builder, count, deltaThreshold));
+		outSubjectUpdates.push_back(this->SerializeUpdate(builder, count, deltaThreshold, quantRanges));
 
 		auto ovSubjectUpdates = builder.CreateVector(outSubjectUpdates);
 
@@ -751,9 +843,10 @@ flatbuffers::Offset<flatbuffers::Vector<const O3DS::Data::CurveUpdate *>> Subjec
 
 		std::vector<flatbuffers::Offset<O3DS::Data::SubjectUpdate>> outSubjectUpdates;
 
+		const QuantRanges* quantRanges = mQuantizationEnabled ? &mQuantRanges : nullptr;
 		for (auto& subject : this->mItems)
 		{
-			outSubjectUpdates.push_back(subject->SerializeUpdate(builder, count, mDeltaThreshold));
+			outSubjectUpdates.push_back(subject->SerializeUpdate(builder, count, mDeltaThreshold, quantRanges));
 		}
 
 		auto ovSubjectUpdates = builder.CreateVector(outSubjectUpdates);
@@ -1009,6 +1102,15 @@ flatbuffers::Offset<flatbuffers::Vector<const O3DS::Data::CurveUpdate *>> Subjec
 					{
 						*inTranslation >> outTransform->translation;
 						outTransform->transformOrder.push_back(O3DS::TTranslation);
+
+						// D1 (roadmap doc §6/D1): mirrors the sender-side
+						// anchor capture in Subject::Serialize() above -
+						// both sides (re)anchor to the same full-sync value,
+						// so a later quantized delta update decodes
+						// correctly regardless of which side's clock it's
+						// measured against.
+						outTransform->mQuantAnchorTranslation = outTransform->translation.value;
+						outTransform->mQuantAnchorSet = true;
 					}
 					if (componentId == O3DS::Data::Component::Component_Rotation && inRotation != nullptr)
 					{
@@ -1071,6 +1173,51 @@ flatbuffers::Offset<flatbuffers::Vector<const O3DS::Data::CurveUpdate *>> Subjec
 			}
 		}
 
+		// D1 (roadmap doc §6/D1): quantized translation deltas are relative
+		// to this Transform's rest-pose anchor (see Transform::
+		// mQuantAnchorTranslation's own doc comment) - NOT the value
+		// currently sitting in translation.value, which the plain
+		// translations() loop above may not even have touched this frame.
+		// A Transform with no anchor yet (its first-ever full sync hasn't
+		// happened) has nothing safe to reconstruct against and is skipped;
+		// this shouldn't occur in practice with a matching sender - both
+		// sides always anchor at the same full sync (see Subject::Serialize
+		// and ParseSubject) - but a corrupt/adversarial buffer could still
+		// carry these fields for a channel that doesn't have one.
+		if (inUpdate->translations_q8()) {
+			const double byteRange = inUpdate->quant_byte_range();
+			for (auto inTranslation : *inUpdate->translations_q8())
+			{
+				id = inTranslation->i();
+				if (id < 0 || (size_t)id >= outSubject->mTransforms.size())
+					continue;
+				Transform* xf = outSubject->mTransforms[id];
+				if (!xf->mQuantAnchorSet)
+					continue;
+				xf->translation = O3DS::TransformTranslation(
+					xf->mQuantAnchorTranslation.v[0] + DequantizeByte(inTranslation->dx(), byteRange),
+					xf->mQuantAnchorTranslation.v[1] + DequantizeByte(inTranslation->dy(), byteRange),
+					xf->mQuantAnchorTranslation.v[2] + DequantizeByte(inTranslation->dz(), byteRange));
+			}
+		}
+
+		if (inUpdate->translations_q16()) {
+			const double halfRange = inUpdate->quant_half_range();
+			for (auto inTranslation : *inUpdate->translations_q16())
+			{
+				id = inTranslation->i();
+				if (id < 0 || (size_t)id >= outSubject->mTransforms.size())
+					continue;
+				Transform* xf = outSubject->mTransforms[id];
+				if (!xf->mQuantAnchorSet)
+					continue;
+				xf->translation = O3DS::TransformTranslation(
+					xf->mQuantAnchorTranslation.v[0] + DequantizeHalf(inTranslation->dx(), halfRange),
+					xf->mQuantAnchorTranslation.v[1] + DequantizeHalf(inTranslation->dy(), halfRange),
+					xf->mQuantAnchorTranslation.v[2] + DequantizeHalf(inTranslation->dz(), halfRange));
+			}
+		}
+
 		if (inUpdate->rotation()) {
 			for (auto inRotation : *inUpdate->rotation())
 			{
@@ -1079,6 +1226,42 @@ flatbuffers::Offset<flatbuffers::Vector<const O3DS::Data::CurveUpdate *>> Subjec
 					*inRotation >> outSubject->mTransforms[id]->rotation;
 				else
 					break;
+			}
+		}
+
+		// Quantized rotation is the ABSOLUTE value (smallest-three) - no
+		// anchor needed, unlike translation above.
+		if (inUpdate->rotations_q8()) {
+			for (auto inRotation : *inUpdate->rotations_q8())
+			{
+				id = inRotation->i();
+				if (id < 0 || (size_t)id >= outSubject->mTransforms.size())
+					continue;
+				SmallestThreeQ8 q;
+				q.droppedIndex = inRotation->dropped();
+				q.a = inRotation->a();
+				q.b = inRotation->b();
+				q.c = inRotation->c();
+				Quat decoded = DequantizeRotationByte(q);
+				outSubject->mTransforms[id]->rotation = O3DS::TransformRotation(
+					decoded.v[0], decoded.v[1], decoded.v[2], decoded.v[3]);
+			}
+		}
+
+		if (inUpdate->rotations_q16()) {
+			for (auto inRotation : *inUpdate->rotations_q16())
+			{
+				id = inRotation->i();
+				if (id < 0 || (size_t)id >= outSubject->mTransforms.size())
+					continue;
+				SmallestThreeQ16 q;
+				q.droppedIndex = inRotation->dropped();
+				q.a = inRotation->a();
+				q.b = inRotation->b();
+				q.c = inRotation->c();
+				Quat decoded = DequantizeRotationHalf(q);
+				outSubject->mTransforms[id]->rotation = O3DS::TransformRotation(
+					decoded.v[0], decoded.v[1], decoded.v[2], decoded.v[3]);
 			}
 		}
 

--- a/src/o3ds/model.cpp
+++ b/src/o3ds/model.cpp
@@ -585,8 +585,15 @@ flatbuffers::Offset<flatbuffers::Vector<const O3DS::Data::CurveUpdate *>> Subjec
 		auto roQ8 = rotationsQ8.empty() ? 0 : builder.CreateVectorOfStructs(rotationsQ8);
 		auto roQ16 = rotationsQ16.empty() ? 0 : builder.CreateVectorOfStructs(rotationsQ16);
 
-		const float byteRangeOut = (quantRanges != nullptr) ? (float)quantRanges->byteRange : 0.0f;
-		const float halfRangeOut = (quantRanges != nullptr) ? (float)quantRanges->halfRange : 0.0f;
+		// Only non-zero when actually needed to decode something in THIS
+		// update: rotation's smallest-three quantization needs no range at
+		// all (see RotationUpdateQ8/16's own doc comment), so an update
+		// with only quantized rotation channels (or none quantized at all)
+		// must not carry a stale non-zero range - that would contradict the
+		// schema's "0 == not used this update" contract and waste 4-8
+		// bytes for nothing.
+		const float byteRangeOut = translationsQ8.empty() ? 0.0f : (float)quantRanges->byteRange;
+		const float halfRangeOut = translationsQ16.empty() ? 0.0f : (float)quantRanges->halfRange;
 
 		return CreateSubjectUpdate(builder, oSubjectName, tr, ro, sc, cu,
 			/*predictor_id*/0, /*is_keyframe*/false,

--- a/src/o3ds/model.h
+++ b/src/o3ds/model.h
@@ -32,6 +32,7 @@ SOFTWARE.
 #include "context.h"
 #include "transform_component.h"
 #include "predict/residual_codec.h"
+#include "quant/channel_quant.h"
 #include "o3ds_generated.h"
 
 
@@ -71,6 +72,25 @@ namespace O3DS
 
 		void *mReference;
 
+		// D1 (roadmap doc §6/D1): rest-pose/bind-pose LOCAL translation
+		// anchor for legacy-mode quantization (Subject::SerializeUpdate/
+		// SubjectList::ParseUpdate's Byte/Half tiers - see quant/
+		// channel_quant.h). Deliberately NOT the last-SENT value (that
+		// would be a moving reference: one dropped packet on an unreliable
+		// transport permanently desyncs every later quantized delta,
+		// reintroducing exactly the history-divergence-under-loss problem
+		// D1 exists to avoid - see C2's own risk notes). Captured lazily,
+		// once, the first time quantization runs for this Transform, and
+		// held for this object's entire lifetime - it only "resets" when a
+		// topology change creates a brand-new Transform, matching "known
+		// from the skeleton descriptor" rather than per-frame state. A
+		// typical rigid skeleton's LOCAL (parent-relative, not world-space)
+		// translation stays near this anchor even during animation - only
+		// large local deviations (e.g. IK stretching, or a root bone whose
+		// local space is effectively world space) fall back to the Full
+		// tier, same safety net as today's deltaThreshold.
+		Vector3d mQuantAnchorTranslation = Vector3d(0.0, 0.0, 0.0);
+		bool     mQuantAnchorSet = false;
 	};
 
 	//! Platform specific builder to make a transform object
@@ -193,7 +213,22 @@ namespace O3DS
 
 		flatbuffers::Offset<O3DS::Data::Subject> Serialize(flatbuffers::FlatBufferBuilder& builder);
 
-		flatbuffers::Offset<O3DS::Data::SubjectUpdate> SerializeUpdate(flatbuffers::FlatBufferBuilder& builder, size_t& count, double deltaThreshold);
+		//! `quantRanges` (D1, roadmap doc §6/D1): when non-null, translation/
+		//! rotation channels that clear deltaThreshold are additionally
+		//! considered for adaptive quantization (Byte/Half tiers) instead of
+		//! always being sent at full float32 precision - see quant/
+		//! channel_quant.h. Translation quantizes a delta from this
+		//! Transform's rest-pose anchor (see Transform::
+		//! mQuantAnchorTranslation's own doc comment for why NOT a moving
+		//! last-sent reference); a Transform with no anchor yet (never gone
+		//! through a full Serialize()/ParseSubject()) always falls back to
+		//! Full for this call. Rotation quantizes the absolute value
+		//! (smallest-three, no anchor needed) and reuses the same
+		//! byteRange/halfRange thresholds against its own quaternion-space
+		//! delta() as a simple, classical tier-selection rule. Default
+		//! nullptr (disabled) leaves the wire byte-for-byte identical to
+		//! before D1 existed.
+		flatbuffers::Offset<O3DS::Data::SubjectUpdate> SerializeUpdate(flatbuffers::FlatBufferBuilder& builder, size_t& count, double deltaThreshold, const QuantRanges* quantRanges = nullptr);
 
 		// C2 (roadmap doc §5/C2): opt-in per-subject residual coding. Both
 		// members are null by default (legacy mode, unaffected). Whichever
@@ -233,7 +268,7 @@ namespace O3DS
 
 		int Serialize(std::vector<char>& outbuf, double timestamp);
 
-		int SerializeUpdate(std::vector<char>& outbuf, size_t& count, double deltaThreshold, double timestamp);
+		int SerializeUpdate(std::vector<char>& outbuf, size_t& count, double deltaThreshold, double timestamp, const QuantRanges* quantRanges = nullptr);
 
 		//! Self-contained residual-coded variant of the vector<char> overload
 		//! above, mirroring it exactly (builds its own FlatBufferBuilder and
@@ -309,6 +344,15 @@ namespace O3DS
 		double mTime;
 		double mDeltaThreshold;
 		std::string mError;
+
+		// D1 (roadmap doc §6/D1): opt-in adaptive channel quantization for
+		// SerializeUpdate() below, mirroring mDeltaThreshold's own
+		// member-not-parameter pattern. Disabled (false) by default -
+		// SerializeUpdate()'s wire output is then byte-for-byte identical
+		// to before D1 existed. mQuantRanges is only consulted when
+		// mQuantizationEnabled is true.
+		bool mQuantizationEnabled = false;
+		QuantRanges mQuantRanges;
 
 		//! Encode all of the items in the subject list as binary data.
 		//! tx_seq/tx_wallclock_us/frame_epoch are optional (0 == unset, the

--- a/src/o3ds/quant/channel_quant.cpp
+++ b/src/o3ds/quant/channel_quant.cpp
@@ -80,6 +80,18 @@ namespace O3DS
 
 	double DequantizeByte(int8_t code, double range)
 	{
+		// range comes straight from the wire (SubjectUpdate::quant_byte_range)
+		// on the decode path - untrusted network input. A non-finite or
+		// non-positive value would otherwise propagate an Infinity/NaN
+		// straight into Transform::translation.value, which nothing
+		// downstream (CalcMatrices()'s NaN check runs before translation is
+		// applied; Infinity isn't NaN anyway) would catch. Treat it the same
+		// as QuantizeByte already treats an invalid encode-side range: no
+		// usable delta.
+		if (!(range > 0.0) || !std::isfinite(range))
+		{
+			return 0.0;
+		}
 		return (static_cast<double>(code) / kByteMax) * range;
 	}
 
@@ -94,6 +106,11 @@ namespace O3DS
 
 	double DequantizeHalf(int16_t code, double range)
 	{
+		// See DequantizeByte's comment - same untrusted-wire-range guard.
+		if (!(range > 0.0) || !std::isfinite(range))
+		{
+			return 0.0;
+		}
 		return (static_cast<double>(code) / kHalfMax) * range;
 	}
 

--- a/src/o3ds/quant/channel_quant.cpp
+++ b/src/o3ds/quant/channel_quant.cpp
@@ -1,0 +1,211 @@
+/*
+Open 3D Stream
+
+Copyright 2026 Alastair Macleod
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#include "channel_quant.h"
+
+#include <algorithm>
+#include <cmath>
+
+namespace O3DS
+{
+	namespace
+	{
+		constexpr double kByteMax = 127.0;
+		constexpr double kHalfMax = 32767.0;
+
+		// Standard "smallest three" bound: for a unit quaternion, if the
+		// largest-magnitude component is dropped, each of the remaining
+		// three is bounded by 1/sqrt(2). Derivation: the dropped component
+		// d is the max of 4 non-negative squares summing to 1, so d^2 >=
+		// 1/4. For any other component c, c^2 <= d^2 (d is the max), and
+		// d^2 + c^2 <= 1 (both are among the 4 squares summing to 1), so
+		// 2*c^2 <= d^2 + c^2 <= 1, giving |c| <= 1/sqrt(2).
+		const double kSmallestThreeBound = 1.0 / std::sqrt(2.0);
+
+		int8_t ClampToByteCode(double raw)
+		{
+			double clamped = std::max(-kByteMax, std::min(kByteMax, raw));
+			return static_cast<int8_t>(std::lround(clamped));
+		}
+
+		int16_t ClampToHalfCode(double raw)
+		{
+			double clamped = std::max(-kHalfMax, std::min(kHalfMax, raw));
+			return static_cast<int16_t>(std::lround(clamped));
+		}
+	}
+
+	QuantTier ChooseScalarTier(double absDelta, const QuantRanges& ranges)
+	{
+		if (absDelta <= ranges.byteRange)
+		{
+			return QuantTier::Byte;
+		}
+		if (absDelta <= ranges.halfRange)
+		{
+			return QuantTier::Half;
+		}
+		return QuantTier::Full;
+	}
+
+	int8_t QuantizeByte(double delta, double range)
+	{
+		if (range <= 0.0)
+		{
+			return 0;
+		}
+		return ClampToByteCode((delta / range) * kByteMax);
+	}
+
+	double DequantizeByte(int8_t code, double range)
+	{
+		return (static_cast<double>(code) / kByteMax) * range;
+	}
+
+	int16_t QuantizeHalf(double delta, double range)
+	{
+		if (range <= 0.0)
+		{
+			return 0;
+		}
+		return ClampToHalfCode((delta / range) * kHalfMax);
+	}
+
+	double DequantizeHalf(int16_t code, double range)
+	{
+		return (static_cast<double>(code) / kHalfMax) * range;
+	}
+
+	namespace
+	{
+		// Shared encode-side logic for both smallest-three tiers: finds the
+		// largest-magnitude component, sign-normalizes so it's positive
+		// (q and -q are the same rotation), and returns its index plus the
+		// other three components in ascending index order.
+		void PrepareSmallestThree(const Quat& q, uint8_t& outDroppedIndex, double outOthers[3])
+		{
+			int maxIdx = 0;
+			double maxAbs = std::fabs(q.v[0]);
+			for (int i = 1; i < 4; ++i)
+			{
+				double a = std::fabs(q.v[i]);
+				if (a > maxAbs)
+				{
+					maxAbs = a;
+					maxIdx = i;
+				}
+			}
+
+			double sign = (q.v[maxIdx] < 0.0) ? -1.0 : 1.0;
+
+			int outIdx = 0;
+			for (int i = 0; i < 4; ++i)
+			{
+				if (i == maxIdx)
+				{
+					continue;
+				}
+				outOthers[outIdx++] = q.v[i] * sign;
+			}
+			outDroppedIndex = static_cast<uint8_t>(maxIdx);
+		}
+
+		// Shared decode-side logic: reconstructs the dropped component from
+		// the unit-length constraint (always non-negative by construction -
+		// see PrepareSmallestThree's sign normalization) and reassembles the
+		// full quaternion, then renormalizes to absorb quantization error
+		// (the roadmap's "decode always renormalizes cleanly" requirement).
+		Quat ReconstructSmallestThree(uint8_t droppedIndex, double a, double b, double c)
+		{
+			// droppedIndex is untrusted network input (wire byte, see
+			// RotationUpdateQ8/16 in o3ds.fbs) - a value outside [0,3] would
+			// otherwise never match the `i == droppedIndex` check below, so
+			// the loop would read others[3] on its 4th iteration, one past
+			// the end of the 3-element array. Clamp defensively rather than
+			// trust it.
+			if (droppedIndex > 3)
+			{
+				droppedIndex = 3;
+			}
+
+			double sumSq = a * a + b * b + c * c;
+			double dropped = std::sqrt(std::max(0.0, 1.0 - sumSq));
+
+			double comp[4];
+			int inIdx = 0;
+			double others[3] = { a, b, c };
+			for (int i = 0; i < 4; ++i)
+			{
+				if (i == droppedIndex)
+				{
+					comp[i] = dropped;
+				}
+				else
+				{
+					comp[i] = others[inIdx++];
+				}
+			}
+
+			return QuatNormalize(Quat(comp[0], comp[1], comp[2], comp[3]));
+		}
+	}
+
+	SmallestThreeQ8 QuantizeRotationByte(const Quat& q)
+	{
+		SmallestThreeQ8 out;
+		double others[3];
+		PrepareSmallestThree(q, out.droppedIndex, others);
+		out.a = ClampToByteCode((others[0] / kSmallestThreeBound) * kByteMax);
+		out.b = ClampToByteCode((others[1] / kSmallestThreeBound) * kByteMax);
+		out.c = ClampToByteCode((others[2] / kSmallestThreeBound) * kByteMax);
+		return out;
+	}
+
+	Quat DequantizeRotationByte(const SmallestThreeQ8& q)
+	{
+		double a = (static_cast<double>(q.a) / kByteMax) * kSmallestThreeBound;
+		double b = (static_cast<double>(q.b) / kByteMax) * kSmallestThreeBound;
+		double c = (static_cast<double>(q.c) / kByteMax) * kSmallestThreeBound;
+		return ReconstructSmallestThree(q.droppedIndex, a, b, c);
+	}
+
+	SmallestThreeQ16 QuantizeRotationHalf(const Quat& q)
+	{
+		SmallestThreeQ16 out;
+		double others[3];
+		PrepareSmallestThree(q, out.droppedIndex, others);
+		out.a = ClampToHalfCode((others[0] / kSmallestThreeBound) * kHalfMax);
+		out.b = ClampToHalfCode((others[1] / kSmallestThreeBound) * kHalfMax);
+		out.c = ClampToHalfCode((others[2] / kSmallestThreeBound) * kHalfMax);
+		return out;
+	}
+
+	Quat DequantizeRotationHalf(const SmallestThreeQ16& q)
+	{
+		double a = (static_cast<double>(q.a) / kHalfMax) * kSmallestThreeBound;
+		double b = (static_cast<double>(q.b) / kHalfMax) * kSmallestThreeBound;
+		double c = (static_cast<double>(q.c) / kHalfMax) * kSmallestThreeBound;
+		return ReconstructSmallestThree(q.droppedIndex, a, b, c);
+	}
+}

--- a/src/o3ds/quant/channel_quant.h
+++ b/src/o3ds/quant/channel_quant.h
@@ -1,0 +1,114 @@
+/*
+Open 3D Stream
+
+Copyright 2026 Alastair Macleod
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#ifndef O3DS_QUANT_CHANNEL_QUANT_H
+#define O3DS_QUANT_CHANNEL_QUANT_H
+
+#include <cstdint>
+#include "../predict/quat_math.h"
+
+// Adaptive/variable-precision channel quantization (roadmap doc, Workstream
+// D/D1). Pure math, FlatBuffers- and wire-format-agnostic - deliberately
+// mirrors predict/residual_codec.h's separation of "the algorithm" from "how
+// it's put on the wire" (see model.cpp/o3ds.fbs for the wire integration).
+//
+// Two independent quantization schemes live here:
+//  - Scalar delta quantization (translation/scale components, curves): the
+//    VALUE BEING QUANTIZED must already be a bounded delta (e.g. actual minus
+//    a reference both sides already know - the legacy last-sent value, or
+//    C2's ResidualEncoder::Reference()) - world-space absolutes are not
+//    bounded and are not what this quantizes.
+//  - Smallest-three quaternion quantization (rotation): quantizes the
+//    ABSOLUTE rotation directly, since unit-quaternion components are
+//    inherently bounded to [-1, 1] - no caller-supplied range needed.
+namespace O3DS
+{
+	//! Precision tier chosen per channel, self-describing on the wire
+	//! (SubjectUpdate's new quantized vectors, one per tier). 0 == Full
+	//! deliberately matches the "0 == legacy/unquantized" convention already
+	//! used for predictor_id (see O3DS::ResidualPredictorId) - never encode
+	//! a real quantized tier as 0.
+	enum class QuantTier : uint8_t
+	{
+		Full = 0, //!< No quantization; today's full float32, unconditionally lossless.
+		Half = 1, //!< 16-bit fixed-point.
+		Byte = 2, //!< 8-bit fixed-point.
+	};
+
+	//! Configurable bounds (in the value's own units) for the Byte/Half
+	//! tiers of scalar delta quantization. A delta whose magnitude exceeds
+	//! halfRange always falls back to QuantTier::Full - the "large/fast
+	//! movement -> full float ceiling" safety net the roadmap calls for, so
+	//! there is never a case where a channel's precision is *worse* than
+	//! today's unconditional float32.
+	struct QuantRanges
+	{
+		double byteRange = 0.01; //!< Max |delta| representable at Byte tier.
+		double halfRange = 1.0;  //!< Max |delta| representable at Half tier.
+	};
+
+	//! Chooses the smallest tier that can represent absDelta (already
+	//! std::abs'd by the caller) within ranges, without clamping/losing
+	//! range - Full if absDelta exceeds halfRange.
+	QuantTier ChooseScalarTier(double absDelta, const QuantRanges& ranges);
+
+	//! Quantizes delta (already known to satisfy |delta| <= range - callers
+	//! choose range via ChooseScalarTier first) to a signed 8-bit code.
+	//! Clamps defensively if called with an out-of-range delta rather than
+	//! wrapping/overflowing.
+	int8_t QuantizeByte(double delta, double range);
+	double DequantizeByte(int8_t code, double range);
+
+	//! 16-bit counterpart of QuantizeByte/DequantizeByte.
+	int16_t QuantizeHalf(double delta, double range);
+	double DequantizeHalf(int16_t code, double range);
+
+	//! Smallest-three quaternion quantization: drops the largest-magnitude
+	//! component (reconstructed on decode from the unit-length constraint),
+	//! storing which axis was dropped (0=x,1=y,2=z,3=w) plus the other three
+	//! components quantized against the standard 1/sqrt(2) bound (see
+	//! channel_quant.cpp for the derivation). If the dropped component's
+	//! original sign was negative, the whole quaternion is negated first
+	//! (q and -q represent the same rotation) so the dropped component's
+	//! reconstructed sign (always positive) matches.
+	struct SmallestThreeQ8
+	{
+		uint8_t droppedIndex = 3;
+		int8_t a = 0, b = 0, c = 0; //!< The other three components, in ascending index order.
+	};
+
+	struct SmallestThreeQ16
+	{
+		uint8_t droppedIndex = 3;
+		int16_t a = 0, b = 0, c = 0;
+	};
+
+	SmallestThreeQ8 QuantizeRotationByte(const Quat& q);
+	Quat DequantizeRotationByte(const SmallestThreeQ8& q);
+
+	SmallestThreeQ16 QuantizeRotationHalf(const Quat& q);
+	Quat DequantizeRotationHalf(const SmallestThreeQ16& q);
+}
+
+#endif

--- a/src/o3ds_generated.h
+++ b/src/o3ds_generated.h
@@ -23,6 +23,18 @@ struct RotationUpdate;
 
 struct ScaleUpdate;
 
+struct TranslationUpdateQ8;
+
+struct TranslationUpdateQ16;
+
+struct CurveUpdateQ8;
+
+struct CurveUpdateQ16;
+
+struct RotationUpdateQ8;
+
+struct RotationUpdateQ16;
+
 struct Transform;
 struct TransformBuilder;
 
@@ -432,6 +444,233 @@ FLATBUFFERS_MANUALLY_ALIGNED_STRUCT(4) ScaleUpdate FLATBUFFERS_FINAL_CLASS {
 };
 FLATBUFFERS_STRUCT_END(ScaleUpdate, 16);
 
+FLATBUFFERS_MANUALLY_ALIGNED_STRUCT(4) TranslationUpdateQ8 FLATBUFFERS_FINAL_CLASS {
+ private:
+  int8_t dx_;
+  int8_t dy_;
+  int8_t dz_;
+  int8_t padding0__;
+  int32_t i_;
+
+ public:
+  TranslationUpdateQ8()
+      : dx_(0),
+        dy_(0),
+        dz_(0),
+        padding0__(0),
+        i_(0) {
+    (void)padding0__;
+  }
+  TranslationUpdateQ8(int8_t _dx, int8_t _dy, int8_t _dz, int32_t _i)
+      : dx_(flatbuffers::EndianScalar(_dx)),
+        dy_(flatbuffers::EndianScalar(_dy)),
+        dz_(flatbuffers::EndianScalar(_dz)),
+        padding0__(0),
+        i_(flatbuffers::EndianScalar(_i)) {
+    (void)padding0__;
+  }
+  int8_t dx() const {
+    return flatbuffers::EndianScalar(dx_);
+  }
+  int8_t dy() const {
+    return flatbuffers::EndianScalar(dy_);
+  }
+  int8_t dz() const {
+    return flatbuffers::EndianScalar(dz_);
+  }
+  int32_t i() const {
+    return flatbuffers::EndianScalar(i_);
+  }
+};
+FLATBUFFERS_STRUCT_END(TranslationUpdateQ8, 8);
+
+FLATBUFFERS_MANUALLY_ALIGNED_STRUCT(4) TranslationUpdateQ16 FLATBUFFERS_FINAL_CLASS {
+ private:
+  int16_t dx_;
+  int16_t dy_;
+  int16_t dz_;
+  int16_t padding0__;
+  int32_t i_;
+
+ public:
+  TranslationUpdateQ16()
+      : dx_(0),
+        dy_(0),
+        dz_(0),
+        padding0__(0),
+        i_(0) {
+    (void)padding0__;
+  }
+  TranslationUpdateQ16(int16_t _dx, int16_t _dy, int16_t _dz, int32_t _i)
+      : dx_(flatbuffers::EndianScalar(_dx)),
+        dy_(flatbuffers::EndianScalar(_dy)),
+        dz_(flatbuffers::EndianScalar(_dz)),
+        padding0__(0),
+        i_(flatbuffers::EndianScalar(_i)) {
+    (void)padding0__;
+  }
+  int16_t dx() const {
+    return flatbuffers::EndianScalar(dx_);
+  }
+  int16_t dy() const {
+    return flatbuffers::EndianScalar(dy_);
+  }
+  int16_t dz() const {
+    return flatbuffers::EndianScalar(dz_);
+  }
+  int32_t i() const {
+    return flatbuffers::EndianScalar(i_);
+  }
+};
+FLATBUFFERS_STRUCT_END(TranslationUpdateQ16, 12);
+
+FLATBUFFERS_MANUALLY_ALIGNED_STRUCT(4) CurveUpdateQ8 FLATBUFFERS_FINAL_CLASS {
+ private:
+  int8_t dv_;
+  int8_t padding0__;  int16_t padding1__;
+  int32_t i_;
+
+ public:
+  CurveUpdateQ8()
+      : dv_(0),
+        padding0__(0),
+        padding1__(0),
+        i_(0) {
+    (void)padding0__;
+    (void)padding1__;
+  }
+  CurveUpdateQ8(int8_t _dv, int32_t _i)
+      : dv_(flatbuffers::EndianScalar(_dv)),
+        padding0__(0),
+        padding1__(0),
+        i_(flatbuffers::EndianScalar(_i)) {
+    (void)padding0__;
+    (void)padding1__;
+  }
+  int8_t dv() const {
+    return flatbuffers::EndianScalar(dv_);
+  }
+  int32_t i() const {
+    return flatbuffers::EndianScalar(i_);
+  }
+};
+FLATBUFFERS_STRUCT_END(CurveUpdateQ8, 8);
+
+FLATBUFFERS_MANUALLY_ALIGNED_STRUCT(4) CurveUpdateQ16 FLATBUFFERS_FINAL_CLASS {
+ private:
+  int16_t dv_;
+  int16_t padding0__;
+  int32_t i_;
+
+ public:
+  CurveUpdateQ16()
+      : dv_(0),
+        padding0__(0),
+        i_(0) {
+    (void)padding0__;
+  }
+  CurveUpdateQ16(int16_t _dv, int32_t _i)
+      : dv_(flatbuffers::EndianScalar(_dv)),
+        padding0__(0),
+        i_(flatbuffers::EndianScalar(_i)) {
+    (void)padding0__;
+  }
+  int16_t dv() const {
+    return flatbuffers::EndianScalar(dv_);
+  }
+  int32_t i() const {
+    return flatbuffers::EndianScalar(i_);
+  }
+};
+FLATBUFFERS_STRUCT_END(CurveUpdateQ16, 8);
+
+FLATBUFFERS_MANUALLY_ALIGNED_STRUCT(4) RotationUpdateQ8 FLATBUFFERS_FINAL_CLASS {
+ private:
+  uint8_t dropped_;
+  int8_t a_;
+  int8_t b_;
+  int8_t c_;
+  int32_t i_;
+
+ public:
+  RotationUpdateQ8()
+      : dropped_(0),
+        a_(0),
+        b_(0),
+        c_(0),
+        i_(0) {
+  }
+  RotationUpdateQ8(uint8_t _dropped, int8_t _a, int8_t _b, int8_t _c, int32_t _i)
+      : dropped_(flatbuffers::EndianScalar(_dropped)),
+        a_(flatbuffers::EndianScalar(_a)),
+        b_(flatbuffers::EndianScalar(_b)),
+        c_(flatbuffers::EndianScalar(_c)),
+        i_(flatbuffers::EndianScalar(_i)) {
+  }
+  uint8_t dropped() const {
+    return flatbuffers::EndianScalar(dropped_);
+  }
+  int8_t a() const {
+    return flatbuffers::EndianScalar(a_);
+  }
+  int8_t b() const {
+    return flatbuffers::EndianScalar(b_);
+  }
+  int8_t c() const {
+    return flatbuffers::EndianScalar(c_);
+  }
+  int32_t i() const {
+    return flatbuffers::EndianScalar(i_);
+  }
+};
+FLATBUFFERS_STRUCT_END(RotationUpdateQ8, 8);
+
+FLATBUFFERS_MANUALLY_ALIGNED_STRUCT(4) RotationUpdateQ16 FLATBUFFERS_FINAL_CLASS {
+ private:
+  uint8_t dropped_;
+  int8_t padding0__;
+  int16_t a_;
+  int16_t b_;
+  int16_t c_;
+  int32_t i_;
+
+ public:
+  RotationUpdateQ16()
+      : dropped_(0),
+        padding0__(0),
+        a_(0),
+        b_(0),
+        c_(0),
+        i_(0) {
+    (void)padding0__;
+  }
+  RotationUpdateQ16(uint8_t _dropped, int16_t _a, int16_t _b, int16_t _c, int32_t _i)
+      : dropped_(flatbuffers::EndianScalar(_dropped)),
+        padding0__(0),
+        a_(flatbuffers::EndianScalar(_a)),
+        b_(flatbuffers::EndianScalar(_b)),
+        c_(flatbuffers::EndianScalar(_c)),
+        i_(flatbuffers::EndianScalar(_i)) {
+    (void)padding0__;
+  }
+  uint8_t dropped() const {
+    return flatbuffers::EndianScalar(dropped_);
+  }
+  int16_t a() const {
+    return flatbuffers::EndianScalar(a_);
+  }
+  int16_t b() const {
+    return flatbuffers::EndianScalar(b_);
+  }
+  int16_t c() const {
+    return flatbuffers::EndianScalar(c_);
+  }
+  int32_t i() const {
+    return flatbuffers::EndianScalar(i_);
+  }
+};
+FLATBUFFERS_STRUCT_END(RotationUpdateQ16, 12);
+
 FLATBUFFERS_MANUALLY_ALIGNED_STRUCT(4) CurveUpdate FLATBUFFERS_FINAL_CLASS {
  private:
   float value_;
@@ -722,7 +961,15 @@ struct SubjectUpdate FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
     VT_SCALE = 10,
     VT_CURVES = 12,
     VT_PREDICTOR_ID = 14,
-    VT_IS_KEYFRAME = 16
+    VT_IS_KEYFRAME = 16,
+    VT_QUANT_BYTE_RANGE = 18,
+    VT_QUANT_HALF_RANGE = 20,
+    VT_TRANSLATIONS_Q8 = 22,
+    VT_TRANSLATIONS_Q16 = 24,
+    VT_ROTATIONS_Q8 = 26,
+    VT_ROTATIONS_Q16 = 28,
+    VT_CURVES_Q8 = 30,
+    VT_CURVES_Q16 = 32
   };
   const flatbuffers::String *name() const {
     return GetPointer<const flatbuffers::String *>(VT_NAME);
@@ -745,6 +992,30 @@ struct SubjectUpdate FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   bool is_keyframe() const {
     return GetField<uint8_t>(VT_IS_KEYFRAME, 0) != 0;
   }
+  float quant_byte_range() const {
+    return GetField<float>(VT_QUANT_BYTE_RANGE, 0.0f);
+  }
+  float quant_half_range() const {
+    return GetField<float>(VT_QUANT_HALF_RANGE, 0.0f);
+  }
+  const flatbuffers::Vector<const O3DS::Data::TranslationUpdateQ8 *> *translations_q8() const {
+    return GetPointer<const flatbuffers::Vector<const O3DS::Data::TranslationUpdateQ8 *> *>(VT_TRANSLATIONS_Q8);
+  }
+  const flatbuffers::Vector<const O3DS::Data::TranslationUpdateQ16 *> *translations_q16() const {
+    return GetPointer<const flatbuffers::Vector<const O3DS::Data::TranslationUpdateQ16 *> *>(VT_TRANSLATIONS_Q16);
+  }
+  const flatbuffers::Vector<const O3DS::Data::RotationUpdateQ8 *> *rotations_q8() const {
+    return GetPointer<const flatbuffers::Vector<const O3DS::Data::RotationUpdateQ8 *> *>(VT_ROTATIONS_Q8);
+  }
+  const flatbuffers::Vector<const O3DS::Data::RotationUpdateQ16 *> *rotations_q16() const {
+    return GetPointer<const flatbuffers::Vector<const O3DS::Data::RotationUpdateQ16 *> *>(VT_ROTATIONS_Q16);
+  }
+  const flatbuffers::Vector<const O3DS::Data::CurveUpdateQ8 *> *curves_q8() const {
+    return GetPointer<const flatbuffers::Vector<const O3DS::Data::CurveUpdateQ8 *> *>(VT_CURVES_Q8);
+  }
+  const flatbuffers::Vector<const O3DS::Data::CurveUpdateQ16 *> *curves_q16() const {
+    return GetPointer<const flatbuffers::Vector<const O3DS::Data::CurveUpdateQ16 *> *>(VT_CURVES_Q16);
+  }
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
            VerifyOffset(verifier, VT_NAME) &&
@@ -759,6 +1030,20 @@ struct SubjectUpdate FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
            verifier.VerifyVector(curves()) &&
            VerifyField<uint32_t>(verifier, VT_PREDICTOR_ID, 4) &&
            VerifyField<uint8_t>(verifier, VT_IS_KEYFRAME, 1) &&
+           VerifyField<float>(verifier, VT_QUANT_BYTE_RANGE, 4) &&
+           VerifyField<float>(verifier, VT_QUANT_HALF_RANGE, 4) &&
+           VerifyOffset(verifier, VT_TRANSLATIONS_Q8) &&
+           verifier.VerifyVector(translations_q8()) &&
+           VerifyOffset(verifier, VT_TRANSLATIONS_Q16) &&
+           verifier.VerifyVector(translations_q16()) &&
+           VerifyOffset(verifier, VT_ROTATIONS_Q8) &&
+           verifier.VerifyVector(rotations_q8()) &&
+           VerifyOffset(verifier, VT_ROTATIONS_Q16) &&
+           verifier.VerifyVector(rotations_q16()) &&
+           VerifyOffset(verifier, VT_CURVES_Q8) &&
+           verifier.VerifyVector(curves_q8()) &&
+           VerifyOffset(verifier, VT_CURVES_Q16) &&
+           verifier.VerifyVector(curves_q16()) &&
            verifier.EndTable();
   }
 };
@@ -788,6 +1073,30 @@ struct SubjectUpdateBuilder {
   void add_is_keyframe(bool is_keyframe) {
     fbb_.AddElement<uint8_t>(SubjectUpdate::VT_IS_KEYFRAME, static_cast<uint8_t>(is_keyframe), 0);
   }
+  void add_quant_byte_range(float quant_byte_range) {
+    fbb_.AddElement<float>(SubjectUpdate::VT_QUANT_BYTE_RANGE, quant_byte_range, 0.0f);
+  }
+  void add_quant_half_range(float quant_half_range) {
+    fbb_.AddElement<float>(SubjectUpdate::VT_QUANT_HALF_RANGE, quant_half_range, 0.0f);
+  }
+  void add_translations_q8(flatbuffers::Offset<flatbuffers::Vector<const O3DS::Data::TranslationUpdateQ8 *>> translations_q8) {
+    fbb_.AddOffset(SubjectUpdate::VT_TRANSLATIONS_Q8, translations_q8);
+  }
+  void add_translations_q16(flatbuffers::Offset<flatbuffers::Vector<const O3DS::Data::TranslationUpdateQ16 *>> translations_q16) {
+    fbb_.AddOffset(SubjectUpdate::VT_TRANSLATIONS_Q16, translations_q16);
+  }
+  void add_rotations_q8(flatbuffers::Offset<flatbuffers::Vector<const O3DS::Data::RotationUpdateQ8 *>> rotations_q8) {
+    fbb_.AddOffset(SubjectUpdate::VT_ROTATIONS_Q8, rotations_q8);
+  }
+  void add_rotations_q16(flatbuffers::Offset<flatbuffers::Vector<const O3DS::Data::RotationUpdateQ16 *>> rotations_q16) {
+    fbb_.AddOffset(SubjectUpdate::VT_ROTATIONS_Q16, rotations_q16);
+  }
+  void add_curves_q8(flatbuffers::Offset<flatbuffers::Vector<const O3DS::Data::CurveUpdateQ8 *>> curves_q8) {
+    fbb_.AddOffset(SubjectUpdate::VT_CURVES_Q8, curves_q8);
+  }
+  void add_curves_q16(flatbuffers::Offset<flatbuffers::Vector<const O3DS::Data::CurveUpdateQ16 *>> curves_q16) {
+    fbb_.AddOffset(SubjectUpdate::VT_CURVES_Q16, curves_q16);
+  }
   explicit SubjectUpdateBuilder(flatbuffers::FlatBufferBuilder &_fbb)
         : fbb_(_fbb) {
     start_ = fbb_.StartTable();
@@ -807,8 +1116,24 @@ inline flatbuffers::Offset<SubjectUpdate> CreateSubjectUpdate(
     flatbuffers::Offset<flatbuffers::Vector<const O3DS::Data::ScaleUpdate *>> scale = 0,
     flatbuffers::Offset<flatbuffers::Vector<const O3DS::Data::CurveUpdate *>> curves = 0,
     uint32_t predictor_id = 0,
-    bool is_keyframe = false) {
+    bool is_keyframe = false,
+    float quant_byte_range = 0.0f,
+    float quant_half_range = 0.0f,
+    flatbuffers::Offset<flatbuffers::Vector<const O3DS::Data::TranslationUpdateQ8 *>> translations_q8 = 0,
+    flatbuffers::Offset<flatbuffers::Vector<const O3DS::Data::TranslationUpdateQ16 *>> translations_q16 = 0,
+    flatbuffers::Offset<flatbuffers::Vector<const O3DS::Data::RotationUpdateQ8 *>> rotations_q8 = 0,
+    flatbuffers::Offset<flatbuffers::Vector<const O3DS::Data::RotationUpdateQ16 *>> rotations_q16 = 0,
+    flatbuffers::Offset<flatbuffers::Vector<const O3DS::Data::CurveUpdateQ8 *>> curves_q8 = 0,
+    flatbuffers::Offset<flatbuffers::Vector<const O3DS::Data::CurveUpdateQ16 *>> curves_q16 = 0) {
   SubjectUpdateBuilder builder_(_fbb);
+  builder_.add_curves_q16(curves_q16);
+  builder_.add_curves_q8(curves_q8);
+  builder_.add_rotations_q16(rotations_q16);
+  builder_.add_rotations_q8(rotations_q8);
+  builder_.add_translations_q16(translations_q16);
+  builder_.add_translations_q8(translations_q8);
+  builder_.add_quant_half_range(quant_half_range);
+  builder_.add_quant_byte_range(quant_byte_range);
   builder_.add_predictor_id(predictor_id);
   builder_.add_curves(curves);
   builder_.add_scale(scale);
@@ -827,12 +1152,26 @@ inline flatbuffers::Offset<SubjectUpdate> CreateSubjectUpdateDirect(
     const std::vector<O3DS::Data::ScaleUpdate> *scale = nullptr,
     const std::vector<O3DS::Data::CurveUpdate> *curves = nullptr,
     uint32_t predictor_id = 0,
-    bool is_keyframe = false) {
+    bool is_keyframe = false,
+    float quant_byte_range = 0.0f,
+    float quant_half_range = 0.0f,
+    const std::vector<O3DS::Data::TranslationUpdateQ8> *translations_q8 = nullptr,
+    const std::vector<O3DS::Data::TranslationUpdateQ16> *translations_q16 = nullptr,
+    const std::vector<O3DS::Data::RotationUpdateQ8> *rotations_q8 = nullptr,
+    const std::vector<O3DS::Data::RotationUpdateQ16> *rotations_q16 = nullptr,
+    const std::vector<O3DS::Data::CurveUpdateQ8> *curves_q8 = nullptr,
+    const std::vector<O3DS::Data::CurveUpdateQ16> *curves_q16 = nullptr) {
   auto name__ = name ? _fbb.CreateString(name) : 0;
   auto translations__ = translations ? _fbb.CreateVectorOfStructs<O3DS::Data::TranslationUpdate>(*translations) : 0;
   auto rotation__ = rotation ? _fbb.CreateVectorOfStructs<O3DS::Data::RotationUpdate>(*rotation) : 0;
   auto scale__ = scale ? _fbb.CreateVectorOfStructs<O3DS::Data::ScaleUpdate>(*scale) : 0;
   auto curves__ = curves ? _fbb.CreateVectorOfStructs<O3DS::Data::CurveUpdate>(*curves) : 0;
+  auto translations_q8__ = translations_q8 ? _fbb.CreateVectorOfStructs<O3DS::Data::TranslationUpdateQ8>(*translations_q8) : 0;
+  auto translations_q16__ = translations_q16 ? _fbb.CreateVectorOfStructs<O3DS::Data::TranslationUpdateQ16>(*translations_q16) : 0;
+  auto rotations_q8__ = rotations_q8 ? _fbb.CreateVectorOfStructs<O3DS::Data::RotationUpdateQ8>(*rotations_q8) : 0;
+  auto rotations_q16__ = rotations_q16 ? _fbb.CreateVectorOfStructs<O3DS::Data::RotationUpdateQ16>(*rotations_q16) : 0;
+  auto curves_q8__ = curves_q8 ? _fbb.CreateVectorOfStructs<O3DS::Data::CurveUpdateQ8>(*curves_q8) : 0;
+  auto curves_q16__ = curves_q16 ? _fbb.CreateVectorOfStructs<O3DS::Data::CurveUpdateQ16>(*curves_q16) : 0;
   return O3DS::Data::CreateSubjectUpdate(
       _fbb,
       name__,
@@ -841,7 +1180,15 @@ inline flatbuffers::Offset<SubjectUpdate> CreateSubjectUpdateDirect(
       scale__,
       curves__,
       predictor_id,
-      is_keyframe);
+      is_keyframe,
+      quant_byte_range,
+      quant_half_range,
+      translations_q8__,
+      translations_q16__,
+      rotations_q8__,
+      rotations_q16__,
+      curves_q8__,
+      curves_q16__);
 }
 
 struct SubjectList FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -20,6 +20,8 @@ add_executable(o3ds_core_tests
 	udp_fragment_tests.cpp
 	residual_codec_tests.cpp
 	model_residual_tests.cpp
+	channel_quant_tests.cpp
+	channel_quant_wire_tests.cpp
 )
 
 target_link_libraries(o3ds_core_tests PRIVATE open3dstreamstatic)

--- a/test/channel_quant_tests.cpp
+++ b/test/channel_quant_tests.cpp
@@ -1,0 +1,221 @@
+// Acceptance matrix for src/o3ds/quant/channel_quant.* (roadmap doc,
+// Workstream D/D1). Pure math round-trip tests, independent of the
+// FlatBuffers wire integration (see model.cpp/o3ds.fbs for that).
+#include "test_framework.h"
+
+#include "o3ds/quant/channel_quant.h"
+
+#include <cmath>
+
+using namespace O3DS;
+
+namespace
+{
+	bool NearlyEqual(double a, double b, double tol)
+	{
+		return std::abs(a - b) < tol;
+	}
+
+	// Angle (radians) between two unit quaternions, taking the shortest
+	// path (q and -q represent the same rotation).
+	double QuatAngleDelta(const Quat& a, const Quat& b)
+	{
+		double dot = a.v[0] * b.v[0] + a.v[1] * b.v[1] + a.v[2] * b.v[2] + a.v[3] * b.v[3];
+		dot = std::max(-1.0, std::min(1.0, std::fabs(dot)));
+		return 2.0 * std::acos(dot);
+	}
+}
+
+O3DS_TEST(ChooseScalarTier_PicksByteForSmallDelta)
+{
+	QuantRanges ranges;
+	ranges.byteRange = 0.01;
+	ranges.halfRange = 1.0;
+	O3DS_CHECK(ChooseScalarTier(0.001, ranges) == QuantTier::Byte);
+	O3DS_CHECK(ChooseScalarTier(0.01, ranges) == QuantTier::Byte);
+}
+
+O3DS_TEST(ChooseScalarTier_PicksHalfForMediumDelta)
+{
+	QuantRanges ranges;
+	ranges.byteRange = 0.01;
+	ranges.halfRange = 1.0;
+	O3DS_CHECK(ChooseScalarTier(0.5, ranges) == QuantTier::Half);
+	O3DS_CHECK(ChooseScalarTier(1.0, ranges) == QuantTier::Half);
+}
+
+O3DS_TEST(ChooseScalarTier_FallsBackToFullBeyondHalfRange)
+{
+	QuantRanges ranges;
+	ranges.byteRange = 0.01;
+	ranges.halfRange = 1.0;
+	O3DS_CHECK(ChooseScalarTier(1.0001, ranges) == QuantTier::Full);
+	O3DS_CHECK(ChooseScalarTier(1000.0, ranges) == QuantTier::Full);
+}
+
+O3DS_TEST(QuantizeByte_RoundTripsWithinExpectedResolution)
+{
+	const double range = 0.01;
+	for (double v = -range; v <= range; v += range / 20.0)
+	{
+		int8_t code = QuantizeByte(v, range);
+		double back = DequantizeByte(code, range);
+		// Resolution at this range is range/127 per step.
+		O3DS_CHECK(NearlyEqual(back, v, (range / 127.0) + 1.0e-12));
+	}
+}
+
+O3DS_TEST(QuantizeByte_ClampsOutOfRangeInputInsteadOfOverflowing)
+{
+	const double range = 0.01;
+	int8_t codeHigh = QuantizeByte(range * 100.0, range);
+	int8_t codeLow = QuantizeByte(-range * 100.0, range);
+	O3DS_CHECK(codeHigh == 127);
+	O3DS_CHECK(codeLow == -127);
+}
+
+O3DS_TEST(QuantizeByte_ZeroRoundTripsExactly)
+{
+	const double range = 0.01;
+	O3DS_CHECK(QuantizeByte(0.0, range) == 0);
+	O3DS_CHECK(NearlyEqual(DequantizeByte(0, range), 0.0, 1.0e-12));
+}
+
+O3DS_TEST(QuantizeHalf_RoundTripsWithinExpectedResolution)
+{
+	const double range = 1.0;
+	for (double v = -range; v <= range; v += range / 50.0)
+	{
+		int16_t code = QuantizeHalf(v, range);
+		double back = DequantizeHalf(code, range);
+		O3DS_CHECK(NearlyEqual(back, v, (range / 32767.0) + 1.0e-12));
+	}
+}
+
+O3DS_TEST(QuantizeHalf_ClampsOutOfRangeInputInsteadOfOverflowing)
+{
+	const double range = 1.0;
+	int16_t codeHigh = QuantizeHalf(range * 100.0, range);
+	int16_t codeLow = QuantizeHalf(-range * 100.0, range);
+	O3DS_CHECK(codeHigh == 32767);
+	O3DS_CHECK(codeLow == -32767);
+}
+
+O3DS_TEST(QuantizeHalf_IsMeaningfullyMorePreciseThanByte)
+{
+	// D1's whole premise: Half must resolve finer detail than Byte at the
+	// same range - otherwise there'd be no reason for a Half tier to exist.
+	const double range = 1.0;
+	int8_t byteCode = QuantizeByte(0.123456, range);
+	int16_t halfCode = QuantizeHalf(0.123456, range);
+	double byteBack = DequantizeByte(byteCode, range);
+	double halfBack = DequantizeHalf(halfCode, range);
+	double byteError = std::abs(byteBack - 0.123456);
+	double halfError = std::abs(halfBack - 0.123456);
+	O3DS_CHECK(halfError < byteError);
+}
+
+O3DS_TEST(RotationByte_RoundTripsIdentity)
+{
+	Quat identity = QuatIdentity();
+	SmallestThreeQ8 encoded = QuantizeRotationByte(identity);
+	Quat decoded = DequantizeRotationByte(encoded);
+	O3DS_CHECK(QuatAngleDelta(identity, decoded) < 0.05);
+}
+
+O3DS_TEST(RotationByte_RoundTripsAxisAlignedRotations)
+{
+	// One rotation per principal axis, each landing a different component
+	// as "largest" (dropped) to exercise all four droppedIndex cases.
+	Quat rotations[] = {
+		QuatFromAxisAngle(Vector3d(1.0, 0.0, 0.0), rad(37.0)),
+		QuatFromAxisAngle(Vector3d(0.0, 1.0, 0.0), rad(75.0)),
+		QuatFromAxisAngle(Vector3d(0.0, 0.0, 1.0), rad(112.0)),
+		QuatFromAxisAngle(Vector3d(1.0, 1.0, 1.0), rad(15.0)),
+	};
+	for (const Quat& q : rotations)
+	{
+		SmallestThreeQ8 encoded = QuantizeRotationByte(q);
+		Quat decoded = DequantizeRotationByte(encoded);
+		// Byte tier is coarse (~1/127 per component) - allow a generous
+		// angular tolerance, just confirming it's in the right neighborhood
+		// and not catastrophically wrong (e.g. wrong dropped-axis bug).
+		O3DS_CHECK(QuatAngleDelta(q, decoded) < rad(5.0));
+	}
+}
+
+O3DS_TEST(RotationHalf_RoundTripsAxisAlignedRotationsMorePrecisely)
+{
+	Quat rotations[] = {
+		QuatFromAxisAngle(Vector3d(1.0, 0.0, 0.0), rad(37.0)),
+		QuatFromAxisAngle(Vector3d(0.0, 1.0, 0.0), rad(75.0)),
+		QuatFromAxisAngle(Vector3d(0.0, 0.0, 1.0), rad(112.0)),
+		QuatFromAxisAngle(Vector3d(1.0, 1.0, 1.0), rad(15.0)),
+	};
+	for (const Quat& q : rotations)
+	{
+		SmallestThreeQ16 encoded = QuantizeRotationHalf(q);
+		Quat decoded = DequantizeRotationHalf(encoded);
+		O3DS_CHECK(QuatAngleDelta(q, decoded) < rad(0.05));
+	}
+}
+
+O3DS_TEST(RotationHalf_DecodedQuaternionStaysUnitLength)
+{
+	// The roadmap's explicit requirement: unlike naive per-component
+	// quantization, smallest-three must always renormalize cleanly.
+	Quat q = QuatFromAxisAngle(Vector3d(0.3, 0.7, -0.2), rad(83.0));
+	SmallestThreeQ16 encoded = QuantizeRotationHalf(q);
+	Quat decoded = DequantizeRotationHalf(encoded);
+	double lenSq = decoded.v[0] * decoded.v[0] + decoded.v[1] * decoded.v[1]
+		+ decoded.v[2] * decoded.v[2] + decoded.v[3] * decoded.v[3];
+	O3DS_CHECK(NearlyEqual(lenSq, 1.0, 1.0e-9));
+}
+
+O3DS_TEST(RotationByte_NegativeLargestComponentStillRoundTrips)
+{
+	// Forces the sign-normalization branch: construct a quaternion whose
+	// largest-magnitude component is negative before encoding.
+	Quat q = QuatFromAxisAngle(Vector3d(0.0, 0.0, 1.0), rad(179.0));
+	Quat negated(-q.v[0], -q.v[1], -q.v[2], -q.v[3]); // same rotation, w now negative
+	SmallestThreeQ8 encoded = QuantizeRotationByte(negated);
+	Quat decoded = DequantizeRotationByte(encoded);
+	O3DS_CHECK(QuatAngleDelta(q, decoded) < rad(5.0));
+}
+
+O3DS_TEST(RotationByte_OutOfRangeDroppedIndexDoesNotReadOutOfBounds)
+{
+	// Regression: droppedIndex is untrusted wire input (RotationUpdateQ8's
+	// `dropped` byte) - a value outside [0,3] previously made
+	// ReconstructSmallestThree's loop read one element past the end of its
+	// 3-element `others` array on the 4th iteration (ASan catches this).
+	// Just confirms it doesn't crash/misbehave; the resulting quaternion's
+	// exact value for garbage input isn't otherwise meaningful.
+	SmallestThreeQ8 garbage;
+	garbage.droppedIndex = 200;
+	garbage.a = 10;
+	garbage.b = -20;
+	garbage.c = 30;
+	Quat decoded = DequantizeRotationByte(garbage);
+	double lenSq = decoded.v[0] * decoded.v[0] + decoded.v[1] * decoded.v[1]
+		+ decoded.v[2] * decoded.v[2] + decoded.v[3] * decoded.v[3];
+	O3DS_CHECK(NearlyEqual(lenSq, 1.0, 1.0e-9));
+}
+
+O3DS_TEST(RotationHalf_ManyRandomLikeRotationsRoundTripWithinTolerance)
+{
+	// Deterministic pseudo-random sweep (no <random> - keep the test
+	// itself trivially reproducible) across axes and angles.
+	for (int i = 0; i < 50; ++i)
+	{
+		double ax = std::sin(static_cast<double>(i) * 0.7);
+		double ay = std::cos(static_cast<double>(i) * 1.3);
+		double az = std::sin(static_cast<double>(i) * 2.1 + 0.5);
+		double angleDeg = static_cast<double>((i * 37) % 360);
+		Quat q = QuatFromAxisAngle(Vector3d(ax, ay, az), rad(angleDeg));
+
+		SmallestThreeQ16 encoded = QuantizeRotationHalf(q);
+		Quat decoded = DequantizeRotationHalf(encoded);
+		O3DS_CHECK(QuatAngleDelta(q, decoded) < rad(0.1));
+	}
+}

--- a/test/channel_quant_wire_tests.cpp
+++ b/test/channel_quant_wire_tests.cpp
@@ -7,6 +7,7 @@
 
 #include "o3ds/model.h"
 #include "o3ds/predict/quat_math.h"
+#include "o3ds_generated.h"
 
 #include <cmath>
 
@@ -14,6 +15,39 @@ using namespace O3DS;
 
 namespace
 {
+	enum class WireTier { None, Full, Byte, Half };
+
+	// Inspects the raw wire bytes directly (bypassing the round-trip through
+	// a receiver) to confirm exactly which tier a channel was actually
+	// encoded at - a precise, unambiguous check that doesn't rely on
+	// inferring tier choice from reconstruction tolerance (which can be
+	// misleading: Full-tier float32 precision is tighter than Byte-tier's
+	// own tolerance, so a tolerance-only check can't distinguish "quantized
+	// via Byte" from "fell back to Full").
+	WireTier TranslationTierForIndex(const std::vector<char>& buf, int transformIndex)
+	{
+		// finalize() prepends an 8-byte (flags+CRC) header before the
+		// FlatBuffers payload - same layout SubjectList::Parse() itself skips.
+		auto root = O3DS::Data::GetSubjectList(buf.data() + 8);
+		if (!root->updates() || root->updates()->size() == 0)
+			return WireTier::None;
+		auto update = root->updates()->Get(0);
+
+		if (update->translations()) {
+			for (auto t : *update->translations())
+				if (t->i() == transformIndex) return WireTier::Full;
+		}
+		if (update->translations_q8()) {
+			for (auto t : *update->translations_q8())
+				if (t->i() == transformIndex) return WireTier::Byte;
+		}
+		if (update->translations_q16()) {
+			for (auto t : *update->translations_q16())
+				if (t->i() == transformIndex) return WireTier::Half;
+		}
+		return WireTier::None;
+	}
+
 	void BuildSkeleton(SubjectList& subjects, const std::string& name)
 	{
 		auto* subject = subjects.addSubject(name);
@@ -56,12 +90,27 @@ O3DS_TEST(D1_QuantizationDisabledByDefault_WireOutputHasNoQuantizedVectors)
 	std::vector<char> buf;
 	O3DS_CHECK(sender.SerializeUpdate(buf, count) > 0); // mQuantizationEnabled defaults false
 
+	// Regression (adversarial review, Finding 1): CreateVectorOfStructs()
+	// writes a real (non-null-offset) empty vector even when nothing was
+	// pushed to it - calling it unconditionally for the four D1 vectors
+	// added real wire bytes to EVERY update regardless of whether
+	// quantization was ever enabled, contradicting "byte-for-byte identical
+	// when disabled". Confirm the wire literally has no quantized vectors
+	// at all when disabled, not just that decoding still works.
+	O3DS_CHECK(TranslationTierForIndex(buf, 0) == WireTier::Full);
+	{
+		auto root = O3DS::Data::GetSubjectList(buf.data() + 8);
+		auto update = root->updates()->Get(0);
+		O3DS_CHECK(update->translations_q8() == nullptr);
+		O3DS_CHECK(update->translations_q16() == nullptr);
+		O3DS_CHECK(update->rotations_q8() == nullptr);
+		O3DS_CHECK(update->rotations_q16() == nullptr);
+	}
+
 	O3DS::SubjectList probe;
 	O3DS_CHECK(probe.Parse(buf.data(), buf.size()));
-	// No direct accessor for "did this update use quantized vectors" at the
-	// SubjectList level - round-trip via the receiver instead and confirm
-	// the value still applies correctly through the plain (non-quantized)
-	// path, which is the behavior-level guarantee that matters here.
+	// Round-trip via the receiver too, confirming the value still applies
+	// correctly through the plain (non-quantized) path.
 	O3DS_CHECK(receiver.Parse(buf.data(), buf.size()));
 	Subject* r = receiver.findSubject("Actor");
 	O3DS_CHECK(NearlyEqual(r->mTransforms[0]->translation.value.v[0], 0.001, 1.0e-9));
@@ -182,37 +231,85 @@ O3DS_TEST(D1_RotationQuantization_RoundTripsViaByteAndHalfTiers)
 	O3DS_CHECK(angleDelta(s->mTransforms[1]->rotation.value, r->mTransforms[1]->rotation.value) < rad(0.1));
 }
 
-O3DS_TEST(D1_TopologyResync_ReestablishesFreshAnchorOnBothSides)
+O3DS_TEST(D1_RepeatedFullSync_PreservesOriginalAnchor_NotVulnerableToLostKeyframe)
 {
+	// Regression (adversarial review): the anchor must be captured ONCE and
+	// held for a Transform's entire logical lifetime, NOT re-captured on
+	// every full sync. Real senders in this codebase periodically re-send a
+	// full snapshot as a "keyframe" over the same best-effort connector as
+	// delta updates, with no ACK - if a keyframe re-anchored and one such
+	// packet were dropped, the sender would silently move to a new anchor
+	// the receiver never learned, corrupting every quantized delta after it.
 	SubjectList sender;
 	BuildSkeleton(sender, "Actor");
 	SubjectList receiver;
-	FullSync(sender, receiver);
+	FullSync(sender, receiver); // anchor = (0,0,0) on both sides
 
 	sender.mQuantizationEnabled = true;
 	sender.mQuantRanges.byteRange = 0.01;
 	sender.mQuantRanges.halfRange = 1.0;
 
 	Subject* s = sender.findSubject("Actor");
-	s->mTransforms[0]->translation.value = Vector3d(50.0, 0.0, 0.0); // drive it far from the original anchor
+	s->mTransforms[0]->translation.value = Vector3d(50.0, 0.0, 0.0); // drive far from the original anchor
 
-	// A second full sync re-anchors both sides at this new value - a
-	// subsequent SMALL delta from here should quantize via Byte tier again,
-	// not be forced to Full (which it would be if the anchor were still the
-	// original rest pose, since 50.0 - originalAnchor would exceed
-	// halfRange).
+	// A second full sync of the SAME topology must NOT move the anchor -
+	// same transform name, so the original (0,0,0) anchor is preserved.
 	FullSync(sender, receiver);
 
+	// A small move from here (50.005) is only "small" relative to the
+	// ORIGINAL anchor if measured as 50.005 - 50.0 = 0.005; measured against
+	// the (correctly preserved) 0.0 anchor, the delta is 50.005 - far
+	// outside halfRange, so this MUST fall back to Full, not Byte/Half.
 	s->mTransforms[0]->translation.value = Vector3d(50.005, 0.0, 0.0);
 
 	size_t count = 0;
 	std::vector<char> buf;
 	O3DS_CHECK(sender.SerializeUpdate(buf, count, 1.0e-6) > 0);
+	O3DS_CHECK(TranslationTierForIndex(buf, 0) == WireTier::Full);
+
+	O3DS_CHECK(receiver.Parse(buf.data(), buf.size()));
+	Subject* r = receiver.findSubject("Actor");
+	O3DS_CHECK(NearlyEqual(r->mTransforms[0]->translation.value.v[0], 50.005, 1.0e-4));
+}
+
+O3DS_TEST(D1_DroppedKeyframeResync_DoesNotCorruptSubsequentQuantizedDeltas)
+{
+	// The actual loss-safety guarantee D1 exists for: simulate a periodic
+	// full "keyframe" resync that never reaches the receiver (dropped
+	// packet) - subsequent quantized delta updates must still decode
+	// correctly, because the anchor never moved on the sender's side either.
+	SubjectList sender;
+	BuildSkeleton(sender, "Actor");
+	SubjectList receiver;
+	FullSync(sender, receiver); // anchor = (0,0,0) on both sides
+
+	sender.mQuantizationEnabled = true;
+	sender.mQuantRanges.byteRange = 0.01;
+	sender.mQuantRanges.halfRange = 1.0;
+
+	Subject* s = sender.findSubject("Actor");
+	s->mTransforms[0]->translation.value = Vector3d(0.003, 0.0, 0.0);
+
+	// Sender performs a periodic keyframe resync (e.g. every N frames) -
+	// simulate it being LOST by only calling sender.Serialize() (as a real
+	// sender would, unconditionally) WITHOUT feeding the bytes to the
+	// receiver's Parse().
+	std::vector<char> droppedKeyframe;
+	O3DS_CHECK(sender.Serialize(droppedKeyframe) > 0);
+	(void)droppedKeyframe; // deliberately never delivered to receiver
+
+	// A subsequent quantized delta update must still decode correctly on
+	// the receiver, since the sender's anchor was untouched by the dropped
+	// keyframe (captured once, at the very first FullSync above).
+	size_t count = 0;
+	std::vector<char> buf;
+	O3DS_CHECK(sender.SerializeUpdate(buf, count, 1.0e-6) > 0);
+	O3DS_CHECK(TranslationTierForIndex(buf, 0) == WireTier::Byte);
 	O3DS_CHECK(receiver.Parse(buf.data(), buf.size()));
 
 	Subject* r = receiver.findSubject("Actor");
 	const double tol = (0.01 / 127.0) + 1.0e-9;
-	O3DS_CHECK(NearlyEqual(r->mTransforms[0]->translation.value.v[0], 50.005, tol));
+	O3DS_CHECK(NearlyEqual(r->mTransforms[0]->translation.value.v[0], 0.003, tol));
 }
 
 O3DS_TEST(D1_NoAnchorYet_FallsBackToFullWithoutCrashing)

--- a/test/channel_quant_wire_tests.cpp
+++ b/test/channel_quant_wire_tests.cpp
@@ -1,0 +1,242 @@
+// Full Subject/SubjectList wire round-trip tests for D1 adaptive channel
+// quantization (roadmap doc §6/D1), layered on top of channel_quant_tests.cpp's
+// pure-math codec tests. Exercises the actual SerializeUpdate()/ParseUpdate()
+// integration - schema fields, rest-pose anchor capture/reconstruction, and
+// tier fallback - not just QuantizeByte/QuantizeRotationByte in isolation.
+#include "test_framework.h"
+
+#include "o3ds/model.h"
+#include "o3ds/predict/quat_math.h"
+
+#include <cmath>
+
+using namespace O3DS;
+
+namespace
+{
+	void BuildSkeleton(SubjectList& subjects, const std::string& name)
+	{
+		auto* subject = subjects.addSubject(name);
+		auto* root = subject->addTransform("Root", -1);
+		root->transformOrder.push_back(O3DS::TTranslation);
+		root->transformOrder.push_back(O3DS::TRotation);
+
+		auto* spine = subject->addTransform("Spine", 0);
+		spine->transformOrder.push_back(O3DS::TTranslation);
+		spine->transformOrder.push_back(O3DS::TRotation);
+	}
+
+	bool NearlyEqual(double a, double b, double tol)
+	{
+		return std::abs(a - b) < tol;
+	}
+
+	// Establishes matching sender/receiver Subjects with the same rest-pose
+	// anchor, exactly as a real sender/receiver pair would via a full
+	// Serialize()/Parse() exchange.
+	void FullSync(SubjectList& sender, SubjectList& receiver)
+	{
+		std::vector<char> buf;
+		O3DS_CHECK(sender.Serialize(buf) > 0);
+		O3DS_CHECK(receiver.Parse(buf.data(), buf.size()));
+	}
+}
+
+O3DS_TEST(D1_QuantizationDisabledByDefault_WireOutputHasNoQuantizedVectors)
+{
+	SubjectList sender;
+	BuildSkeleton(sender, "Actor");
+	SubjectList receiver;
+	FullSync(sender, receiver);
+
+	Subject* s = sender.findSubject("Actor");
+	s->mTransforms[0]->translation.value = Vector3d(0.001, 0.0, 0.0);
+
+	size_t count = 0;
+	std::vector<char> buf;
+	O3DS_CHECK(sender.SerializeUpdate(buf, count) > 0); // mQuantizationEnabled defaults false
+
+	O3DS::SubjectList probe;
+	O3DS_CHECK(probe.Parse(buf.data(), buf.size()));
+	// No direct accessor for "did this update use quantized vectors" at the
+	// SubjectList level - round-trip via the receiver instead and confirm
+	// the value still applies correctly through the plain (non-quantized)
+	// path, which is the behavior-level guarantee that matters here.
+	O3DS_CHECK(receiver.Parse(buf.data(), buf.size()));
+	Subject* r = receiver.findSubject("Actor");
+	O3DS_CHECK(NearlyEqual(r->mTransforms[0]->translation.value.v[0], 0.001, 1.0e-9));
+}
+
+O3DS_TEST(D1_SmallTranslationMotion_RoundTripsViaByteTier)
+{
+	SubjectList sender;
+	BuildSkeleton(sender, "Actor");
+	SubjectList receiver;
+	FullSync(sender, receiver);
+
+	sender.mQuantizationEnabled = true;
+	sender.mQuantRanges.byteRange = 0.01;
+	sender.mQuantRanges.halfRange = 1.0;
+
+	Subject* s = sender.findSubject("Actor");
+	// Small motion, well within byteRange, on the Root transform.
+	s->mTransforms[0]->translation.value = Vector3d(0.005, -0.003, 0.002);
+
+	size_t count = 0;
+	std::vector<char> buf;
+	O3DS_CHECK(sender.SerializeUpdate(buf, count, 1.0e-6) > 0);
+	O3DS_CHECK(receiver.Parse(buf.data(), buf.size()));
+
+	Subject* r = receiver.findSubject("Actor");
+	// Byte tier resolution at range=0.01 is ~0.01/127 per axis.
+	const double tol = (0.01 / 127.0) + 1.0e-9;
+	O3DS_CHECK(NearlyEqual(r->mTransforms[0]->translation.value.v[0], 0.005, tol));
+	O3DS_CHECK(NearlyEqual(r->mTransforms[0]->translation.value.v[1], -0.003, tol));
+	O3DS_CHECK(NearlyEqual(r->mTransforms[0]->translation.value.v[2], 0.002, tol));
+}
+
+O3DS_TEST(D1_MediumTranslationMotion_RoundTripsViaHalfTier)
+{
+	SubjectList sender;
+	BuildSkeleton(sender, "Actor");
+	SubjectList receiver;
+	FullSync(sender, receiver);
+
+	sender.mQuantizationEnabled = true;
+	sender.mQuantRanges.byteRange = 0.01;
+	sender.mQuantRanges.halfRange = 1.0;
+
+	Subject* s = sender.findSubject("Actor");
+	s->mTransforms[0]->translation.value = Vector3d(0.5, -0.25, 0.1);
+
+	size_t count = 0;
+	std::vector<char> buf;
+	O3DS_CHECK(sender.SerializeUpdate(buf, count, 1.0e-6) > 0);
+	O3DS_CHECK(receiver.Parse(buf.data(), buf.size()));
+
+	Subject* r = receiver.findSubject("Actor");
+	const double tol = (1.0 / 32767.0) + 1.0e-9;
+	O3DS_CHECK(NearlyEqual(r->mTransforms[0]->translation.value.v[0], 0.5, tol));
+	O3DS_CHECK(NearlyEqual(r->mTransforms[0]->translation.value.v[1], -0.25, tol));
+	O3DS_CHECK(NearlyEqual(r->mTransforms[0]->translation.value.v[2], 0.1, tol));
+}
+
+O3DS_TEST(D1_LargeTranslationMotion_FallsBackToFullPrecision)
+{
+	SubjectList sender;
+	BuildSkeleton(sender, "Actor");
+	SubjectList receiver;
+	FullSync(sender, receiver);
+
+	sender.mQuantizationEnabled = true;
+	sender.mQuantRanges.byteRange = 0.01;
+	sender.mQuantRanges.halfRange = 1.0;
+
+	Subject* s = sender.findSubject("Actor");
+	// Exceeds halfRange - must fall back to exact float32, not clamp/lose
+	// precision the way a quantized tier would.
+	s->mTransforms[0]->translation.value = Vector3d(123.456f, 0.0, 0.0);
+
+	size_t count = 0;
+	std::vector<char> buf;
+	O3DS_CHECK(sender.SerializeUpdate(buf, count, 1.0e-6) > 0);
+	O3DS_CHECK(receiver.Parse(buf.data(), buf.size()));
+
+	Subject* r = receiver.findSubject("Actor");
+	// Full float32 round-trip is exact modulo the double<->float cast
+	// already inherent to the legacy (non-quantized) wire format.
+	O3DS_CHECK(NearlyEqual(r->mTransforms[0]->translation.value.v[0], (double)(float)123.456f, 1.0e-6));
+}
+
+O3DS_TEST(D1_RotationQuantization_RoundTripsViaByteAndHalfTiers)
+{
+	SubjectList sender;
+	BuildSkeleton(sender, "Actor");
+	SubjectList receiver;
+	FullSync(sender, receiver);
+
+	sender.mQuantizationEnabled = true;
+	// Rotation reuses byteRange/halfRange as a generic "how much did this
+	// channel move" threshold against its own quaternion-space delta() -
+	// small angle -> Byte, larger -> Half (the fresh-Subject delta() vs.
+	// the identity-rotation default is what selects the tier here).
+	sender.mQuantRanges.byteRange = 0.05;
+	sender.mQuantRanges.halfRange = 1.0;
+
+	Subject* s = sender.findSubject("Actor");
+	s->mTransforms[0]->rotation.value = QuatFromAxisAngle(Vector3d(0.0, 0.0, 1.0), rad(3.0)); // small angle -> Byte tier
+	s->mTransforms[1]->rotation.value = QuatFromAxisAngle(Vector3d(0.0, 1.0, 0.0), rad(60.0)); // larger -> Half tier
+
+	size_t count = 0;
+	std::vector<char> buf;
+	O3DS_CHECK(sender.SerializeUpdate(buf, count, 1.0e-6) > 0);
+	O3DS_CHECK(receiver.Parse(buf.data(), buf.size()));
+
+	Subject* r = receiver.findSubject("Actor");
+	auto angleDelta = [](const Quat& a, const Quat& b) {
+		double dot = a.v[0] * b.v[0] + a.v[1] * b.v[1] + a.v[2] * b.v[2] + a.v[3] * b.v[3];
+		dot = std::max(-1.0, std::min(1.0, std::fabs(dot)));
+		return 2.0 * std::acos(dot);
+	};
+	O3DS_CHECK(angleDelta(s->mTransforms[0]->rotation.value, r->mTransforms[0]->rotation.value) < rad(5.0));
+	O3DS_CHECK(angleDelta(s->mTransforms[1]->rotation.value, r->mTransforms[1]->rotation.value) < rad(0.1));
+}
+
+O3DS_TEST(D1_TopologyResync_ReestablishesFreshAnchorOnBothSides)
+{
+	SubjectList sender;
+	BuildSkeleton(sender, "Actor");
+	SubjectList receiver;
+	FullSync(sender, receiver);
+
+	sender.mQuantizationEnabled = true;
+	sender.mQuantRanges.byteRange = 0.01;
+	sender.mQuantRanges.halfRange = 1.0;
+
+	Subject* s = sender.findSubject("Actor");
+	s->mTransforms[0]->translation.value = Vector3d(50.0, 0.0, 0.0); // drive it far from the original anchor
+
+	// A second full sync re-anchors both sides at this new value - a
+	// subsequent SMALL delta from here should quantize via Byte tier again,
+	// not be forced to Full (which it would be if the anchor were still the
+	// original rest pose, since 50.0 - originalAnchor would exceed
+	// halfRange).
+	FullSync(sender, receiver);
+
+	s->mTransforms[0]->translation.value = Vector3d(50.005, 0.0, 0.0);
+
+	size_t count = 0;
+	std::vector<char> buf;
+	O3DS_CHECK(sender.SerializeUpdate(buf, count, 1.0e-6) > 0);
+	O3DS_CHECK(receiver.Parse(buf.data(), buf.size()));
+
+	Subject* r = receiver.findSubject("Actor");
+	const double tol = (0.01 / 127.0) + 1.0e-9;
+	O3DS_CHECK(NearlyEqual(r->mTransforms[0]->translation.value.v[0], 50.005, tol));
+}
+
+O3DS_TEST(D1_NoAnchorYet_FallsBackToFullWithoutCrashing)
+{
+	// A Subject built directly (never gone through a full Serialize()) has
+	// no rest-pose anchor - quantization must degrade gracefully to Full
+	// rather than reading garbage or crashing.
+	SubjectList sender;
+	BuildSkeleton(sender, "Actor");
+	sender.mQuantizationEnabled = true;
+	sender.mQuantRanges.byteRange = 0.01;
+	sender.mQuantRanges.halfRange = 1.0;
+
+	Subject* s = sender.findSubject("Actor");
+	s->mTransforms[0]->translation.value = Vector3d(0.001, 0.0, 0.0);
+
+	size_t count = 0;
+	std::vector<char> buf;
+	O3DS_CHECK(sender.SerializeUpdate(buf, count, 1.0e-6) > 0);
+
+	SubjectList receiver;
+	BuildSkeleton(receiver, "Actor"); // receiver also has no anchor yet
+	O3DS_CHECK(receiver.Parse(buf.data(), buf.size()));
+
+	Subject* r = receiver.findSubject("Actor");
+	O3DS_CHECK(NearlyEqual(r->mTransforms[0]->translation.value.v[0], 0.001, 1.0e-6));
+}

--- a/test/channel_quant_wire_tests.cpp
+++ b/test/channel_quant_wire_tests.cpp
@@ -219,6 +219,21 @@ O3DS_TEST(D1_RotationQuantization_RoundTripsViaByteAndHalfTiers)
 	size_t count = 0;
 	std::vector<char> buf;
 	O3DS_CHECK(sender.SerializeUpdate(buf, count, 1.0e-6) > 0);
+
+	// Regression (Copilot review): quant_byte_range/quant_half_range must
+	// stay 0 when no TRANSLATION channel was quantized this update - only
+	// rotation was quantized here, and rotation's smallest-three encoding
+	// needs neither range field to decode. A stale non-zero range would
+	// contradict the schema's "0 == no [byte/half]-tier translation vector
+	// present" contract for no reason.
+	{
+		auto root = O3DS::Data::GetSubjectList(buf.data() + 8);
+		auto update = root->updates()->Get(0);
+		O3DS_CHECK(update->quant_byte_range() == 0.0f);
+		O3DS_CHECK(update->quant_half_range() == 0.0f);
+		O3DS_CHECK(update->rotations_q8() != nullptr || update->rotations_q16() != nullptr);
+	}
+
 	O3DS_CHECK(receiver.Parse(buf.data(), buf.size()));
 
 	Subject* r = receiver.findSubject("Actor");


### PR DESCRIPTION
## Summary

Implements Workstream D / Phase D1 from the roadmap doc: adaptive/variable-bit channel quantization for the wire format, independent of whether a channel is predicted (C0–C2) or held. Opt-in (`SubjectList::mQuantizationEnabled`, default `false`) — wire output is unchanged unless explicitly enabled.

- **`src/o3ds/quant/channel_quant.h/.cpp`** (new): pure-math codec, independent of the wire format.
  - Scalar Byte (8-bit) / Half (16-bit) fixed-point quantization of a bounded delta.
  - Smallest-three quaternion quantization for rotation (drops the largest-magnitude component, reconstructs it from the unit-length constraint, renormalizes on decode) — avoids the denormalization risk of naive per-component quantization.
- **Translation** quantizes a delta from each `Transform`'s **rest-pose anchor** (`Transform::mQuantAnchorTranslation`), not the legacy last-sent value. This is deliberate: D1's whole reason for existing (per the roadmap) is that it's usable on transports too unreliable for C2's residual coding, which already has a known history-divergence-under-loss problem. A last-sent-style moving reference would reintroduce exactly that. The anchor is captured **once**, at the first full sync (`Subject::Serialize`/`SubjectList::ParseSubject`), and held for the transform's logical lifetime — a later dropped "keyframe" resync (real senders in this codebase periodically re-send a full snapshot with no ACK) has no effect on anchor correctness.
- **Rotation** quantizes the absolute value (components are inherently bounded, no anchor needed).
- **`src/o3ds.fbs`**: new fixed-size structs (`TranslationUpdateQ8/Q16`, `RotationUpdateQ8/Q16`) appended as new `SubjectUpdate` vector fields — kept as FlatBuffers `struct`s, not `table`s, to avoid per-instance vtable/offset overhead that would erase the byte savings. A channel appears in at most one of the plain/Q8/Q16 vectors per update.
- Scale and curve channels are out of scope for this pass (scale is already dead code in the legacy path; curves would need their own anchor bookkeeping for comparatively low payoff). The residual-coding (C2) path isn't wired into quantization yet either — noted as a follow-on, not done here.

## Review

Ran a dedicated adversarial review before opening this PR. It found (and I fixed) two real HIGH-severity bugs, empirically verified:

1. **Wire bloat even when disabled**: `CreateVectorOfStructs()` writes a real vector even for zero elements, so unconditionally creating the four new quantized vectors added real bytes to *every* update regardless of whether quantization was ever enabled — confirmed via a side-by-side comparison against `develop` (136 → 184 bytes, a 35% regression, quantization **off**). Fixed by only creating each vector's offset when non-empty.
2. **Anchor loss-safety gap**: the anchor was being unconditionally re-captured on every full sync, but real senders in this codebase periodically re-send a full snapshot as a "keyframe" over the same best-effort connector as delta updates, with no ACK — a single dropped keyframe would silently desync sender/receiver anchors forever after, exactly the failure mode D1 is supposed to avoid. Fixed by anchoring once and preserving it across subsequent resyncs (matched by transform name on the receiver, since its `ParseSubject()` always rebuilds fresh `Transform` objects even when topology is unchanged).

Also fixed a MEDIUM finding (unvalidated wire floats for the quantization range, could inject an Infinite translation) and a doc/implementation mismatch (a schema comment claiming composition with C2 that doesn't exist yet).

I also self-caught and fixed one bug before the review even ran: an untrusted `droppedIndex` wire byte outside `[0,3]` caused a stack-buffer-overflow in the rotation decoder (confirmed via ASan repro, then fixed with a clamp + regression test).

## Test plan

- [x] Pure-codec round-trip tests (`test/channel_quant_tests.cpp`): tier boundaries, clamping, smallest-three round-trips (identity, axis-aligned, negative-sign, random sweep), and the out-of-range `droppedIndex` regression.
- [x] Full wire-level tests (`test/channel_quant_wire_tests.cpp`): tier selection/fallback, disabled-by-default (asserted directly via raw wire inspection, not just round-trip), topology-resync anchor preservation, and a dedicated dropped-keyframe test simulating a lost full-sync packet.
- [x] 158 tests passing under `ctest`, Debug + ASan/UBSan and Release.
- [x] Adversarial review completed and all findings addressed.
- [ ] This is core-library-only (no UE plugin changes) — no self-hosted Windows build needed for this PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LHHqoB2uhpd7k7wSdbE4H6)_