### PR TITLE
Ensure CMake on self-hosted runner

### DIFF
--- a/.github/workflows/open3dbroadcast-plugin-ci.yml
+++ b/.github/workflows/open3dbroadcast-plugin-ci.yml
@@ -82,9 +82,30 @@ jobs:
         run: |
           & .\Build\Scripts\Setup-UE.ps1 -UEPath "${{ env.UE_ROOT }}"
 
-      - name: Install CMake
+      - name: Ensure CMake
         shell: powershell
-        run: choco install cmake -y --installargs 'ADD_CMAKE_TO_PATH=System'
+        run: |
+          $cmake = Get-Command cmake -ErrorAction SilentlyContinue
+          if ($cmake) {
+            & $cmake.Source --version
+            exit 0
+          }
+
+          $choco = Get-Command choco -ErrorAction SilentlyContinue
+          if (-not $choco) {
+            throw 'CMake is missing and Chocolatey is unavailable. Preinstall CMake on this self-hosted runner.'
+          }
+
+          & $choco.Source install cmake -y --installargs 'ADD_CMAKE_TO_PATH=System'
+          if ($LASTEXITCODE -ne 0) {
+            throw "Chocolatey failed to install CMake (exit code $LASTEXITCODE)."
+          }
+
+          $cmake = Get-Command cmake -ErrorAction SilentlyContinue
+          if (-not $cmake) {
+            throw 'CMake was installed but is not available on PATH. Restart the runner and retry.'
+          }
+          & $cmake.Source --version
 
       # Same toolchain windows.yml uses to build the o3ds release zip - see
       # that workflow's own comment on why -G "Visual Studio 17 2022" isn't


### PR DESCRIPTION
## What changed
- Reuse an existing CMake installation before invoking Chocolatey.
- Provide clear failures when CMake or Chocolatey is unavailable.

## Why
The Windows self-hosted runner runs as `NetworkService`, which cannot write to Chocolatey's system directory. CMake is now preinstalled on that runner, so CI should not attempt a package install during each job.

## Validation
- Installed CMake 4.4.0 system-wide on the runner.
- Restarted the GitHub Actions runner service so it receives the updated system PATH.
- Checked the workflow diff for whitespace errors.