### PR TITLE
Fix quantization hysteresis: upgrades must be immediate, not delayed

### DIFF
--- a/src/o3ds/quant/channel_quant.cpp
+++ b/src/o3ds/quant/channel_quant.cpp
@@ -88,34 +88,48 @@ namespace O3DS
 			return ChooseScalarTier(absDelta, ranges);
 		}
 
-		const double expandedByteRange = ranges.byteRange * (1.0 + h);
 		const double contractedByteRange = ranges.byteRange * (1.0 - h);
-		const double expandedHalfRange = ranges.halfRange * (1.0 + h);
 		const double contractedHalfRange = ranges.halfRange * (1.0 - h);
 
+		// Upgrades (finer -> coarser tier, i.e. away from Byte/Half toward
+		// Full) always happen immediately at the plain, unexpanded boundary
+		// - never later. QuantRanges::byteRange/halfRange are the max |delta|
+		// a tier can represent WITHOUT clamping (QuantizeByte/QuantizeHalf's
+		// documented precondition); letting a value that already exceeds a
+		// tier's range stay in that tier - which an earlier version of this
+		// function did, via an "expanded" upgrade threshold - would silently
+		// clamp it, trading a correctness violation for smoothness. Only
+		// downgrades (coarser -> finer tier) get the hysteresis margin
+		// (contractedByteRange/contractedHalfRange below), since those are
+		// what actually caused the flapping this function exists to prevent:
+		// once a value has crossed into a coarser tier, it shouldn't
+		// immediately drop back the moment it dips slightly below the
+		// boundary again, only once it's clearly settled back inside the
+		// finer tier's range. Full has nothing coarser to upgrade to, so
+		// these checks only apply when previousTier is Byte or Half - see
+		// that case below for why hoisting them above the switch entirely
+		// is wrong (it would preempt Full's own downgrade logic for any
+		// absDelta between byteRange and halfRange).
 		switch (previousTier)
 		{
 		case QuantTier::Byte:
-			// Upgrading out of Byte needs to clear byteRange by the margin;
-			// a big-enough single-frame jump can go straight to Full.
-			if (absDelta > expandedHalfRange)
+			if (absDelta > ranges.halfRange)
 			{
 				return QuantTier::Full;
 			}
-			if (absDelta > expandedByteRange)
+			if (absDelta > ranges.byteRange)
 			{
 				return QuantTier::Half;
 			}
 			return QuantTier::Byte;
 
 		case QuantTier::Half:
-			// Downgrading to Byte needs to clear byteRange's margin on the
-			// low side; upgrading to Full needs to clear halfRange's margin
-			// on the high side. Otherwise stay put.
-			if (absDelta > expandedHalfRange)
+			if (absDelta > ranges.halfRange)
 			{
 				return QuantTier::Full;
 			}
+			// Downgrade to Byte only once it's clearly within Byte's range,
+			// not just barely.
 			if (absDelta <= contractedByteRange)
 			{
 				return QuantTier::Byte;
@@ -124,9 +138,10 @@ namespace O3DS
 
 		case QuantTier::Full:
 		default:
-			// Entering a finer tier from Full needs to clear the relevant
-			// margin on the low side - a single big drop can go straight to
-			// Byte, matching ChooseScalarTier's own precedence.
+			// Full is already the safe ceiling - no upgrade check needed.
+			// Entering a finer tier needs to clear the relevant margin on
+			// the low side - a single big drop can go straight to Byte,
+			// matching ChooseScalarTier's own precedence.
 			if (absDelta <= contractedByteRange)
 			{
 				return QuantTier::Byte;

--- a/src/o3ds/quant/channel_quant.h
+++ b/src/o3ds/quant/channel_quant.h
@@ -67,15 +67,22 @@ namespace O3DS
 		double byteRange = 0.01; //!< Max |delta| representable at Byte tier.
 		double halfRange = 1.0;  //!< Max |delta| representable at Half tier.
 
-		//! Fractional hysteresis margin (e.g. 0.15 == 15%) applied around
-		//! each tier boundary by ChooseScalarTierWithHysteresis. Without it,
-		//! a value that naturally hovers near byteRange/halfRange (e.g.
-		//! idle-animation sway oscillating around a roughly constant
-		//! amplitude) flips tiers every time it crosses back and forth -
-		//! and since each tier reconstructs on a different rounding grid,
-		//! every flip is a visible jump on the receiver, not just added
-		//! noise. 0 (or a non-finite value) disables hysteresis, matching
-		//! plain ChooseScalarTier exactly.
+		//! Fractional hysteresis margin (e.g. 0.15 == 15%) applied by
+		//! ChooseScalarTierWithHysteresis to the DOWNGRADE threshold only
+		//! (coarser tier -> finer tier) - upgrades (finer -> coarser) always
+		//! happen immediately at the plain byteRange/halfRange boundary,
+		//! since byteRange/halfRange are the max |delta| a tier can
+		//! represent WITHOUT clamping (see QuantizeByte/QuantizeHalf's
+		//! documented precondition); delaying an upgrade would let a value
+		//! that already exceeds the current tier's range stay there and
+		//! silently clamp. Without this margin on downgrades, a value that
+		//! naturally hovers near a boundary (e.g. idle-animation sway
+		//! oscillating around a roughly constant amplitude) would cross back
+		//! and forth and flip tiers every time - and since each tier
+		//! reconstructs on a different rounding grid, every flip is a
+		//! visible jump on the receiver, not just added noise. 0 (or a
+		//! non-finite value) disables hysteresis, matching plain
+		//! ChooseScalarTier exactly.
 		double hysteresisFactor = 0.15;
 	};
 
@@ -88,15 +95,19 @@ namespace O3DS
 	QuantTier ChooseScalarTier(double absDelta, const QuantRanges& ranges);
 
 	//! Hysteresis-aware tier selection for a channel whose previously-chosen
-	//! tier is known. Only moves away from previousTier once absDelta clears
-	//! the boundary on the *opposite* side by ranges.hysteresisFactor,
-	//! instead of the instant the plain boundary is crossed - see
-	//! QuantRanges::hysteresisFactor's doc comment for the flapping problem
-	//! this avoids. A channel with no meaningful prior choice (e.g. a
-	//! freshly-created Transform) should pass QuantTier::Full, the always-
-	//! safe/correct starting point already used elsewhere in this scheme
-	//! (e.g. "no anchor yet" falls back to Full too) - hysteresis then
-	//! applies normally from there and converges within one call.
+	//! tier is known. Upgrading to a coarser tier (Byte->Half, Half->Full,
+	//! or a big-enough single-frame jump straight to Full) always happens
+	//! immediately at the plain byteRange/halfRange boundary - absDelta
+	//! never sits in a tier that can't represent it. Downgrading to a finer
+	//! tier only happens once absDelta clears the boundary by
+	//! ranges.hysteresisFactor, instead of the instant it dips back below -
+	//! see QuantRanges::hysteresisFactor's doc comment for the flapping
+	//! problem this asymmetry avoids. A channel with no meaningful prior
+	//! choice (e.g. a freshly-created Transform) should pass
+	//! QuantTier::Full, the always-safe/correct starting point already used
+	//! elsewhere in this scheme (e.g. "no anchor yet" falls back to Full
+	//! too) - hysteresis then applies normally from there and converges
+	//! within one call.
 	QuantTier ChooseScalarTierWithHysteresis(double absDelta, const QuantRanges& ranges, QuantTier previousTier);
 
 	//! Quantizes delta (already known to satisfy |delta| <= range - callers

--- a/test/channel_quant_tests.cpp
+++ b/test/channel_quant_tests.cpp
@@ -77,21 +77,22 @@ O3DS_TEST(ChooseScalarTierWithHysteresis_MatchesPlainTierWhenFactorIsZero)
 	}
 }
 
