### PR TITLE
D1: add hysteresis to quantization tier selection, fix idle-animation jitter

### DIFF
--- a/src/o3ds/model.cpp
+++ b/src/o3ds/model.cpp
@@ -484,7 +484,14 @@ flatbuffers::Offset<flatbuffers::Vector<const O3DS::Data::CurveUpdate *>> Subjec
 					double dy = t->translation.value.v[1] - t->mQuantAnchorTranslation.v[1];
 					double dz = t->translation.value.v[2] - t->mQuantAnchorTranslation.v[2];
 					double maxAbs = std::max(std::fabs(dx), std::max(std::fabs(dy), std::fabs(dz)));
-					QuantTier tier = ChooseScalarTier(maxAbs, *quantRanges);
+					// Hysteresis-aware (see quant/channel_quant.h): re-evaluating
+					// against a stateless boundary test every frame flaps tiers
+					// (and thus reconstruction precision) whenever maxAbs hovers
+					// near byteRange/halfRange - exactly what continuous,
+					// small-amplitude motion (e.g. idle-animation sway around
+					// the rest-pose anchor) does.
+					QuantTier tier = ChooseScalarTierWithHysteresis(maxAbs, *quantRanges, t->mLastTranslationTier);
+					t->mLastTranslationTier = tier;
 					if (tier == QuantTier::Byte)
 					{
 						translationsQ8.push_back(O3DS::Data::TranslationUpdateQ8(
@@ -503,6 +510,14 @@ flatbuffers::Offset<flatbuffers::Vector<const O3DS::Data::CurveUpdate *>> Subjec
 							transformId));
 						quantized = true;
 					}
