### PR TITLE
Fix reproducibility bugs in o3ds-from-source CI build (from #245 review)

### DIFF
--- a/.github/workflows/open3dbroadcast-plugin-ci.yml
+++ b/.github/workflows/open3dbroadcast-plugin-ci.yml
@@ -59,6 +59,7 @@ jobs:
         with:
           fetch-depth: 0
           lfs: true
+          submodules: 'recursive'
 
       - name: Post build started comment
         if: github.event_name == 'pull_request' && github.event.pull_request.number != null

--- a/.github/workflows/open3dbroadcast-plugin-nightly.yml
+++ b/.github/workflows/open3dbroadcast-plugin-nightly.yml
@@ -34,6 +34,7 @@ jobs:
         with:
           fetch-depth: 0
           lfs: true
+          submodules: 'recursive'
 
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v2

--- a/.github/workflows/open3dbroadcast-plugin-release.yml
+++ b/.github/workflows/open3dbroadcast-plugin-release.yml
@@ -35,6 +35,7 @@ jobs:
         with:
           fetch-depth: 0
           lfs: true
+          submodules: 'recursive'
 
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v2

--- a/.github/workflows/open3dbroadcast-plugin-test.yml
+++ b/.github/workflows/open3dbroadcast-plugin-test.yml
@@ -64,6 +64,7 @@ jobs:
         with:
           fetch-depth: 0
           lfs: true
+          submodules: 'recursive'
 
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v2

--- a/Build/README.md
+++ b/Build/README.md
@@ -29,7 +29,7 @@ Builds the o3ds core library (and its NNG/CML/CRCpp/FlatBuffers dependencies) fr
 
 **Parameters:**
 - `-RepoRoot` - Path to the repository root (default: inferred from script location)
-- `-BuildDir` - Scratch directory for CMake build trees (default: `<RepoRoot>/_o3ds_core_build`)
+- `-BuildDir` - Scratch directory for CMake build trees (default: `<RepoRoot>/_o3ds_build`, already covered by the repo root `.gitignore`)
 - `-Configuration` - CMake build configuration (default: `Release`)
 - `-PluginRoot` - Path to the Open3DBroadcast plugin root (default: `<RepoRoot>/ProjectSandbox/Plugins/Open3DBroadcast`)
 

--- a/Build/Scripts/Sync-O3DSCore.ps1
+++ b/Build/Scripts/Sync-O3DSCore.ps1
@@ -33,7 +33,8 @@
 
 .PARAMETER BuildDir
     Scratch directory for CMake build trees and the dependency install
-    prefix. Defaults to $RepoRoot/_o3ds_core_build.
+    prefix. Defaults to $RepoRoot/_o3ds_build (already covered by the repo
+    root .gitignore, unlike an ad hoc name).
 
 .PARAMETER Configuration
     CMake build configuration. Defaults to Release.
@@ -45,7 +46,7 @@
 [CmdletBinding()]
 param(
     [string]$RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..\..")).Path,
-    [string]$BuildDir = (Join-Path $RepoRoot "_o3ds_core_build"),
+    [string]$BuildDir = (Join-Path $RepoRoot "_o3ds_build"),
     [string]$Configuration = "Release",
     [string]$PluginRoot = (Join-Path $RepoRoot "ProjectSandbox\Plugins\Open3DBroadcast")
 )
@@ -70,19 +71,27 @@ $InstallDir = Join-Path $BuildDir "out"
 New-Item -ItemType Directory -Force -Path $Prefix | Out-Null
 
 Write-Host "==> Building o3ds dependencies (NNG, CML, CRCpp, FlatBuffers) into $Prefix"
-$Deps = @("thirdparty/nng", "thirdparty/cml", "thirdparty/crccpp", "thirdparty/flatbuffers")
+# Extra per-dependency args mirroring .github/workflows/windows.yml's own recipe -
+# in particular NNG_ENABLE_TLS=Off, so this script doesn't silently pull in a TLS
+# backend (mbedtls/OpenSSL) that windows.yml deliberately avoids.
+$Deps = @(
+    @{ Path = "thirdparty/nng"; ExtraArgs = @("-DNNG_ENABLE_TLS=Off") },
+    @{ Path = "thirdparty/cml"; ExtraArgs = @() },
+    @{ Path = "thirdparty/crccpp"; ExtraArgs = @() },
+    @{ Path = "thirdparty/flatbuffers"; ExtraArgs = @() }
+)
 foreach ($Dep in $Deps)
 {
-    $DepPath = Join-Path $RepoRoot $Dep
-    $DepBuild = Join-Path $BuildDir ("dep_" + (Split-Path $Dep -Leaf))
-    Write-Host "  -- $Dep"
+    $DepPath = Join-Path $RepoRoot $Dep.Path
+    $DepBuild = Join-Path $BuildDir ("dep_" + (Split-Path $Dep.Path -Leaf))
+    Write-Host "  -- $($Dep.Path)"
     Invoke-Checked "cmake" @(
         "-S", $DepPath, "-B", $DepBuild,
         "-DCMAKE_POLICY_VERSION_MINIMUM=3.5",
         "-DCMAKE_BUILD_TYPE=$Configuration",
         "-DCMAKE_INSTALL_PREFIX=$Prefix",
         "-DCMAKE_PREFIX_PATH=$Prefix"
-    )
+    ) + $Dep.ExtraArgs
     Invoke-Checked "cmake" @("--build", $DepBuild, "--config", $Configuration)
     Invoke-Checked "cmake" @("--install", $DepBuild, "--config", $Configuration)
 }