-O3DS_TEST(ChooseScalarTierWithHysteresis_StaysInByteWithinUpperBand)
+O3DS_TEST(ChooseScalarTierWithHysteresis_UpgradesToHalfImmediatelyAtByteRange)
 {
-	// byteRange=0.01, hysteresisFactor=0.15 -> expandedByteRange=0.0115.
-	// A delta just past byteRange but still within the band should NOT
-	// flip Byte -> Half yet - this is the exact "hovering near a boundary"
-	// case that caused every-frame tier flapping (and thus a visible
-	// reconstruction jump every flap, since Byte/Half round differently).
+	// Regression guard (Copilot review, PR #247): upgrades must happen at
+	// the plain byteRange boundary, NOT a hysteresis-expanded one - a value
+	// that already exceeds byteRange must never stay in Byte, since
+	// QuantizeByte would then silently clamp it (byteRange is the max
+	// |delta| Byte can represent WITHOUT clamping). Only downgrades get a
+	// hysteresis margin - see QuantRanges::hysteresisFactor's doc comment.
 	QuantRanges ranges;
 	ranges.byteRange = 0.01;
 	ranges.halfRange = 1.0;
 	ranges.hysteresisFactor = 0.15;
-	O3DS_CHECK(ChooseScalarTierWithHysteresis(0.011, ranges, QuantTier::Byte) == QuantTier::Byte);
+	O3DS_CHECK(ChooseScalarTierWithHysteresis(0.011, ranges, QuantTier::Byte) == QuantTier::Half);
 }
 