+				}
+				else if (quantRanges != nullptr)
+				{
+					// No anchor yet - the same "fall back to Full for this call
+					// only" case the comment above describes. Reset the
+					// hysteresis state too, so a real anchor arriving later
+					// starts unbiased rather than inheriting a stale tier.
+					t->mLastTranslationTier = QuantTier::Full;
 				}
 				if (!quantized)
 				{
@@ -528,7 +543,14 @@ flatbuffers::Offset<flatbuffers::Vector<const O3DS::Data::CurveUpdate *>> Subjec
 				// to translation's own linear units.
 				if (quantRanges != nullptr)
 				{
-					QuantTier tier = ChooseScalarTier(t->rotation.delta(), *quantRanges);
+					// Hysteresis-aware for the same reason as translation above -
+					// t->rotation.delta() (frame-to-last-sent quaternion distance)
+					// oscillates at a roughly constant magnitude during continuous
+					// low-amplitude motion (idle sway/look-around), and re-picking
+					// the tier from scratch every frame flaps it whenever that
+					// magnitude hovers near byteRange/halfRange.
+					QuantTier tier = ChooseScalarTierWithHysteresis(t->rotation.delta(), *quantRanges, t->mLastRotationTier);
+					t->mLastRotationTier = tier;
 					if (tier == QuantTier::Byte)
 					{
 						SmallestThreeQ8 q = QuantizeRotationByte(t->rotation.value);

--- a/src/o3ds/model.h
+++ b/src/o3ds/model.h
@@ -91,6 +91,19 @@ namespace O3DS
 		// tier, same safety net as today's deltaThreshold.
 		Vector3d mQuantAnchorTranslation = Vector3d(0.0, 0.0, 0.0);
 		bool     mQuantAnchorSet = false;
+
+		// D1 hysteresis: the tier ChooseScalarTierWithHysteresis last chose
+		// for this channel (see quant/channel_quant.h) - carried per-Transform,
+		// per-channel so the next call can require clearing the *opposite*
+		// side of a boundary before switching tiers again, instead of
+		// flapping every frame a value hovers near byteRange/halfRange (each
+		// tier reconstructs on a different rounding grid, so every flap is a
+		// visible jump on the receiver). Defaults to Full, the always-correct
+		// starting point - a fresh Transform (this object's whole lifetime,
+		// same "resets only on topology change" rule as mQuantAnchorSet
+		// above) has no prior tier to be biased toward.
+		QuantTier mLastTranslationTier = QuantTier::Full;
+		QuantTier mLastRotationTier = QuantTier::Full;
 	};
 
 	//! Platform specific builder to make a transform object

--- a/src/o3ds/quant/channel_quant.cpp
+++ b/src/o3ds/quant/channel_quant.cpp
@@ -69,6 +69,76 @@ namespace O3DS
 		return QuantTier::Full;
 	}
 
+	QuantTier ChooseScalarTierWithHysteresis(double absDelta, const QuantRanges& ranges, QuantTier previousTier)
+	{
+		double h = ranges.hysteresisFactor;
+		if (!std::isfinite(h) || h < 0.0)
+		{
+			h = 0.0;
+		}
+		else if (h > 0.99)
+		{
+			// Keep the contracted thresholds strictly positive (and the band
+			// non-degenerate) regardless of caller-supplied config.
+			h = 0.99;
+		}
+
+		if (h == 0.0)
+		{
+			return ChooseScalarTier(absDelta, ranges);
+		}
+
+		const double expandedByteRange = ranges.byteRange * (1.0 + h);
+		const double contractedByteRange = ranges.byteRange * (1.0 - h);
+		const double expandedHalfRange = ranges.halfRange * (1.0 + h);
+		const double contractedHalfRange = ranges.halfRange * (1.0 - h);
+
+		switch (previousTier)
+		{
+		case QuantTier::Byte:
+			// Upgrading out of Byte needs to clear byteRange by the margin;
+			// a big-enough single-frame jump can go straight to Full.
+			if (absDelta > expandedHalfRange)
+			{
+				return QuantTier::Full;
+			}
+			if (absDelta > expandedByteRange)
+			{
+				return QuantTier::Half;
+			}
+			return QuantTier::Byte;
+
+		case QuantTier::Half:
+			// Downgrading to Byte needs to clear byteRange's margin on the
+			// low side; upgrading to Full needs to clear halfRange's margin
+			// on the high side. Otherwise stay put.
+			if (absDelta > expandedHalfRange)
+			{
+				return QuantTier::Full;
+			}
+			if (absDelta <= contractedByteRange)
+			{
+				return QuantTier::Byte;
+			}
+			return QuantTier::Half;
+
+		case QuantTier::Full:
+		default:
+			// Entering a finer tier from Full needs to clear the relevant
+			// margin on the low side - a single big drop can go straight to
+			// Byte, matching ChooseScalarTier's own precedence.
+			if (absDelta <= contractedByteRange)
+			{
+				return QuantTier::Byte;
+			}
+			if (absDelta <= contractedHalfRange)
+			{
+				return QuantTier::Half;
+			}
+			return QuantTier::Full;
+		}
+	}
+
 	int8_t QuantizeByte(double delta, double range)
 	{
 		// range can come from caller-supplied config (e.g. a UE UPROPERTY,

--- a/src/o3ds/quant/channel_quant.h
+++ b/src/o3ds/quant/channel_quant.h
@@ -66,12 +66,38 @@ namespace O3DS
 	{
 		double byteRange = 0.01; //!< Max |delta| representable at Byte tier.
 		double halfRange = 1.0;  //!< Max |delta| representable at Half tier.
+
+		//! Fractional hysteresis margin (e.g. 0.15 == 15%) applied around
+		//! each tier boundary by ChooseScalarTierWithHysteresis. Without it,
+		//! a value that naturally hovers near byteRange/halfRange (e.g.
+		//! idle-animation sway oscillating around a roughly constant
+		//! amplitude) flips tiers every time it crosses back and forth -
+		//! and since each tier reconstructs on a different rounding grid,
+		//! every flip is a visible jump on the receiver, not just added
+		//! noise. 0 (or a non-finite value) disables hysteresis, matching
+		//! plain ChooseScalarTier exactly.
+		double hysteresisFactor = 0.15;
 	};
 
 	//! Chooses the smallest tier that can represent absDelta (already
 	//! std::abs'd by the caller) within ranges, without clamping/losing
-	//! range - Full if absDelta exceeds halfRange.
+	//! range - Full if absDelta exceeds halfRange. Stateless: the same
+	//! absDelta always yields the same tier, regardless of what was chosen
+	//! last time - see ChooseScalarTierWithHysteresis below for a
+	//! flap-resistant alternative driven by a per-channel previous tier.
 	QuantTier ChooseScalarTier(double absDelta, const QuantRanges& ranges);
+
+	//! Hysteresis-aware tier selection for a channel whose previously-chosen
+	//! tier is known. Only moves away from previousTier once absDelta clears
+	//! the boundary on the *opposite* side by ranges.hysteresisFactor,
+	//! instead of the instant the plain boundary is crossed - see
+	//! QuantRanges::hysteresisFactor's doc comment for the flapping problem
+	//! this avoids. A channel with no meaningful prior choice (e.g. a
+	//! freshly-created Transform) should pass QuantTier::Full, the always-
+	//! safe/correct starting point already used elsewhere in this scheme
+	//! (e.g. "no anchor yet" falls back to Full too) - hysteresis then
+	//! applies normally from there and converges within one call.
+	QuantTier ChooseScalarTierWithHysteresis(double absDelta, const QuantRanges& ranges, QuantTier previousTier);
 
 	//! Quantizes delta (already known to satisfy |delta| <= range - callers
 	//! choose range via ChooseScalarTier first) to a signed 8-bit code.

--- a/test/channel_quant_tests.cpp
+++ b/test/channel_quant_tests.cpp
@@ -54,6 +54,190 @@ O3DS_TEST(ChooseScalarTier_FallsBackToFullBeyondHalfRange)
 	O3DS_CHECK(ChooseScalarTier(1000.0, ranges) == QuantTier::Full);
 }
 
+O3DS_TEST(ChooseScalarTierWithHysteresis_MatchesPlainTierWhenFactorIsZero)
+{
+	// Regression guard for jitter reported from a live PIE test (idle
+	// animations flapping between quantization tiers frame-to-frame):
+	// with hysteresisFactor == 0, the hysteresis-aware selector must be
+	// byte-for-byte identical to the stateless ChooseScalarTier, regardless
+	// of previousTier.
+	QuantRanges ranges;
+	ranges.byteRange = 0.01;
+	ranges.halfRange = 1.0;
+	ranges.hysteresisFactor = 0.0;
+
+	double samples[] = { 0.001, 0.01, 0.5, 1.0, 1.0001, 1000.0 };
+	QuantTier previousTiers[] = { QuantTier::Full, QuantTier::Half, QuantTier::Byte };
+	for (double sample : samples)
+	{
+		for (QuantTier previous : previousTiers)
+		{
+			O3DS_CHECK(ChooseScalarTierWithHysteresis(sample, ranges, previous) == ChooseScalarTier(sample, ranges));
+		}
+	}
+}
+
+O3DS_TEST(ChooseScalarTierWithHysteresis_StaysInByteWithinUpperBand)
+{
+	// byteRange=0.01, hysteresisFactor=0.15 -> expandedByteRange=0.0115.
+	// A delta just past byteRange but still within the band should NOT
+	// flip Byte -> Half yet - this is the exact "hovering near a boundary"
+	// case that caused every-frame tier flapping (and thus a visible
+	// reconstruction jump every flap, since Byte/Half round differently).
+	QuantRanges ranges;
+	ranges.byteRange = 0.01;
+	ranges.halfRange = 1.0;
+	ranges.hysteresisFactor = 0.15;
+	O3DS_CHECK(ChooseScalarTierWithHysteresis(0.011, ranges, QuantTier::Byte) == QuantTier::Byte);
+}
+
+O3DS_TEST(ChooseScalarTierWithHysteresis_UpgradesToHalfPastUpperBand)
+{
+	QuantRanges ranges;
+	ranges.byteRange = 0.01;
+	ranges.halfRange = 1.0;
+	ranges.hysteresisFactor = 0.15;
+	O3DS_CHECK(ChooseScalarTierWithHysteresis(0.012, ranges, QuantTier::Byte) == QuantTier::Half);
+}
+
+O3DS_TEST(ChooseScalarTierWithHysteresis_StaysInHalfWithinLowerBand)
+{
+	// contractedByteRange=0.0085. A delta just below byteRange but still
+	// within the band should NOT flip Half -> Byte yet.
+	QuantRanges ranges;
+	ranges.byteRange = 0.01;
+	ranges.halfRange = 1.0;
+	ranges.hysteresisFactor = 0.15;
+	O3DS_CHECK(ChooseScalarTierWithHysteresis(0.009, ranges, QuantTier::Half) == QuantTier::Half);
+}
+
+O3DS_TEST(ChooseScalarTierWithHysteresis_DowngradesToBytePastLowerBand)
+{
+	QuantRanges ranges;
+	ranges.byteRange = 0.01;
+	ranges.halfRange = 1.0;
+	ranges.hysteresisFactor = 0.15;
+	O3DS_CHECK(ChooseScalarTierWithHysteresis(0.008, ranges, QuantTier::Half) == QuantTier::Byte);
+}
+
+O3DS_TEST(ChooseScalarTierWithHysteresis_StaysInHalfNearHalfRangeUpperSide)
+{
+	// expandedHalfRange=1.15. A delta just past halfRange but still within
+	// the band should NOT flip Half -> Full yet.
+	QuantRanges ranges;
+	ranges.byteRange = 0.01;
+	ranges.halfRange = 1.0;
+	ranges.hysteresisFactor = 0.15;
+	O3DS_CHECK(ChooseScalarTierWithHysteresis(1.1, ranges, QuantTier::Half) == QuantTier::Half);
+}
+
+O3DS_TEST(ChooseScalarTierWithHysteresis_UpgradesToFullPastHalfRangeUpperBand)
+{
+	QuantRanges ranges;
+	ranges.byteRange = 0.01;
+	ranges.halfRange = 1.0;
+	ranges.hysteresisFactor = 0.15;
+	O3DS_CHECK(ChooseScalarTierWithHysteresis(1.2, ranges, QuantTier::Half) == QuantTier::Full);
+}
+
+O3DS_TEST(ChooseScalarTierWithHysteresis_StaysInFullWithinLowerBand)
+{
+	// contractedHalfRange=0.85. A delta just below halfRange but still
+	// within the band should NOT flip Full -> Half yet.
+	QuantRanges ranges;
+	ranges.byteRange = 0.01;
+	ranges.halfRange = 1.0;
+	ranges.hysteresisFactor = 0.15;
+	O3DS_CHECK(ChooseScalarTierWithHysteresis(0.9, ranges, QuantTier::Full) == QuantTier::Full);
+}
+
+O3DS_TEST(ChooseScalarTierWithHysteresis_DowngradesFromFullToHalfPastLowerBand)
+{
+	QuantRanges ranges;
+	ranges.byteRange = 0.01;
+	ranges.halfRange = 1.0;
+	ranges.hysteresisFactor = 0.15;
+	O3DS_CHECK(ChooseScalarTierWithHysteresis(0.8, ranges, QuantTier::Full) == QuantTier::Half);
+}
+
+O3DS_TEST(ChooseScalarTierWithHysteresis_FreshChannelFromFullNeedsToClearContractedThreshold)
+{
+	// A "fresh" channel (no prior tier - see Transform::mLastTranslationTier's
+	// default of QuantTier::Full) is slightly more conservative on its very
+	// first evaluation than the stateless ChooseScalarTier: entering Byte
+	// specifically (not just some finer tier) needs to clear the tighter
+	// contractedByteRange (0.0085), not just byteRange (0.01) itself. A
+	// delta in between - comfortably "Byte territory" for the plain
+	// function, but not quite past Full's Byte-entry margin - settles into
+	// Half instead of Byte on this first call (it easily clears the more
+	// lenient contractedHalfRange), and only reaches Byte once the delta
+	// itself drops below contractedByteRange. This converges quickly for
+	// any genuinely continuous signal (the next frame's previousTier
+	// reflects whichever tier was just settled into) so it isn't a
+	// user-visible regression - see StaysInFullWithinLowerBand above for
+	// the "doesn't enter any finer tier at all yet" case.
+	QuantRanges ranges;
+	ranges.byteRange = 0.01;
+	ranges.halfRange = 1.0;
+	ranges.hysteresisFactor = 0.15;
+	O3DS_CHECK(ChooseScalarTierWithHysteresis(0.009, ranges, QuantTier::Full) == QuantTier::Half);
+	O3DS_CHECK(ChooseScalarTierWithHysteresis(0.008, ranges, QuantTier::Full) == QuantTier::Byte);
+}
+
+O3DS_TEST(ChooseScalarTierWithHysteresis_HugeJumpFromByteSkipsHalfGoesStraightToFull)
+{
+	// A genuinely large single-frame movement (e.g. a snap/teleport) must
+	// still reach Full in one call, not get stuck needing two calls to pass
+	// through Half first.
+	QuantRanges ranges;
+	ranges.byteRange = 0.01;
+	ranges.halfRange = 1.0;
+	ranges.hysteresisFactor = 0.15;
+	O3DS_CHECK(ChooseScalarTierWithHysteresis(5.0, ranges, QuantTier::Byte) == QuantTier::Full);
+}
+
+O3DS_TEST(ChooseScalarTierWithHysteresis_HugeDropFromFullSkipsHalfGoesStraightToByte)
+{
+	QuantRanges ranges;
+	ranges.byteRange = 0.01;
+	ranges.halfRange = 1.0;
+	ranges.hysteresisFactor = 0.15;
+	O3DS_CHECK(ChooseScalarTierWithHysteresis(0.0001, ranges, QuantTier::Full) == QuantTier::Byte);
+}
+
+O3DS_TEST(ChooseScalarTierWithHysteresis_NonFiniteOrNegativeFactorDisablesHysteresis)
+{
+	// Mirrors QuantizeByte/QuantizeHalf's own non-finite-range guard - a
+	// caller-supplied hysteresisFactor (UE UPROPERTY) could be NaN or
+	// negative; both should behave exactly like plain ChooseScalarTier
+	// rather than propagating garbage into the expanded/contracted math.
+	const double nan = std::numeric_limits<double>::quiet_NaN();
+	QuantRanges rangesNan;
+	rangesNan.byteRange = 0.01;
+	rangesNan.halfRange = 1.0;
+	rangesNan.hysteresisFactor = nan;
+	O3DS_CHECK(ChooseScalarTierWithHysteresis(0.011, rangesNan, QuantTier::Byte) == QuantTier::Half);
+
+	QuantRanges rangesNegative;
+	rangesNegative.byteRange = 0.01;
+	rangesNegative.halfRange = 1.0;
+	rangesNegative.hysteresisFactor = -0.5;
+	O3DS_CHECK(ChooseScalarTierWithHysteresis(0.011, rangesNegative, QuantTier::Byte) == QuantTier::Half);
+}
+
+O3DS_TEST(ChooseScalarTierWithHysteresis_FactorAboveOneIsClampedNotDegenerate)
+{
+	// hysteresisFactor >= 1.0 would otherwise make contractedByteRange <= 0
+	// (or negative), which could make every delta - even zero - unable to
+	// clear the "enter Byte" threshold. Confirm it's clamped to something
+	// still usable instead.
+	QuantRanges ranges;
+	ranges.byteRange = 0.01;
+	ranges.halfRange = 1.0;
+	ranges.hysteresisFactor = 5.0;
+	O3DS_CHECK(ChooseScalarTierWithHysteresis(0.0, ranges, QuantTier::Full) == QuantTier::Byte);
+}
+
 O3DS_TEST(QuantizeByte_RoundTripsWithinExpectedResolution)
 {
 	const double range = 0.01;


### PR DESCRIPTION
## Summary

Fixes jitter reported from a live PIE test of D1 adaptive channel quantization: idle animations showed pronounced jitter, much less on a run animation, and it persisted (reduced but not eliminated) even after tightening `QuantizationByteRange`/`QuantizationHalfRange` well below their defaults.

**Root cause:** `ChooseScalarTier` (`src/o3ds/quant/channel_quant.cpp`) is a stateless `<=` comparison, re-evaluated fresh every frame with no memory of the previously-chosen tier. Byte/Half/Full each reconstruct on a different rounding grid, so whenever a channel's tier-selection input naturally hovers near a `byteRange`/`halfRange` boundary, the encoder flaps between tiers every time it crosses back and forth - and every flap is a visible reconstruction jump on the receiver, not just added noise.

This bites hardest on continuous, low-amplitude motion: idle-animation sway (translation's anchor-relative displacement) or subtle look-around (rotation's frame-to-frame quaternion distance) sit near a boundary for extended periods, unlike a run animation's decisive excursions that land solidly on one side of every threshold. That matches the reported symptoms exactly, and also explains why tightening the ranges only partially helped: translation and rotation reuse the *same* `byteRange`/`halfRange` numbers despite being dimensionally different quantities (the code already has a comment acknowledging this), so a value tuned to stop translation from flapping isn't guaranteed to do the same for rotation.

## Changes

- `channel_quant.h`/`.cpp`: adds `ChooseScalarTierWithHysteresis(absDelta, ranges, previousTier)` and `QuantRanges::hysteresisFactor` (default 15%). Given the channel's previously-chosen tier, it only switches once the input clears the *opposite* boundary by the margin, instead of the instant the plain boundary is crossed. A big-enough single-frame jump still moves straight from Byte to Full (or Full to Byte) in one call - it doesn't have to pass through Half first.
- `model.h`: `Transform` gains `mLastTranslationTier`/`mLastRotationTier`, defaulting to `Full` (the always-safe starting point, matching "no anchor yet" elsewhere in this scheme). No preserve-across-resync logic needed - this is sender-only state, and `BuildSubjectFromDescriptor` already only rebuilds genuinely fresh `Transform`s today (no periodic-full-resync code path exists yet that would need it).
- `model.cpp`: both `SerializeUpdate` tier-selection call sites (translation, rotation) now call the hysteresis-aware selector and persist the chosen tier.
- `channel_quant_tests.cpp`: 14 new cases covering: matches the plain function at `hysteresisFactor = 0`, stays put within each boundary's band, switches once the band is cleared (both directions, both boundaries), a fresh channel's slightly-more-conservative first call from `Full`, multi-tier single-frame jumps, and the same non-finite/out-of-range config guards `QuantizeByte`/`Half` already have.

Not addressed here (flagged as a known follow-up, out of scope for this fix): rotation and translation still share one `byteRange`/`halfRange` pair despite being different quantities. Hysteresis stops the flapping either way, but getting both channels simultaneously well-tuned may still need separate thresholds.

## Test plan

- [x] `ctest` (174 cases, including 14 new hysteresis-specific ones) passes locally via the standard CMake/Ninja build
- [ ] Live PIE re-test of the same Idle/Run comparison that surfaced the original bug, to confirm the jitter is gone


---
_Generated by [Claude Code](https://claude.ai/code/session_01LHHqoB2uhpd7k7wSdbE4H6)_