### PR TITLE
Clarify quantization hysteresis doc comments (from #248 review)

### DIFF
--- a/src/o3ds/quant/channel_quant.cpp
+++ b/src/o3ds/quant/channel_quant.cpp
@@ -91,25 +91,26 @@ namespace O3DS
 		const double contractedByteRange = ranges.byteRange * (1.0 - h);
 		const double contractedHalfRange = ranges.halfRange * (1.0 - h);
 
-		// Upgrades (finer -> coarser tier, i.e. away from Byte/Half toward
-		// Full) always happen immediately at the plain, unexpanded boundary
-		// - never later. QuantRanges::byteRange/halfRange are the max |delta|
-		// a tier can represent WITHOUT clamping (QuantizeByte/QuantizeHalf's
+		// Moving to a larger-range tier (Byte->Half, Half->Full) always
+		// happens immediately at the plain, unexpanded boundary - never
+		// later. QuantRanges::byteRange/halfRange are the max |delta| a
+		// tier can represent WITHOUT clamping (QuantizeByte/QuantizeHalf's
 		// documented precondition); letting a value that already exceeds a
 		// tier's range stay in that tier - which an earlier version of this
-		// function did, via an "expanded" upgrade threshold - would silently
-		// clamp it, trading a correctness violation for smoothness. Only
-		// downgrades (coarser -> finer tier) get the hysteresis margin
-		// (contractedByteRange/contractedHalfRange below), since those are
-		// what actually caused the flapping this function exists to prevent:
-		// once a value has crossed into a coarser tier, it shouldn't
-		// immediately drop back the moment it dips slightly below the
-		// boundary again, only once it's clearly settled back inside the
-		// finer tier's range. Full has nothing coarser to upgrade to, so
-		// these checks only apply when previousTier is Byte or Half - see
-		// that case below for why hoisting them above the switch entirely
-		// is wrong (it would preempt Full's own downgrade logic for any
-		// absDelta between byteRange and halfRange).
+		// function did, via an "expanded" threshold on this move - would
+		// silently clamp it, trading a correctness violation for smoothness.
+		// Only moves to a SMALLER-range tier (Half->Byte, Full->Half,
+		// Full->Byte) get the hysteresis margin (contractedByteRange/
+		// contractedHalfRange below), since those are what actually caused
+		// the flapping this function exists to prevent: once a value has
+		// moved to a larger-range tier, it shouldn't immediately move back
+		// the moment it dips slightly below the boundary again, only once
+		// it's clearly settled back inside the smaller tier's range. Full
+		// has no larger-range tier to move to, so the immediate-move checks
+		// only apply when previousTier is Byte or Half - see that case below
+		// for why hoisting them above the switch entirely is wrong (it would
+		// preempt Full's own move-to-smaller-range logic for any absDelta
+		// between byteRange and halfRange).
 		switch (previousTier)
 		{
 		case QuantTier::Byte:
@@ -138,10 +139,10 @@ namespace O3DS
 
 		case QuantTier::Full:
 		default:
-			// Full is already the safe ceiling - no upgrade check needed.
-			// Entering a finer tier needs to clear the relevant margin on
-			// the low side - a single big drop can go straight to Byte,
-			// matching ChooseScalarTier's own precedence.
+			// Full is already the safe ceiling - no immediate-move check
+			// needed. Moving to a smaller-range tier needs to clear the
+			// relevant margin on the low side - a single big drop can go
+			// straight to Byte, matching ChooseScalarTier's own precedence.
 			if (absDelta <= contractedByteRange)
 			{
 				return QuantTier::Byte;

--- a/src/o3ds/quant/channel_quant.h
+++ b/src/o3ds/quant/channel_quant.h
@@ -68,17 +68,19 @@ namespace O3DS
 		double halfRange = 1.0;  //!< Max |delta| representable at Half tier.
 
 		//! Fractional hysteresis margin (e.g. 0.15 == 15%) applied by
-		//! ChooseScalarTierWithHysteresis to the DOWNGRADE threshold only
-		//! (coarser tier -> finer tier) - upgrades (finer -> coarser) always
-		//! happen immediately at the plain byteRange/halfRange boundary,
-		//! since byteRange/halfRange are the max |delta| a tier can
-		//! represent WITHOUT clamping (see QuantizeByte/QuantizeHalf's
-		//! documented precondition); delaying an upgrade would let a value
-		//! that already exceeds the current tier's range stay there and
-		//! silently clamp. Without this margin on downgrades, a value that
-		//! naturally hovers near a boundary (e.g. idle-animation sway
-		//! oscillating around a roughly constant amplitude) would cross back
-		//! and forth and flip tiers every time - and since each tier
+		//! ChooseScalarTierWithHysteresis only to transitions that move
+		//! toward a smaller range (Half->Byte, Full->Half, Full->Byte) -
+		//! transitions that move toward a larger range (Byte->Half,
+		//! Half->Full, or Byte->Full in one jump) always happen immediately
+		//! at the plain byteRange/halfRange boundary, since byteRange/
+		//! halfRange are the max |delta| a tier can represent WITHOUT
+		//! clamping (see QuantizeByte/QuantizeHalf's documented
+		//! precondition); delaying that move would let a value that already
+		//! exceeds the current tier's range stay there and silently clamp.
+		//! Without this margin on the toward-smaller-range transitions, a
+		//! value that naturally hovers near a boundary (e.g. idle-animation
+		//! sway oscillating around a roughly constant amplitude) would cross
+		//! back and forth and flip tiers every time - and since each tier
 		//! reconstructs on a different rounding grid, every flip is a
 		//! visible jump on the receiver, not just added noise. 0 (or a
 		//! non-finite value) disables hysteresis, matching plain
@@ -95,17 +97,18 @@ namespace O3DS
 	QuantTier ChooseScalarTier(double absDelta, const QuantRanges& ranges);
 
 	//! Hysteresis-aware tier selection for a channel whose previously-chosen
-	//! tier is known. Upgrading to a coarser tier (Byte->Half, Half->Full,
-	//! or a big-enough single-frame jump straight to Full) always happens
-	//! immediately at the plain byteRange/halfRange boundary - absDelta
-	//! never sits in a tier that can't represent it. Downgrading to a finer
-	//! tier only happens once absDelta clears the boundary by
-	//! ranges.hysteresisFactor, instead of the instant it dips back below -
-	//! see QuantRanges::hysteresisFactor's doc comment for the flapping
-	//! problem this asymmetry avoids. A channel with no meaningful prior
-	//! choice (e.g. a freshly-created Transform) should pass
-	//! QuantTier::Full, the always-safe/correct starting point already used
-	//! elsewhere in this scheme (e.g. "no anchor yet" falls back to Full
+	//! tier is known. Moving to a larger-range tier (Byte->Half, Half->Full,
+	//! or a big-enough single-frame jump straight from Byte to Full) always
+	//! happens immediately at the plain byteRange/halfRange boundary -
+	//! absDelta never sits in a tier that can't represent it. Moving to a
+	//! smaller-range tier (Half->Byte, Full->Half, Full->Byte) only happens
+	//! once absDelta clears the boundary by ranges.hysteresisFactor, instead
+	//! of the instant it dips back below - see QuantRanges::hysteresisFactor's
+	//! doc comment for the flapping problem this asymmetry avoids. A channel
+	//! with no meaningful prior choice (e.g. a freshly-created Transform)
+	//! should pass QuantTier::Full, the always-safe/correct starting point
+	//! already used elsewhere in this scheme (e.g. "no anchor yet" falls
+	//! back to Full
 	//! too) - hysteresis then applies normally from there and converges
 	//! within one call.
 	QuantTier ChooseScalarTierWithHysteresis(double absDelta, const QuantRanges& ranges, QuantTier previousTier);

--- a/test/channel_quant_tests.cpp
+++ b/test/channel_quant_tests.cpp
@@ -167,17 +167,17 @@ O3DS_TEST(ChooseScalarTierWithHysteresis_FreshChannelFromFullNeedsToClearContrac
 	// A "fresh" channel (no prior tier - see Transform::mLastTranslationTier's
 	// default of QuantTier::Full) is slightly more conservative on its very
 	// first evaluation than the stateless ChooseScalarTier: entering Byte
-	// specifically (not just some finer tier) needs to clear the tighter
-	// contractedByteRange (0.0085), not just byteRange (0.01) itself. A
-	// delta in between - comfortably "Byte territory" for the plain
-	// function, but not quite past Full's Byte-entry margin - settles into
-	// Half instead of Byte on this first call (it easily clears the more
-	// lenient contractedHalfRange), and only reaches Byte once the delta
-	// itself drops below contractedByteRange. This converges quickly for
-	// any genuinely continuous signal (the next frame's previousTier
+	// specifically (not just some smaller-range tier) needs to clear the
+	// tighter contractedByteRange (0.0085), not just byteRange (0.01)
+	// itself. A delta in between - comfortably "Byte territory" for the
+	// plain function, but not quite past Full's Byte-entry margin - settles
+	// into Half instead of Byte on this first call (it easily clears the
+	// more lenient contractedHalfRange), and only reaches Byte once the
+	// delta itself drops below contractedByteRange. This converges quickly
+	// for any genuinely continuous signal (the next frame's previousTier
 	// reflects whichever tier was just settled into) so it isn't a
 	// user-visible regression - see StaysInFullWithinLowerBand above for
-	// the "doesn't enter any finer tier at all yet" case.
+	// the "doesn't enter any smaller-range tier at all yet" case.
 	QuantRanges ranges;
 	ranges.byteRange = 0.01;
 	ranges.halfRange = 1.0;


### PR DESCRIPTION
## Summary

Follow-up to #248 (merged). Copilot's review flagged that the doc comments describe hysteresis transitions using "coarser"/"finer" tier language, which is genuinely ambiguous here: `Full` is actually lossless (zero quantization error - it's plain float32), so calling it "the coarsest tier" reads backwards even though it's the tier used for the largest deltas.

Reworded all three flagged spots (`channel_quant.h` x2, `channel_quant.cpp` x1) to use explicit tier-name transitions (`Byte->Half`, `Half->Full`, etc.) and "larger/smaller-range tier" instead of "coarser/finer", and fixed two similarly-worded comments in the new hysteresis tests for consistency. No behavior change - doc/comment only.

## Test plan

- [x] `ctest` (174 cases) passes locally, confirming this is a no-op behaviorally


---
_Generated by [Claude Code](https://claude.ai/code/session_01LHHqoB2uhpd7k7wSdbE4H6)_