-O3DS_TEST(ChooseScalarTierWithHysteresis_UpgradesToHalfPastUpperBand)
+O3DS_TEST(ChooseScalarTierWithHysteresis_UpgradesToHalfImmediatelyFurtherPastByteRange)
 {
 	QuantRanges ranges;
 	ranges.byteRange = 0.01;
@@ -120,18 +121,19 @@ O3DS_TEST(ChooseScalarTierWithHysteresis_DowngradesToBytePastLowerBand)
 	O3DS_CHECK(ChooseScalarTierWithHysteresis(0.008, ranges, QuantTier::Half) == QuantTier::Byte);
 }
 
-O3DS_TEST(ChooseScalarTierWithHysteresis_StaysInHalfNearHalfRangeUpperSide)
+O3DS_TEST(ChooseScalarTierWithHysteresis_UpgradesToFullImmediatelyAtHalfRange)
 {
-	// expandedHalfRange=1.15. A delta just past halfRange but still within
-	// the band should NOT flip Half -> Full yet.
+	// Same regression guard as UpgradesToHalfImmediatelyAtByteRange, one
+	// tier up: a value past halfRange must upgrade to Full immediately,
+	// never stay in Half and risk QuantizeHalf clamping it.
 	QuantRanges ranges;
 	ranges.byteRange = 0.01;
 	ranges.halfRange = 1.0;
 	ranges.hysteresisFactor = 0.15;
-	O3DS_CHECK(ChooseScalarTierWithHysteresis(1.1, ranges, QuantTier::Half) == QuantTier::Half);
+	O3DS_CHECK(ChooseScalarTierWithHysteresis(1.1, ranges, QuantTier::Half) == QuantTier::Full);
 }
 
-O3DS_TEST(ChooseScalarTierWithHysteresis_UpgradesToFullPastHalfRangeUpperBand)
+O3DS_TEST(ChooseScalarTierWithHysteresis_UpgradesToFullImmediatelyFurtherPastHalfRange)
 {
 	QuantRanges ranges;
 	ranges.byteRange = 0.01;


### PR DESCRIPTION
## Summary

Follow-up to #247 (merged). Copilot's automated review caught a real correctness bug in `ChooseScalarTierWithHysteresis`, verified by re-deriving the tier-selection logic by hand and confirming against the actual `QuantizeByte`/`QuantizeHalf` contract:

**The bug:** upgrading to a coarser tier used an *expanded* threshold (`byteRange`/`halfRange * (1 + hysteresisFactor)`), so a channel could stay in `Byte` or `Half` even after `absDelta` already exceeded that tier's documented "max representable without clamping" range (`QuantRanges::byteRange`/`halfRange`'s own doc comment). `QuantizeByte`/`QuantizeHalf` would then silently clamp such deltas to their max code - a real precision-loss/clamping bug, which is the opposite of what hysteresis was supposed to fix (it was meant to stop visible reconstruction *jumps*, not introduce clamping).

**The fix:** upgrades (finer -> coarser tier) now always happen immediately at the plain `byteRange`/`halfRange` boundary, exactly like the original stateless `ChooseScalarTier` - a value is never left in a tier that can't represent it. Only downgrades (coarser -> finer tier) get the hysteresis margin, since those are what actually caused the frame-to-frame flapping the function exists to prevent: once a value has crossed into a coarser tier, it now only drops back once clearly settled back inside the finer tier's range, instead of the instant it dips slightly below the boundary again. This asymmetry (immediate upgrade, delayed downgrade) is the standard, correct shape for this kind of hysteresis and still fully prevents the original boundary-flapping jitter.

## Changes

- `channel_quant.cpp`: reworked `ChooseScalarTierWithHysteresis` so `Byte`/`Half`'s upgrade checks use the plain boundary, and only `Half`'s downgrade-to-`Byte` and `Full`'s downgrades use the contracted (hysteresis-margined) thresholds.
- `channel_quant.h`: updated doc comments on `QuantRanges::hysteresisFactor` and `ChooseScalarTierWithHysteresis` to describe the asymmetric design and why it matters.
- `channel_quant_tests.cpp`: fixed the two test cases that had encoded the old (incorrect) "stays in a tier past its own range" behavior as the expected result, replacing them with cases proving the immediate-upgrade behavior instead.

## Test plan

- [x] `ctest` (174 cases) passes locally via the standard CMake/Ninja build, including the corrected hysteresis test cases


---
_Generated by [Claude Code](https://claude.ai/code/session_01LHHqoB2uhpd7k7wSdbE4H6)_