--- a/Build/Scripts/Sync-O3DSCore.ps1
+++ b/Build/Scripts/Sync-O3DSCore.ps1
@@ -85,13 +85,14 @@ foreach ($Dep in $Deps)
     $DepPath = Join-Path $RepoRoot $Dep.Path
     $DepBuild = Join-Path $BuildDir ("dep_" + (Split-Path $Dep.Path -Leaf))
     Write-Host "  -- $($Dep.Path)"
-    Invoke-Checked "cmake" @(
+    $ConfigureArgs = @(
         "-S", $DepPath, "-B", $DepBuild,
         "-DCMAKE_POLICY_VERSION_MINIMUM=3.5",
         "-DCMAKE_BUILD_TYPE=$Configuration",
         "-DCMAKE_INSTALL_PREFIX=$Prefix",
         "-DCMAKE_PREFIX_PATH=$Prefix"
     ) + $Dep.ExtraArgs
+    Invoke-Checked "cmake" $ConfigureArgs
     Invoke-Checked "cmake" @("--build", $DepBuild, "--config", $Configuration)
     Invoke-Checked "cmake" @("--install", $DepBuild, "--config", $Configuration)
 }


### PR DESCRIPTION
## Summary

Follow-up to #245 (merged). Copilot's automated review posted 9 comments after that PR merged; I verified each against the actual CI logs from #245's runs rather than taking them at face value. Three turned out to be real, reproducibility-affecting bugs:

- **Submodules never initialized.** All four `open3dbroadcast-plugin-*.yml` workflows check out the repo without submodules, but `Sync-O3DSCore.ps1` builds `thirdparty/{nng,cml,crccpp,flatbuffers}` from source. #245's CI runs only succeeded because the self-hosted runner reuses a persistent workspace directory that already had those submodules populated from an earlier `windows.yml` run (confirmed in the job log: `git checkout --force` reused an existing working tree, not a fresh clone). A genuinely clean runner would fail. Adds `submodules: recursive` to each workflow's full checkout step.
- **NNG built without `-DNNG_ENABLE_TLS=Off`.** `Sync-O3DSCore.ps1`'s dependency loop applied one generic set of CMake args to all four dependencies, dropping the NNG-specific flag `windows.yml` uses. The #245 CI log shows `tls.c`/`tls_common.c` got compiled in as a result - it only worked because OpenSSL happened to be present via choco on that runner. Gives each dependency its own extra-args list instead.
- **Scratch build dir not gitignored.** `Sync-O3DSCore.ps1` defaulted to `_o3ds_core_build`, which the repo root `.gitignore` doesn't cover (it only ignores `/_o3ds_build`, `windows.yml`'s own build dir name). Renamed to reuse that already-ignored name; updated `Build/README.md` to match.

**Not fixed** (verified as a false positive): Copilot also flagged `src/CMakeLists.txt`'s `install(TARGETS ... CONFIGURATIONS RelWithDebInfo)` as theoretically incompatible with `Sync-O3DSCore.ps1`'s `-Configuration Release` default. I reproduced that exact restriction in isolated CMake tests (3.28, Ninja) and confirmed it does skip the install rule under Release in that setup - but the actual #245 CI logs show `open3dstreamstatic.lib` was built and installed successfully via CMake 4.3.4 + the VS2022 generator on the real runner. Left as-is since production evidence contradicts the theoretical concern and I couldn't reproduce a real failure.

## Test plan

- [ ] `open3dbroadcast-plugin-ci.yml` (or `-test.yml`) runs green on the self-hosted Windows runner with these fixes, ideally after confirming the runner's workspace doesn't already have `thirdparty/*` submodules populated (so the submodule-init fix is actually exercised)
- [ ] Confirm NNG's build log no longer compiles `tls.c`/`tls_common.c`


---
_Generated by [Claude Code](https://claude.ai/code/session_01LHHqoB2uhpd7k7wSdbE4H6)_